### PR TITLE
feat(schema): carry speculated dahai on reach event

### DIFF
--- a/frontend/src/tiles/BotActionTile.tsx
+++ b/frontend/src/tiles/BotActionTile.tsx
@@ -98,15 +98,20 @@ function describe(r: BotResponse, t: (k: string, opts?: Record<string, unknown>)
         mahgen: mjaiToMahgen([r.consumed[0]]),
       }
     case 'reach':
-      // Discard tile selection lives in a separate dahai response — needs
-      // mjai⇄mortal protocol work to merge. Show glyph + label only.
+      // The Mortal bot wrapper peeks the post-reach dahai by replaying
+      // the event log into a throwaway Bot and reading off its next
+      // action; when that succeeds, `pai` carries the predicted
+      // riichi-discard tile so the HUD can render mahgen up-front
+      // (Majsoul fuses declaring + discarding into one click). Bridge-
+      // emitted reach events leave `pai` undefined and we fall back to
+      // glyph + label only.
       return {
         glyph: reachGlyph,
         color: '#e06c20',
         glyphColor: '#e06c20',
         labelKey: 'mahjong.reach',
-        extra: '',
-        mahgen: '',
+        extra: r.pai ?? '',
+        mahgen: r.pai ? mjaiToMahgen([r.pai]) : '',
       }
     case 'hora':
       return r.actor === r.target

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,7 +11,7 @@ export type MjaiEvent =
   | { type: 'kakan'; actor: number; pai: string; consumed: [string, string, string] }
   | { type: 'ankan'; actor: number; consumed: [string, string, string, string] }
   | { type: 'dora'; dora_marker: string }
-  | { type: 'reach'; actor: number }
+  | { type: 'reach'; actor: number; pai?: string }
   | { type: 'reach_accepted'; actor: number }
   | { type: 'hora'; actor: number; target: number; deltas?: number[]; ura_markers?: string[] }
   | { type: 'ryukyoku'; deltas?: number[] }

