### PR TITLE
[Autoplay] JS injection-based browser automation for Majsoul

### DIFF
--- a/autoplay/action_converter.py
+++ b/autoplay/action_converter.py
@@ -1,0 +1,123 @@
+"""Convert MJAI action dicts to Majsoul Liqi protocol bytes."""
+
+from mitm.bridge.majsoul.bridge import MJAI_TILE_2_MS_TILE, Operation
+from mitm.bridge.majsoul.liqi import LiqiProto, MsgType
+
+
+class ActionConverter:
+    """Converts MJAI bot actions to Majsoul Liqi protocol format."""
+
+    def __init__(self):
+        self.liqi_proto = LiqiProto()
+
+    def _tile_to_ms(self, mjai_tile: str) -> str:
+        return MJAI_TILE_2_MS_TILE.get(mjai_tile, mjai_tile)
+
+    def convert(self, mjai_action: dict, seat: int) -> bytes | None:
+        """Convert an MJAI action dict to Liqi protocol bytes.
+
+        Args:
+            mjai_action: MJAI action from bot, e.g. {"type": "dahai", "pai": "5m"}
+            seat: Player's seat index (0-3)
+
+        Returns:
+            Encoded Liqi protocol bytes, or None if action is skip/none.
+        """
+        action_type = mjai_action.get("type")
+
+        if action_type in ("none", None):
+            return None
+
+        if action_type == "dahai":
+            return self._build_discard(mjai_action, seat)
+        elif action_type == "reach":
+            return self._build_reach(mjai_action, seat)
+        elif action_type == "chi":
+            return self._build_chi(mjai_action, seat)
+        elif action_type == "pon":
+            return self._build_pon(mjai_action, seat)
+        elif action_type in ("daiminkan", "kakan", "ankan"):
+            return self._build_kan(mjai_action, seat)
+        elif action_type == "hora":
+            return self._build_hora(mjai_action, seat)
+        elif action_type == "ryukyoku":
+            return self._build_ryukyoku(seat)
+        else:
+            return None
+
+    def _build_discard(self, action: dict, seat: int) -> bytes:
+        tile = self._tile_to_ms(action["pai"])
+        moqie = action.get("tsumogiri", False)
+        return self._compose_action(".lq.FastTest.inputOperation", {
+            "type": Operation.Discard,
+            "tile": tile,
+            "moqie": moqie,
+            "timeuse": 3,
+        })
+
+    def _build_reach(self, action: dict, seat: int) -> bytes:
+        return self._compose_action(".lq.FastTest.inputOperation", {
+            "type": Operation.Liqi,
+            "tile": self._tile_to_ms(action.get("pai", "")),
+            "moqie": action.get("tsumogiri", False),
+            "timeuse": 3,
+        })
+
+    def _build_chi(self, action: dict, seat: int) -> bytes:
+        return self._compose_action(".lq.FastTest.inputChiPengGang", {
+            "type": 0,  # Chi
+            "index": 0,
+            "timeuse": 3,
+        })
+
+    def _build_pon(self, action: dict, seat: int) -> bytes:
+        return self._compose_action(".lq.FastTest.inputChiPengGang", {
+            "type": 1,  # Peng
+            "index": 0,
+            "timeuse": 3,
+        })
+
+    def _build_kan(self, action: dict, seat: int) -> bytes:
+        action_type = action["type"]
+        if action_type == "daiminkan":
+            return self._compose_action(".lq.FastTest.inputChiPengGang", {
+                "type": 2,  # Gang
+                "index": 0,
+                "timeuse": 3,
+            })
+        elif action_type == "ankan":
+            return self._compose_action(".lq.FastTest.inputOperation", {
+                "type": Operation.AnGang,
+                "tile": self._tile_to_ms(action.get("consumed", [""])[0]),
+                "timeuse": 3,
+            })
+        elif action_type == "kakan":
+            return self._compose_action(".lq.FastTest.inputOperation", {
+                "type": Operation.JiaGang,
+                "tile": self._tile_to_ms(action.get("pai", "")),
+                "timeuse": 3,
+            })
+        return None
+
+    def _build_hora(self, action: dict, seat: int) -> bytes:
+        is_tsumo = action.get("actor") == action.get("target", action.get("actor"))
+        op_type = Operation.Zimo if is_tsumo else Operation.Hu
+        return self._compose_action(".lq.FastTest.inputOperation", {
+            "type": op_type,
+            "timeuse": 1,
+        })
+
+    def _build_ryukyoku(self, seat: int) -> bytes:
+        return self._compose_action(".lq.FastTest.inputOperation", {
+            "type": Operation.LiuJu,
+            "timeuse": 1,
+        })
+
+    def _compose_action(self, method: str, data: dict) -> bytes:
+        """Compose a Liqi protocol request message."""
+        msg = {
+            "type": MsgType.Req,
+            "method": method,
+            "data": data,
+        }
+        return self.liqi_proto.compose(msg)

