### PR TITLE
更新mac下的安装指令，避免安装过程中可能遇到的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,16 @@ Download `install_akagi.command` from [Release](https://github.com/shinkuan/Akag
 
 1. Place `install_akagi.command` in the location where you want to install Akagi.
 2. Download the latest Python installation package from the [Python official website](https://www.python.org/downloads/) and install it (skip this step if you already have a compatible version of Python installed).
-3. Double-click `install_akagi.command` to automatically install the required dependencies.
-4. Double-click `run_agaki.command` to start Akagi.
-5. If you are using mitmproxy for the first time, click on "start mitm".
-6. Close it.
-7. Go to your user home directory `~/.mitmproxy`.
-8. Install the certificate.
-9. Put `mortal.pth` into `./Akagi/mjai/bot`.
+3. Open Terminal and cd to the directory where `install_akagi.command` is located.
+4. Execute: bash install_akagi.command
+5. After installation is complete, enter the Akagi folder.
+6. Double-click `run_agaki.command` to start Akagi.
+7. If you are using mitmproxy for the first time, click on "start mitm".
+8. Close it.
+9. Go to your user home directory `~/.mitmproxy`.
+10. Install the certificate.
+11. Put `mortal.pth` into `./Akagi/mjai/bot`.
+
 
 ### settings.json
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -73,9 +73,11 @@ https://github.com/shinkuan/RandomStuff/assets/35415788/ce1b598d-b1d7-49fe-a175-
 
 1. 将 `install_akagi.command` 放在您想安裝 Akagi 的位置。
 2. 从[Python 官方网站](https://www.python.org/downloads/)下载最新的 Python 安装包并安装（如已安装其他兼容版本的 Python 可以跳过这一步）。
-3. 双击`install_akagi.command`自动安装所需的依赖项。
-4. 双击run_agaki.command启动agaki。
-5. 如果您是第一次使用mitmproxy，请点击start mitm。
+3. 打开终端，cd到`install_akagi.command`所在的目录。
+4. 执行：bash install_akagi.command
+5. 安装完成之后，进入Akagi文件夹。
+6. 双击run_agaki.command启动agaki。
+7. 如果您是第一次使用mitmproxy，请点击start mitm。
 5. 关闭它。
 6. 到使用者主目录 `~/.mitmproxy`
 7. 安装证书。


### PR DESCRIPTION
发现从github release下载的install_akagi.command缺少可执行权限，无法双击自动安装，所以在文档中修改为手动运行脚本的安装方式。
脚本本身没有问题，是否可以在下一个release中继续保留mac的安装脚本？