--- a/src/bridge/majsoul/mod.rs
+++ b/src/bridge/majsoul/mod.rs
@@ -384,7 +384,7 @@ impl MajsoulBridge {
             });
         }
         if is_riichi {
-            events.push(MjaiEvent::Reach { actor });
+            events.push(MjaiEvent::Reach { actor, pai: None });
         }
         events.push(MjaiEvent::Dahai {
             actor,
@@ -2317,7 +2317,7 @@ mod tests {
         ));
         assert_eq!(events.len(), 2);
         match &events[0] {
-            MjaiEvent::Reach { actor } => assert_eq!(*actor, 1),
+            MjaiEvent::Reach { actor, .. } => assert_eq!(*actor, 1),
             other => panic!("expected Reach first, got {other:?}"),
         }
         match &events[1] {
@@ -2344,7 +2344,7 @@ mod tests {
             ACTION_DISCARD_TILE,
             json!({ "seat": 0, "tile": "9m", "moqie": true, "is_wliqi": true }),
         ));
-        assert!(matches!(events[0], MjaiEvent::Reach { actor: 0 }));
+        assert!(matches!(events[0], MjaiEvent::Reach { actor: 0, .. }));
         assert_eq!(bridge.pending_reach_accepted, Some(0));
     }
 

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -413,7 +413,7 @@ impl TenhouBridge {
             .get("step")
             .and_then(|v| v.as_str().and_then(|s| s.parse::<u8>().ok()).or(v.as_u64().map(|n| n as u8)));
         let events = match step {
-            Some(1) => vec![MjaiEvent::Reach { actor }],
+            Some(1) => vec![MjaiEvent::Reach { actor, pai: None }],
             Some(2) => {
                 if actor == self.state.seat {
                     self.state.in_riichi = true;
@@ -935,7 +935,7 @@ mod tests {
             r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"0,1,2,3,4,5,6,7,8,9,10,11,12"}"#,
         );
         let e1 = parse_one(&mut b, r#"{"tag":"REACH","who":"0","step":"1"}"#);
-        assert!(matches!(e1[0], MjaiEvent::Reach { actor: 0 }));
+        assert!(matches!(e1[0], MjaiEvent::Reach { actor: 0, .. }));
         let e2 = parse_one(&mut b, r#"{"tag":"REACH","who":"0","step":"2","ten":"240,250,250,260"}"#);
         assert!(matches!(e2[0], MjaiEvent::ReachAccepted { actor: 0 }));
     }

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -468,7 +468,7 @@ mod tests {
             pai: "3m".into(),
         })
         .unwrap();
-        t.handle(&AkagiEvent::Reach { actor: 0 }).unwrap();
+        t.handle(&AkagiEvent::Reach { actor: 0, pai: None }).unwrap();
         t.handle(&AkagiEvent::Dahai {
             actor: 0,
             pai: "1m".into(),

--- a/src/history/aggregator.rs
+++ b/src/history/aggregator.rs
@@ -142,7 +142,7 @@ pub fn aggregate(input: AggregateInput<'_>) -> Option<GameRecord> {
                 }
             }
 
-            MjaiEvent::Reach { actor } => {
+            MjaiEvent::Reach { actor, .. } => {
                 if let Some(me) = our_seat {
                     if *actor == me {
                         riichi_declared = true;
@@ -443,7 +443,7 @@ mod tests {
         let events = vec![
             start_game_4p(2),
             start_kyoku("E", 0, vec![25000, 25000, 25000, 25000]),
-            MjaiEvent::Reach { actor: 2 },
+            MjaiEvent::Reach { actor: 2, pai: None },
             MjaiEvent::ReachAccepted { actor: 2 },
             MjaiEvent::Dahai {
                 actor: 2,
@@ -593,7 +593,7 @@ mod tests {
         let events = vec![
             start_game_4p(0),
             start_kyoku("E", 0, vec![25000, 25000, 25000, 25000]),
-            MjaiEvent::Reach { actor: 0 },
+            MjaiEvent::Reach { actor: 0, pai: None },
             MjaiEvent::ReachAccepted { actor: 0 }, // -1000 to seat 0
             MjaiEvent::Ryukyoku {
                 deltas: Some(vec![1500, -1500, 0, 0]),

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -908,7 +908,7 @@ fn mjai_event_actor(event: &crate::schema::MjaiEvent) -> Option<u8> {
         | E::Daiminkan { actor, .. }
         | E::Kakan { actor, .. }
         | E::Ankan { actor, .. }
-        | E::Reach { actor }
+        | E::Reach { actor, .. }
         | E::ReachAccepted { actor }
         | E::Hora { actor, .. }
         | E::Kita { actor, .. } => Some(*actor),

--- a/src/schema/mjai/mod.rs
+++ b/src/schema/mjai/mod.rs
@@ -254,6 +254,39 @@ mod tests {
         }
         let out = serde_json::to_string(&ev).unwrap();
         assert_eq!(out, with_pai);
+
+        // Explicit null pai (a buggy bot might emit this) deserializes
+        // to None and re-serializes without the key, identical to the
+        // bridge form.
+        let null_pai = r#"{"type":"reach","actor":2,"pai":null}"#;
+        let ev: MjaiEvent = serde_json::from_str(null_pai).unwrap();
+        match &ev {
+            MjaiEvent::Reach { actor, pai } => {
+                assert_eq!(*actor, 2);
+                assert!(pai.is_none(), "explicit null must deserialize to None");
+            }
+            other => panic!("expected Reach, got {other:?}"),
+        }
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"type":"reach","actor":2}"#,
+            "null pai must serialize as omitted",
+        );
+
+        // Empty-string pai is currently accepted as Some("") since
+        // Tile is an unvalidated alias for String. Frontend treats
+        // empty as falsy and falls back to glyph-only rendering, so
+        // round-trip preserves it without crashing the schema layer.
+        let empty_pai = r#"{"type":"reach","actor":3,"pai":""}"#;
+        let ev: MjaiEvent = serde_json::from_str(empty_pai).unwrap();
+        match &ev {
+            MjaiEvent::Reach { actor, pai } => {
+                assert_eq!(*actor, 3);
+                assert_eq!(pai.as_deref(), Some(""));
+            }
+            other => panic!("expected Reach, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_string(&ev).unwrap(), empty_pai);
     }
 
     /// Backward compat: 4p log lines from before `num_players` was added must

--- a/src/schema/mjai/mod.rs
+++ b/src/schema/mjai/mod.rs
@@ -110,6 +110,14 @@ pub enum MjaiEvent {
 
     Reach {
         actor: Actor,
+        /// Non-spec extension: when set, names the tile the bot would
+        /// discard if the riichi declaration is accepted. Bots that
+        /// peek the post-reach dahai can populate this so the HUD can
+        /// surface the predicted riichi tile up-front (Majsoul fuses
+        /// declaring + discarding into one click). Bridge-emitted reach
+        /// events leave it None.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pai: Option<Tile>,
     },
     ReachAccepted {
         actor: Actor,
@@ -212,6 +220,40 @@ mod tests {
             let actual: Value = serde_json::from_str(&out).unwrap();
             assert_eq!(expected, actual, "3p round-trip mismatch: {line}");
         }
+    }
+
+    /// Reach is wire-compatible with bare `{"type":"reach","actor":N}` (the
+    /// shape every bridge emits) but accepts an optional `pai` field that
+    /// the Mortal bot wrapper populates with the speculated riichi-discard
+    /// tile so the HUD can show it up-front. Bridge-shaped reach must
+    /// round-trip without inventing a `pai` key.
+    #[test]
+    fn reach_pai_is_optional_and_round_trips() {
+        // Bridge form: no pai. Deserializes to None, serializes back without pai.
+        let plain = r#"{"type":"reach","actor":0}"#;
+        let ev: MjaiEvent = serde_json::from_str(plain).unwrap();
+        match &ev {
+            MjaiEvent::Reach { actor, pai } => {
+                assert_eq!(*actor, 0);
+                assert!(pai.is_none(), "bridge reach must have pai=None");
+            }
+            other => panic!("expected Reach, got {other:?}"),
+        }
+        let out = serde_json::to_string(&ev).unwrap();
+        assert_eq!(out, plain, "None pai must not be serialized");
+
+        // Bot form: pai populated by post-reach speculation.
+        let with_pai = r#"{"type":"reach","actor":1,"pai":"5p"}"#;
+        let ev: MjaiEvent = serde_json::from_str(with_pai).unwrap();
+        match &ev {
+            MjaiEvent::Reach { actor, pai } => {
+                assert_eq!(*actor, 1);
+                assert_eq!(pai.as_deref(), Some("5p"));
+            }
+            other => panic!("expected Reach, got {other:?}"),
+        }
+        let out = serde_json::to_string(&ev).unwrap();
+        assert_eq!(out, with_pai);
     }
 
     /// Backward compat: 4p log lines from before `num_players` was added must

--- a/tests/example_bot.rs
+++ b/tests/example_bot.rs
@@ -132,7 +132,7 @@ async fn declares_riichi_when_tenpai_with_two_waits() {
         .expect("react");
 
     match resp.action {
-        MjaiEvent::Reach { actor: 2 } => {}
+        MjaiEvent::Reach { actor: 2, .. } => {}
         other => panic!("expected reach by seat 2, got {other:?}"),
     }
     assert!(resp.meta.is_none(), "rule-based bot has no meta payload");
@@ -172,7 +172,7 @@ async fn discards_min_shanten_when_one_shanten() {
 
     match resp.action {
         MjaiEvent::Dahai { actor: 0, .. } => {}
-        MjaiEvent::Reach { actor: 0 } => {} // tenpai-shaped fallthrough is OK
+        MjaiEvent::Reach { actor: 0, .. } => {} // tenpai-shaped fallthrough is OK
         other => panic!("expected dahai/reach, got {other:?}"),
     }
 


### PR DESCRIPTION
## Summary

Closes #96.

Mjai splits the riichi declaration and the riichi-discard across two round-trips, but Majsoul fuses them into a single click — the HUD has to know the discard tile up front for the recommendation to be actionable. The Mortal-bot wrapper now runs a side-channel speculation (parallel PR: shinkuan/Akagi-MjaiBot-Mortal#1) and surfaces the predicted tile on the reach response itself; this PR is the Akagi-side schema/frontend wiring.

- **Schema**: `MjaiEvent::Reach` grows an optional `pai` field, gated with `serde(default, skip_serializing_if = Option::is_none)`. Bridge-shaped reach (`{"type":"reach","actor":N}`) round-trips identically; bot-shaped reach can carry `"pai":"X"`. New regression test `reach_pai_is_optional_and_round_trips` covers both shapes.
- **Frontend**: `BotActionTile` reach branch renders mahgen via `mjaiToMahgen([r.pai])` when the response carries `pai`, falling back to glyph + label when it doesn't (older bots, bridge events).
- **Plumbing**: Pattern matches and constructors across `src/bridge/{majsoul,tenhou}/mod.rs`, `src/game_state/tracker.rs`, `src/history/aggregator.rs`, `src/ipc/commands.rs`, and `tests/example_bot.rs` updated to handle the new field (constructors pass `pai: None`, patterns use `..`).

The change is wire-compatible in both directions: this Akagi version still works with Mortal-bot versions that don't speculate, and older Akagi versions silently ignore the extra `pai` from the new Mortal-bot.

## Test plan

- [x] `cargo test --lib` — 389 passed (includes new schema test)
- [x] `cargo check --tests` clean
- [x] `tsc -b` clean
- [ ] Manual: in Majsoul, declare riichi once and confirm the HUD shows the same tile Mortal actually plays (requires [Mortal-bot PR #1](https://github.com/shinkuan/Akagi-MjaiBot-Mortal/pull/1) deployed)
- [ ] Manual: with an older Mortal-bot (no pai), confirm reach still renders glyph + label (no regression)