--- a/autoplay/js/hook_websocket.js
+++ b/autoplay/js/hook_websocket.js
@@ -1,0 +1,54 @@
+// Hook WebSocket to capture game connection and expose send function
+(function() {
+    if (window.__akagi_hooked) return;
+    window.__akagi_hooked = true;
+    window.__akagi_ws = null;
+    window.__akagi_ws_messages = [];
+
+    const OrigWebSocket = window.WebSocket;
+    window.WebSocket = function(url, protocols) {
+        const ws = protocols
+            ? new OrigWebSocket(url, protocols)
+            : new OrigWebSocket(url);
+
+        // Capture the game gateway WebSocket
+        if (url && (url.includes('gateway') || url.includes('game'))) {
+            window.__akagi_ws = ws;
+            console.log('[Akagi] WebSocket captured:', url);
+
+            ws.addEventListener('message', function(event) {
+                window.__akagi_ws_messages.push({
+                    direction: 'recv',
+                    data: event.data,
+                    timestamp: Date.now()
+                });
+            });
+        }
+
+        return ws;
+    };
+    // Preserve prototype chain
+    window.WebSocket.prototype = OrigWebSocket.prototype;
+    window.WebSocket.CONNECTING = OrigWebSocket.CONNECTING;
+    window.WebSocket.OPEN = OrigWebSocket.OPEN;
+    window.WebSocket.CLOSING = OrigWebSocket.CLOSING;
+    window.WebSocket.CLOSED = OrigWebSocket.CLOSED;
+
+    // Send raw bytes through the game WebSocket
+    window.__akagi_send_raw = function(data) {
+        if (!window.__akagi_ws || window.__akagi_ws.readyState !== WebSocket.OPEN) {
+            console.error('[Akagi] WebSocket not connected');
+            return false;
+        }
+        window.__akagi_ws.send(data);
+        return true;
+    };
+
+    // Check if WebSocket is connected
+    window.__akagi_ws_ready = function() {
+        return window.__akagi_ws !== null
+            && window.__akagi_ws.readyState === WebSocket.OPEN;
+    };
+
+    console.log('[Akagi] WebSocket hook installed');
+})();

--- a/autoplay/majsoul_automation.py
+++ b/autoplay/majsoul_automation.py
@@ -351,13 +351,14 @@ class MajsoulAutomation:
 
             if valid_tiles:
                 if tile in valid_tiles:
-                    # Tsumo tile is a valid riichi discard
+                    # Model's chosen tile is valid
                     riichi_tile = tile
-                    moqie = True
+                    moqie = mjai_action.get("tsumogiri", False)
                 else:
-                    # Tsumo tile is not valid; use first valid option
+                    # Model's tile not in valid list; pick first valid option
                     riichi_tile = valid_tiles[0]
                     moqie = False
+                    logger.warning(f"Riichi: model tile {tile} not in valid={valid_tiles}")
                 logger.info(f"Riichi: valid={valid_tiles}, using={riichi_tile} moqie={moqie}")
             else:
                 # Fallback: use tsumo tile (may fail if invalid)

--- a/autoplay/majsoul_automation.py
+++ b/autoplay/majsoul_automation.py
@@ -1,0 +1,619 @@
+"""Majsoul browser automation using Playwright.
+
+Uses reverse-engineered game JS APIs for login, match-making, and action execution.
+All interaction is done via JS injection into the Laya engine runtime.
+
+Key APIs:
+- app.NetAgent.sendReq2Lobby('Lobby', rpc, data, cb) - lobby RPCs
+- app.NetAgent.sendReq2MJ('FastTest', rpc, data, cb) - in-game RPCs
+- uiscript.UI_Entrance.Inst._try_login_account() - login
+"""
+
+import asyncio
+import time
+import random
+from pathlib import Path
+from playwright.async_api import async_playwright, Page, Browser, BrowserContext
+from settings.settings import settings
+from .logger import logger
+
+JS_DIR = Path(__file__).parent / "js"
+MAJSOUL_URL = "https://game.maj-soul.com/1/"
+
+# Match mode IDs from cfg.desktop.matchmode
+# Format: (game_type, room) → mode_id
+# room: 1=铜之间, 2=银之间, 3=金之间, 4=玉之间, 6=王座间
+# 4p modes: mode=0(速胜), mode=1(東/East), mode=2(南/South)
+# 3p modes: mode=11(East), mode=12(South)
+MATCH_MODE_IDS = {
+    # 4-player modes (mode=1: East, mode=2: South)
+    ("4p_east", "bronze"): 2,
+    ("4p_south", "bronze"): 3,
+    ("4p_east", "silver"): 5,
+    ("4p_south", "silver"): 6,
+    ("4p_east", "gold"): 8,
+    ("4p_south", "gold"): 9,
+    ("4p_east", "jade"): 11,
+    ("4p_south", "jade"): 12,
+    ("4p_east", "throne"): 15,
+    ("4p_south", "throne"): 16,
+    # 3-player modes
+    ("3p_east", "bronze"): 17,
+    ("3p_south", "bronze"): 18,
+    ("3p_east", "silver"): 19,
+    ("3p_south", "silver"): 20,
+    ("3p_east", "gold"): 21,
+    ("3p_south", "gold"): 22,
+    ("3p_east", "jade"): 23,
+    ("3p_south", "jade"): 24,
+    ("3p_east", "throne"): 25,
+    ("3p_south", "throne"): 26,
+}
+
+# MJAI tile format → Majsoul tile format
+MJAI_TO_MS_TILE = {
+    '5mr': '0m', '5pr': '0p', '5sr': '0s',
+    'E': '1z', 'S': '2z', 'W': '3z', 'N': '4z',
+    'P': '5z', 'F': '6z', 'C': '7z',
+}
+
+# Operation type constants (from Liqi protocol)
+OP_DISCARD = 1
+OP_CHI = 2
+OP_PENG = 3
+OP_AN_GANG = 4
+OP_MING_GANG = 5
+OP_JIA_GANG = 6
+OP_LIQI = 7
+OP_ZIMO = 8
+OP_HU = 9
+OP_LIU_JU = 10
+
+
+class MajsoulAutomation:
+    """Controls Majsoul browser via Playwright + JS injection."""
+
+    def __init__(self):
+        self.playwright = None
+        self.browser: Browser | None = None
+        self.context: BrowserContext | None = None
+        self.page: Page | None = None
+
+    async def start_browser(self, proxy_port: int = None):
+        """Launch Chromium with proxy pointing to MITM.
+
+        Uses a persistent user data directory so game assets are cached
+        across runs, avoiding slow re-downloads through the MITM proxy.
+        """
+        self.playwright = await async_playwright().start()
+
+        # Persistent profile directory for asset caching
+        user_data_dir = Path(__file__).parent.parent / ".browser_profile"
+        user_data_dir.mkdir(exist_ok=True)
+
+        launch_args = {
+            "headless": settings.autoplay_headless,
+            "args": [
+                "--disable-blink-features=AutomationControlled",
+                "--no-sandbox",
+            ],
+        }
+
+        if proxy_port:
+            launch_args["proxy"] = {
+                "server": f"http://127.0.0.1:{proxy_port}",
+            }
+
+        self.context = await self.playwright.chromium.launch_persistent_context(
+            str(user_data_dir),
+            viewport={"width": 1280, "height": 720},
+            ignore_https_errors=True,
+            **launch_args,
+        )
+        self.page = self.context.pages[0] if self.context.pages else await self.context.new_page()
+
+        # Inject WebSocket hook before any page loads
+        hook_js = (JS_DIR / "hook_websocket.js").read_text()
+        await self.context.add_init_script(hook_js)
+
+        logger.info("Browser started (persistent profile)")
+
+    async def navigate_to_game(self):
+        """Open Majsoul website and wait for game engine to load."""
+        await self.page.goto(MAJSOUL_URL, wait_until="domcontentloaded", timeout=120000)
+        logger.info("Majsoul page loaded")
+
+    async def wait_for_entrance(self, timeout: float = 180):
+        """Wait for the game to fully initialize to the entrance screen."""
+        logger.info("Waiting for game to initialize...")
+        start = time.time()
+        screenshot_taken = False
+        while time.time() - start < timeout:
+            ready = await self.page.evaluate("""() => {
+                try {
+                    return !!(typeof uiscript !== 'undefined' &&
+                              uiscript.UI_Entrance && uiscript.UI_Entrance.Inst);
+                } catch(e) { return false; }
+            }""")
+            if ready:
+                elapsed = int(time.time() - start)
+                logger.info(f"Game initialized in {elapsed}s")
+                return True
+            elapsed = int(time.time() - start)
+            if elapsed >= 30 and not screenshot_taken:
+                await self.page.screenshot(path="logs/init_debug.png")
+                logger.info("Saved init debug screenshot at 30s")
+                screenshot_taken = True
+            await asyncio.sleep(1)
+
+        await self.page.screenshot(path="logs/init_timeout.png")
+        logger.error(f"Game initialization timeout ({timeout}s)")
+        return False
+
+    async def login(self, username: str, password: str):
+        """Auto-login using the game's own _try_login_account JS API.
+
+        This calls the game's internal login function directly,
+        which handles the full Yostar email/password login flow
+        including RPC, session setup, and lobby transition.
+        """
+        logger.info(f"Logging in as {username}...")
+
+        await asyncio.sleep(2)
+
+        result = await self.page.evaluate("""(creds) => {
+            try {
+                const inst = uiscript.UI_Entrance.Inst;
+                // login_index is the internal counter that must match
+                // for the login to proceed (anti-replay)
+                const counterKey = window.$u[11161];
+                const counter = inst[counterKey];
+                // Call the game's native login function
+                inst._try_login_account(counter, creds[0], creds[1]);
+                return {ok: true};
+            } catch(e) { return {error: e.message}; }
+        }""", [username, password])
+
+        if result.get("error"):
+            logger.error(f"Login call failed: {result['error']}")
+            return False
+
+        logger.info("Login RPC sent via game API")
+        return True
+
+    async def wait_for_lobby(self, timeout: float = 120):
+        """Wait until the game enters the lobby state (or reconnects to game).
+
+        After detecting UI_Lobby.Inst, waits extra time for the lobby
+        to finish its "正在打扫大厅..." loading animation.
+
+        Returns:
+            "lobby" if entered lobby normally
+            "game" if auto-reconnected to an ongoing game
+            None if timed out
+        """
+        logger.info("Waiting for lobby...")
+        start = time.time()
+        while time.time() - start < timeout:
+            state = await self.page.evaluate("""() => {
+                try {
+                    return {
+                        lobby: !!(uiscript.UI_Lobby && uiscript.UI_Lobby.Inst),
+                        in_game: !!(typeof view !== 'undefined' && view.DesktopMgr && view.DesktopMgr.Inst),
+                        logined: GameMgr.Inst.logined || false,
+                        account_id: GameMgr.Inst.account_id || -1,
+                    };
+                } catch(e) { return {error: e.message}; }
+            }""")
+            if state.get("in_game"):
+                logger.info(f"Auto-reconnected to ongoing game (account_id: {state.get('account_id')})")
+                return "game"
+            if state.get("lobby"):
+                logger.info(f"In lobby (account_id: {state.get('account_id')})")
+                # Wait for lobby loading animation to finish
+                logger.info("Waiting for lobby to fully load...")
+                await asyncio.sleep(15)
+                return "lobby"
+            await asyncio.sleep(1)
+
+        logger.error("Lobby timeout")
+        return None
+
+    def _get_match_sid(self) -> str | None:
+        """Build match_sid string for startUnifiedMatch.
+
+        Format: "{match_group}:{mode_id}" where match_group=1 for ranked.
+        """
+        mode_type = settings.autoplay_mode.type
+        room = settings.autoplay_mode.room
+        mode_id = MATCH_MODE_IDS.get((mode_type, room))
+        if mode_id is None:
+            return None
+        # All ranked modes use match_group=1
+        return f"1:{mode_id}"
+
+    async def start_match(self):
+        """Start ranked match queue via startUnifiedMatch RPC.
+
+        Uses the new unified match API with match_sid format "group:mode_id".
+        """
+        match_sid = self._get_match_sid()
+        if match_sid is None:
+            mode_type = settings.autoplay_mode.type
+            room = settings.autoplay_mode.room
+            logger.error(f"Unknown match mode: {mode_type} {room}")
+            return False
+
+        logger.info(f"Starting match: {settings.autoplay_mode.type} "
+                     f"{settings.autoplay_mode.room} (match_sid={match_sid})")
+
+        result = await self.page.evaluate("""(sid) => {
+            try {
+                const versionStr = GameMgr.Inst.getClientVersion();
+                return new Promise((resolve) => {
+                    app.NetAgent.sendReq2Lobby('Lobby', 'startUnifiedMatch', {
+                        match_sid: sid,
+                        client_version_string: versionStr,
+                    }, function(errcode, msg) {
+                        resolve({errcode: errcode || 0, msg: msg || {}});
+                    });
+                    setTimeout(() => resolve({error: 'timeout'}), 15000);
+                });
+            } catch(e) { return {error: e.message}; }
+        }""", match_sid)
+
+        if result.get("error"):
+            logger.error(f"startUnifiedMatch failed: {result}")
+            return False
+
+        errcode = result.get("errcode", 0)
+        msg = result.get("msg", {})
+        msg_error = msg.get("error", {}) if isinstance(msg, dict) else {}
+
+        if errcode or msg_error:
+            logger.error(f"startUnifiedMatch error: errcode={errcode}, msg_error={msg_error}")
+            return False
+
+        logger.info("Match queued successfully")
+        return True
+
+    async def cancel_match(self):
+        """Cancel the current match queue."""
+        match_sid = self._get_match_sid() or "1:5"
+
+        await self.page.evaluate("""(sid) => {
+            app.NetAgent.sendReq2Lobby('Lobby', 'cancelUnifiedMatch', {
+                match_sid: sid,
+            }, function(errcode, msg) {
+                console.log('[Akagi] cancelUnifiedMatch:', errcode, msg);
+            });
+        }""", match_sid)
+        logger.info("Match cancelled")
+
+    async def wait_for_game_start(self, timeout: float = 300):
+        """Wait for the match to start (game found).
+
+        Detects game start by checking for DesktopMgr (the in-game manager).
+        """
+        logger.info("Waiting for game to start...")
+        start = time.time()
+        while time.time() - start < timeout:
+            state = await self.page.evaluate("""() => {
+                try {
+                    return {
+                        in_game: !!(view && view.DesktopMgr && view.DesktopMgr.Inst),
+                        pipei: !!(uiscript.UI_PiPei && uiscript.UI_PiPei.Inst &&
+                                  uiscript.UI_PiPei.Inst._enable),
+                    };
+                } catch(e) { return {error: e.message}; }
+            }""")
+            if state.get("in_game"):
+                logger.info("Game started!")
+                return True
+            await asyncio.sleep(1)
+
+        logger.error("Game start timeout")
+        return False
+
+    async def execute_action(self, mjai_action: dict, seat: int):
+        """Execute an AI-recommended action via the game's JS API.
+
+        Uses app.NetAgent.sendReq2MJ('FastTest', ...) to call the game's
+        own RPC functions, which handles msg_id, protobuf, and state correctly.
+        """
+        action_type = mjai_action.get("type")
+        if action_type in ("none", None):
+            # Skip/pass: decline chi/pon/kan/hu opportunity
+            await self._send_skip()
+            return
+
+        # Apply random delay to look human-like
+        delay = random.uniform(
+            settings.autoplay_time.rand_min,
+            settings.autoplay_time.rand_max,
+        )
+        await asyncio.sleep(delay)
+
+        pai = mjai_action.get("pai", "")
+        tile = MJAI_TO_MS_TILE.get(pai, pai)
+
+        if action_type == "dahai":
+            await self._send_discard_with_retry(
+                tile, mjai_action.get("tsumogiri", False)
+            )
+        elif action_type == "reach":
+            # Riichi requires a valid tile from the server's combination list.
+            # The tsumo tile (pai) may not be a valid riichi discard.
+            from mitm.bridge.majsoul.bridge import get_last_operation_list
+            operations = get_last_operation_list()
+            liqi_op = next((op for op in operations if op.get('type') == OP_LIQI), None)
+            valid_tiles = liqi_op.get('combination', []) if liqi_op else []
+
+            if valid_tiles:
+                if tile in valid_tiles:
+                    # Tsumo tile is a valid riichi discard
+                    riichi_tile = tile
+                    moqie = True
+                else:
+                    # Tsumo tile is not valid; use first valid option
+                    riichi_tile = valid_tiles[0]
+                    moqie = False
+                logger.info(f"Riichi: valid={valid_tiles}, using={riichi_tile} moqie={moqie}")
+            else:
+                # Fallback: use tsumo tile (may fail if invalid)
+                riichi_tile = tile
+                moqie = mjai_action.get("tsumogiri", False)
+                logger.warning(f"Riichi: no operation list, fallback tile={riichi_tile}")
+
+            await self._send_input_operation({
+                "type": OP_LIQI,
+                "tile": riichi_tile,
+                "moqie": moqie,
+                "timeuse": 3,
+            })
+        elif action_type == "chi":
+            await self._send_chi_peng_gang(OP_CHI, mjai_action)
+        elif action_type == "pon":
+            await self._send_chi_peng_gang(OP_PENG, mjai_action)
+        elif action_type == "daiminkan":
+            await self._send_chi_peng_gang(OP_MING_GANG, mjai_action)
+        elif action_type == "ankan":
+            consumed = mjai_action.get("consumed", [""])
+            an_tile = MJAI_TO_MS_TILE.get(consumed[0], consumed[0]) if consumed else ""
+            await self._send_input_operation({
+                "type": OP_AN_GANG,
+                "tile": an_tile,
+                "timeuse": 3,
+            })
+        elif action_type == "kakan":
+            await self._send_input_operation({
+                "type": OP_JIA_GANG,
+                "tile": tile,
+                "timeuse": 3,
+            })
+        elif action_type == "hora":
+            is_tsumo = mjai_action.get("actor") == mjai_action.get(
+                "target", mjai_action.get("actor")
+            )
+            await self._send_input_operation({
+                "type": OP_ZIMO if is_tsumo else OP_HU,
+                "timeuse": 1,
+            })
+        elif action_type == "ryukyoku":
+            await self._send_input_operation({
+                "type": OP_LIU_JU,
+                "timeuse": 1,
+            })
+        else:
+            logger.warning(f"Unknown action type: {action_type}")
+
+    async def _send_discard_with_retry(self, tile: str, moqie: bool) -> bool:
+        """Send a discard with retry if the server silently ignores it.
+
+        The Majsoul server sometimes silently ignores the first inputOperation
+        after ActionNewRound when the player is the dealer (14 tiles, step 0).
+        This method detects that by checking if ActionDiscardTile was received
+        (via a monotonically increasing counter), and retries with increasing delays.
+        """
+        from mitm.bridge.majsoul.bridge import get_discard_counter
+
+        pre_count = get_discard_counter()
+
+        for attempt in range(3):
+            params = {
+                "type": OP_DISCARD,
+                "tile": tile,
+                "moqie": moqie,
+                "timeuse": 3 + attempt * 3,
+            }
+            ok = await self._send_input_operation(params)
+            if not ok:
+                return False
+
+            # Wait up to 5 seconds for ActionDiscardTile confirmation
+            for _ in range(25):
+                await asyncio.sleep(0.2)
+                if get_discard_counter() > pre_count:
+                    return True  # Discard was processed
+
+            if attempt < 2:
+                logger.warning(
+                    f"Discard not acknowledged (attempt {attempt + 1}/3), retrying..."
+                )
+
+        logger.error("Discard failed after 3 attempts")
+        return False
+
+    async def _send_input_operation(self, params: dict) -> bool:
+        """Send inputOperation RPC via game's network layer."""
+        result = await self.page.evaluate("""(params) => {
+            try {
+                return new Promise((resolve) => {
+                    app.NetAgent.sendReq2MJ('FastTest', 'inputOperation', params,
+                        function(errcode, msg) {
+                            resolve({errcode: errcode || 0});
+                        });
+                    setTimeout(() => resolve({error: 'timeout'}), 10000);
+                });
+            } catch(e) { return {error: e.message}; }
+        }""", params)
+
+        if result.get("error"):
+            logger.error(f"inputOperation error: {result}")
+            return False
+        if result.get("errcode"):
+            logger.error(f"inputOperation errcode={result['errcode']}")
+            return False
+        logger.info(f"OK: inputOperation type={params.get('type')} tile={params.get('tile', '')}")
+        return True
+
+    async def _send_skip(self) -> bool:
+        """Send skip/pass via inputChiPengGang with cancel_operation=true."""
+        await asyncio.sleep(0.5)
+        result = await self.page.evaluate("""() => {
+            try {
+                return new Promise((resolve) => {
+                    app.NetAgent.sendReq2MJ('FastTest', 'inputChiPengGang', {
+                        cancel_operation: true,
+                        timeuse: 2,
+                    }, function(errcode, msg) {
+                        resolve({errcode: errcode || 0});
+                    });
+                    setTimeout(() => resolve({error: 'timeout'}), 10000);
+                });
+            } catch(e) { return {error: e.message}; }
+        }""")
+
+        if result.get("error"):
+            logger.error(f"skip error: {result}")
+            return False
+        if result.get("errcode"):
+            logger.warning(f"skip errcode={result['errcode']} (may be no pending operation)")
+            return False
+        logger.info("OK: skip (pass)")
+        return True
+
+    async def _send_chi_peng_gang(self, type_: int, mjai_action: dict) -> bool:
+        """Send inputChiPengGang RPC via game's network layer.
+
+        type_: OP_CHI(2), OP_PENG(3), OP_MING_GANG(5) from Operation enum
+        """
+        from mitm.bridge.majsoul.bridge import get_last_operation_list
+
+        # Convert consumed tiles for index matching
+        consumed = mjai_action.get("consumed", [])
+        ms_consumed = [MJAI_TO_MS_TILE.get(t, t) for t in consumed]
+
+        # Find correct combination index (mainly needed for chi)
+        index = 0
+        if type_ == OP_CHI and ms_consumed:
+            operations = get_last_operation_list()
+            chi_op = next((op for op in operations if op.get('type') == 2), None)
+            if chi_op and chi_op.get('combination'):
+                consumed_sorted = '|'.join(sorted(ms_consumed))
+                for i, combo in enumerate(chi_op['combination']):
+                    combo_sorted = '|'.join(sorted(combo.split('|')))
+                    if combo_sorted == consumed_sorted:
+                        index = i
+                        break
+                logger.info(f"Chi combinations: {chi_op['combination']} → index={index}")
+
+        result = await self.page.evaluate("""(params) => {
+            try {
+                return new Promise((resolve) => {
+                    app.NetAgent.sendReq2MJ('FastTest', 'inputChiPengGang', params,
+                        function(errcode, msg) {
+                            resolve({errcode: errcode || 0});
+                        });
+                    setTimeout(() => resolve({error: 'timeout'}), 10000);
+                });
+            } catch(e) { return {error: e.message}; }
+        }""", {
+            "type": type_,
+            "index": index,
+            "timeuse": 3,
+        })
+
+        if result.get("error"):
+            logger.error(f"inputChiPengGang error: {result}")
+            return False
+        if result.get("errcode"):
+            logger.error(f"inputChiPengGang errcode={result['errcode']}")
+            return False
+        op_name = {OP_CHI: "chi", OP_PENG: "pon", OP_MING_GANG: "kan"}.get(type_, str(type_))
+        logger.info(f"OK: {op_name} consumed={ms_consumed} index={index}")
+        return True
+
+    async def handle_end_game(self):
+        """Handle the end-of-game result screen.
+
+        Uses a combination of mouse clicks to dismiss result screens
+        and checks for lobby re-entry.
+        """
+        logger.info("Handling end game screen...")
+        await asyncio.sleep(5)
+
+        # Click through result screens (multiple clicks needed for
+        # round results → game results → back to lobby)
+        for i in range(15):
+            # Check if we're already back in lobby
+            in_lobby = await self.page.evaluate("""() => {
+                try {
+                    return !!(uiscript.UI_Lobby && uiscript.UI_Lobby.Inst);
+                } catch(e) { return false; }
+            }""")
+            if in_lobby:
+                logger.info(f"Returned to lobby after {i} clicks")
+                return True
+
+            # Click center-ish area to dismiss overlays
+            await self.page.mouse.click(640, 450)
+            await asyncio.sleep(1.5)
+
+        # Final wait for lobby (some transitions take longer)
+        for _ in range(20):
+            in_lobby = await self.page.evaluate("""() => {
+                try {
+                    return !!(uiscript.UI_Lobby && uiscript.UI_Lobby.Inst);
+                } catch(e) { return false; }
+            }""")
+            if in_lobby:
+                logger.info("Returned to lobby")
+                return True
+            await self.page.mouse.click(640, 400)
+            await asyncio.sleep(2)
+
+        logger.warning("Could not confirm lobby return")
+        return False
+
+    async def check_connection(self) -> bool:
+        """Check if the game is still connected and responsive."""
+        try:
+            return await self.page.evaluate("window.__akagi_ws_ready()")
+        except Exception:
+            return False
+
+    async def recover(self):
+        """Try to recover from errors by reloading and re-logging in."""
+        logger.info("Attempting recovery...")
+        try:
+            await self.page.reload(wait_until="domcontentloaded", timeout=120000)
+            if not await self.wait_for_entrance():
+                return False
+            if not await self.login(
+                settings.autoplay_account.username,
+                settings.autoplay_account.password,
+            ):
+                return False
+            return await self.wait_for_lobby()
+        except Exception as e:
+            logger.error(f"Recovery failed: {e}")
+            return False
+
+    async def close(self):
+        """Clean up browser resources."""
+        if self.context:
+            await self.context.close()
+        if self.playwright:
+            await self.playwright.stop()
+        logger.info("Browser closed")

--- a/mitm/bridge/majsoul/bridge.py
+++ b/mitm/bridge/majsoul/bridge.py
@@ -1,10 +1,32 @@
+import threading
 from typing import Self
 from enum import Enum
 from functools import cmp_to_key
 from .liqi import LiqiProto, MsgType
 from ..bridge_base import BridgeBase
 from ..logger import logger
-        
+
+# Thread-safe storage for the latest operation list from server.
+# Used by autoplay to find the correct chi combination index.
+_last_op_lock = threading.Lock()
+_last_op_list = []
+
+# Monotonically increasing counter for ActionDiscardTile events,
+# so autoplay can detect if a discard was silently ignored.
+_discard_counter = 0
+
+
+def get_last_operation_list():
+    """Return the last operation list received from the server."""
+    with _last_op_lock:
+        return list(_last_op_list)
+
+
+def get_discard_counter():
+    """Return monotonic counter incremented on each ActionDiscardTile."""
+    with _last_op_lock:
+        return _discard_counter
+
 MS_TILE_2_MJAI_TILE = {
     '0m': '5mr',
     '1m': '1m',
@@ -310,6 +332,9 @@ class MajsoulBridge(BridgeBase):
                 )
             # dahai
             if liqi_message['data']['name'] == 'ActionDiscardTile':
+                global _discard_counter
+                with _last_op_lock:
+                    _discard_counter += 1
                 actor = liqi_message['data']['data']['seat']
                 self.lastDiscard = actor
                 pai = MS_TILE_2_MJAI_TILE[liqi_message['data']['data']['tile']]
@@ -478,6 +503,10 @@ class MajsoulBridge(BridgeBase):
                 return ret
             if 'data' in liqi_message['data']:
                 if 'operation' in liqi_message['data']['data']:
+                    global _last_op_list
+                    op_data = liqi_message['data']['data']['operation']
+                    with _last_op_lock:
+                        _last_op_list = op_data.get('operationList', [])
                     return ret
         # end_game
         if liqi_message['method'] == '.lq.NotifyGameEndResult' or liqi_message['method'] == '.lq.NotifyGameTerminate':

--- a/mitm/majsoul.py
+++ b/mitm/majsoul.py
@@ -70,7 +70,7 @@ class ClientWebSocket(ClientWebSocketABC):
             logger.error(f"WebSocket connection closed from unactivated flow: {flow.id}")
 
 async def start_proxy(host, port):
-    opts = options.Options(listen_host=host, listen_port=port)
+    opts = options.Options(listen_host=host, listen_port=port, ssl_insecure=True)
     master = DumpMaster(
         opts,
         with_termlog=False,

--- a/mjai_bot/controller.py
+++ b/mjai_bot/controller.py
@@ -71,7 +71,7 @@ class Controller(object):
                     logger.error(f"Event: {event}")
                     continue
             if self.starting_game:
-                return {"type": "none"}
+                return {"type": "none", "can_act": False}
             events = self.temp_mjai_msg + events
             self.temp_mjai_msg = []
             ans = self.bot.react(json.dumps(events, separators=(",", ":")))

--- a/mjai_bot/mortal/bot.py
+++ b/mjai_bot/mortal/bot.py
@@ -88,33 +88,24 @@ class Bot:
             return_action = self.model.react(json.dumps(e, separators=(",", ":")))
 
         if return_action is None:
+            # Model didn't react to any event - no action needed
+            # can_act=False tells the caller NOT to send a skip RPC
+            raw_data = {"type":"none", "can_act": False}
             # ========== Online Server =========== #
             if model.ot_settings['online']:
-                raw_data = {
-                    "type":"none",
-                    "meta": {
-                        "online": model.is_online
-                    }
-                }
-                return_action = json.dumps(raw_data, separators=(",", ":"))
-            else:
-                return_action = json.dumps({"type":"none"}, separators=(",", ":"))
+                raw_data["meta"] = {"online": model.is_online}
             # ==================================== #
-            return return_action
+            return json.dumps(raw_data, separators=(",", ":"))
         else:
+            # Model reacted - either a real action or explicit pass
+            # can_act=True tells the caller this is a deliberate decision
+            raw_data = json.loads(return_action)
+            raw_data["can_act"] = True
             # ========== Online Server =========== #
             if model.ot_settings['online']:
-                if "meta" in return_action:
-                    raw_data = json.loads(return_action)
-                    raw_data["meta"]["online"] = model.is_online
-                    return_action = json.dumps(raw_data, separators=(",", ":"))
-                else:
-                    raw_data = json.loads(return_action)
-                    raw_data["meta"] = {"online": model.is_online}
-                    return_action = json.dumps(raw_data, separators=(",", ":"))
+                if "meta" not in raw_data:
+                    raw_data["meta"] = {}
+                raw_data["meta"]["online"] = model.is_online
             # ==================================== #
-            # raw_data = json.loads(return_action)
-            # del raw_data["meta"]
-            # return json.dumps(raw_data, separators=(",", ":"))
-            return return_action
+            return json.dumps(raw_data, separators=(",", ":"))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,12 @@ protobuf==5.29.3
 # PyTorch
 torch==2.5.1
 numpy==2.1.2
+
+# Autoplay
+playwright==1.49.0
+
+# WebUI
+fastapi==0.115.0
+uvicorn==0.30.0
+websockets==12.0
+watchdog==4.0.0

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -40,6 +40,16 @@ class AutoplayTimeConfig:
     candidate: float
 
 @dataclasses.dataclass
+class AutoplayAccountConfig:
+    username: str
+    password: str
+
+@dataclasses.dataclass
+class AutoplayModeConfig:
+    type: str    # "4p_south", "4p_east", "3p_south", "3p_east"
+    room: str    # "gold", "silver", "jade", "throne"
+
+@dataclasses.dataclass
 class Settings:
     mitm: MITMConfig
     theme: str
@@ -49,6 +59,10 @@ class Settings:
     auto_switch_model: bool
     autoplay_time: AutoplayTimeConfig
     recommendation_temperature: float
+    autoplay_account: AutoplayAccountConfig
+    autoplay_mode: AutoplayModeConfig
+    autoplay_headless: bool
+    model_path: str
     def update(self, settings: dict) -> None:
         """
         Update settings from a dictionary
@@ -73,6 +87,20 @@ class Settings:
             candidate=settings["autoplay_time"]["candidate"]
         )
         self.recommendation_temperature = settings["recommendation_temperature"]
+        if "autoplay_account" in settings:
+            self.autoplay_account = AutoplayAccountConfig(
+                username=settings["autoplay_account"]["username"],
+                password=settings["autoplay_account"]["password"]
+            )
+        if "autoplay_mode" in settings:
+            self.autoplay_mode = AutoplayModeConfig(
+                type=settings["autoplay_mode"]["type"],
+                room=settings["autoplay_mode"]["room"]
+            )
+        if "autoplay_headless" in settings:
+            self.autoplay_headless = settings["autoplay_headless"]
+        if "model_path" in settings:
+            self.model_path = settings["model_path"]
         self.save_ot_settings()
 
     def save_ot_settings(self) -> None:
@@ -129,7 +157,17 @@ class Settings:
                     "rand_max": self.autoplay_time.rand_max,
                     "candidate": self.autoplay_time.candidate
                 },
-                "recommendation_temperature": self.recommendation_temperature
+                "recommendation_temperature": self.recommendation_temperature,
+                "autoplay_account": {
+                    "username": self.autoplay_account.username,
+                    "password": self.autoplay_account.password
+                },
+                "autoplay_mode": {
+                    "type": self.autoplay_mode.type,
+                    "room": self.autoplay_mode.room
+                },
+                "autoplay_headless": self.autoplay_headless,
+                "model_path": self.model_path
             }, f, indent=4)
         # Save the settings to the file
         logger.info(f"Saved settings to {FILE_PATH / 'settings.json'}")
@@ -184,7 +222,17 @@ def load_settings() -> Settings:
                     "rand_max": 3,
                     "candidate": 0.5
                 },
-                "recommendation_temperature": 0.3
+                "recommendation_temperature": 0.3,
+                "autoplay_account": {
+                    "username": "",
+                    "password": ""
+                },
+                "autoplay_mode": {
+                    "type": "4p_south",
+                    "room": "gold"
+                },
+                "autoplay_headless": False,
+                "model_path": "mortal.pth"
             }, f, indent=4)
         logger.info(f"Created new settings.json with default values")
         # Load settings again
@@ -221,7 +269,17 @@ def load_settings() -> Settings:
             rand_max=settings["autoplay_time"]["rand_max"],
             candidate=settings["autoplay_time"]["candidate"]
         ),
-        recommendation_temperature=settings["recommendation_temperature"]
+        recommendation_temperature=settings["recommendation_temperature"],
+        autoplay_account=AutoplayAccountConfig(
+            username=settings.get("autoplay_account", {}).get("username", ""),
+            password=settings.get("autoplay_account", {}).get("password", "")
+        ),
+        autoplay_mode=AutoplayModeConfig(
+            type=settings.get("autoplay_mode", {}).get("type", "4p_south"),
+            room=settings.get("autoplay_mode", {}).get("room", "gold")
+        ),
+        autoplay_headless=settings.get("autoplay_headless", False),
+        model_path=settings.get("model_path", "mortal.pth")
     )
 
 def get_schema() -> dict:

--- a/settings/settings.schema.json
+++ b/settings/settings.schema.json
@@ -88,9 +88,29 @@
     "recommendation_temperature": {
       "type": "number",
       "description": "Temperature setting for recommendation softmax scaling."
+    },
+    "autoplay_account": {
+      "type": "object",
+      "properties": {
+        "username": { "type": "string" },
+        "password": { "type": "string" }
+      }
+    },
+    "autoplay_mode": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["4p_south", "4p_east", "3p_south", "3p_east"] },
+        "room": { "type": "string", "enum": ["bronze", "silver", "gold", "jade", "throne"] }
+      }
+    },
+    "autoplay_headless": {
+      "type": "boolean"
+    },
+    "model_path": {
+      "type": "string",
+      "description": "Path to the Mortal model file (.pth), relative to mjai_bot/mortal/ directory."
     }
   },
   "required": ["mitm", "model", "theme", "ot_server", "autoplay", "auto_switch_model", "recommendation_temperature"],
-  "description": "Settings for the application.",
-  "additionalProperties": false
+  "description": "Settings for the application."
 }


### PR DESCRIPTION
## Summary

Replace the stub autoplay implementation with a full **Playwright + JS injection** browser automation engine for Majsoul.

Instead of coordinate-based mouse clicking, this approach **injects JavaScript to call the game's native RPC APIs** (`app.NetAgent.sendReq2MJ`), making it:
- More reliable (not dependent on UI layout/resolution)
- More maintainable (uses stable game API contracts)
- Faster (direct RPC calls vs simulated UI interactions)

## Key Changes

### New Files
- **`autoplay/majsoul_automation.py`** (620 lines) — Complete Playwright-based browser automation:
  - Login via game's `_try_login_account()` JS API
  - Match queuing via `startUnifiedMatch` RPC
  - Action execution (discard, chi/pon/kan, riichi, hora, ryukyoku) via `sendReq2MJ('FastTest', ...)`
  - Discard retry with acknowledgment detection (handles server silent-ignore edge case)
  - Riichi tile validation against server's operation list
  - Chi combination index matching
  - End-game screen handling and error recovery
- **`autoplay/action_converter.py`** — MJAI-to-Liqi protocol converter
- **`autoplay/js/hook_websocket.js`** — WebSocket hook for connection health monitoring

### Modified Files
- **`mitm/bridge/majsoul/bridge.py`** — Thread-safe operation list tracking + discard acknowledgment counter
- **`mitm/majsoul.py`** — Add `ssl_insecure=True` for HTTPS interception through proxy
- **`settings/settings.py`** — Add `autoplay_account`, `autoplay_mode`, `autoplay_headless`, `model_path` configs
- **`settings/settings.schema.json`** — Schema for new config fields
- **`mjai_bot/controller.py`** — Add `can_act` field to response for autoplay coordination
- **`requirements.txt`** — Add `playwright` and supporting dependencies

## Architecture

```
Browser (Playwright)
  ├── JS Hook (hook_websocket.js) → captures WebSocket for health checks
  ├── Login → uiscript.UI_Entrance.Inst._try_login_account()
  ├── Match Queue → sendReq2Lobby('Lobby', 'startUnifiedMatch', ...)
  └── Actions → sendReq2MJ('FastTest', 'inputOperation'/'inputChiPengGang', ...)
       ↑ validated against operation list from MITM bridge
```

## Configuration

New settings in `settings.json`:
```json
{
  "autoplay_account": { "username": "", "password": "" },
  "autoplay_mode": { "type": "4p_south", "room": "gold" },
  "autoplay_headless": false,
  "model_path": "mortal.pth"
}
```

## Test Plan
- [ ] Verify existing MITM-only flow still works (no regression)
- [ ] Test login via JS API with valid credentials
- [ ] Test match queuing for different room/mode combinations
- [ ] Test full game cycle: queue → play → end → re-queue
- [ ] Test error recovery (page reload + re-login)
- [ ] Test discard retry logic when server silently ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)