### PR TITLE
feat(autoplay): CDP-based mouse-click autoplay for Mahjong Soul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-reflect",
+ "rand 0.9.4",
  "reqwest",
  "riichienv-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ futures-util = "0.3"
 dirs = "6"
 chromiumoxide = "0.9.1"
 ulid = { version = "1", features = ["serde"] }
+rand = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -298,7 +298,22 @@
     "ui_scale_hint": "Scales typography, spacing, and controls across the app. Saved locally.",
     "unsaved_title": "Unsaved changes",
     "unsaved_desc": "You have unsaved settings changes. Save them before leaving, discard them, or stay on this page.",
-    "save_and_leave": "Save & leave"
+    "save_and_leave": "Save & leave",
+    "autoplay": {
+      "title": "Autoplay",
+      "enable": "Enable autoplay",
+      "enable_help": "When enabled, Akagi clicks the bot's chosen action on the Mahjong Soul board automatically. Requires the Chromium capture mode and a running game tab.",
+      "platform_note": "Mahjong Soul only.",
+      "requires_chromium": "Autoplay requires the Chromium capture mode.",
+      "pre_click_delay_min": "Pre-click delay (min, ms)",
+      "pre_click_delay_max": "Pre-click delay (max, ms)",
+      "inter_click_delay": "Inter-click delay (ms)",
+      "hover_delay": "Hover delay before press (ms)",
+      "hover_delay_hint": "Mouse must hover for ≥100ms before mousedown for Mahjong Soul to register a tile click. Lower values risk dropped clicks.",
+      "click_hold": "Click hold (ms)",
+      "dealer_first_discard_extra_delay": "Dealer first-discard extra delay (ms)",
+      "dealer_first_discard_extra_delay_hint": "Mahjong Soul plays a hand-sort animation when the dealer is dealt all 14 tiles. Clicks during the animation are dropped. ~2000ms covers most devices."
+    }
   },
   "setup": {
     "title": "Akagi Setup",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -298,7 +298,22 @@
     "ui_scale_hint": "アプリ全体のフォントサイズ・余白・コントロールをスケールします。ローカルにのみ保存されます。",
     "unsaved_title": "未保存の変更",
     "unsaved_desc": "未保存の設定変更があります。保存して離れる、変更を破棄する、またはこのページに留まるか選択してください。",
-    "save_and_leave": "保存して離れる"
+    "save_and_leave": "保存して離れる",
+    "autoplay": {
+      "title": "自動操作",
+      "enable": "自動操作を有効化",
+      "enable_help": "有効にすると、ボットが選んだ操作をAkagiが雀魂のクライアント上で自動的にクリックします。Chromiumキャプチャモードと開いているゲームタブが必要です。",
+      "platform_note": "雀魂のみ対応。",
+      "requires_chromium": "自動操作にはChromiumキャプチャモードが必要です。",
+      "pre_click_delay_min": "クリック前の待機 (最小, ms)",
+      "pre_click_delay_max": "クリック前の待機 (最大, ms)",
+      "inter_click_delay": "クリック間の待機 (ms)",
+      "hover_delay": "押下前のホバー時間 (ms)",
+      "hover_delay_hint": "雀魂が牌のクリックを認識するには、mousedown前に100ms以上のホバーが必要です。短すぎるとクリックが無視されます。",
+      "click_hold": "ボタン押下保持 (ms)",
+      "dealer_first_discard_extra_delay": "親の初打追加待機 (ms)",
+      "dealer_first_discard_extra_delay_hint": "雀魂は親に14枚配られた後に手牌整列アニメーションを再生し、その間のクリックは無視されます。2000ms前後でほぼ吸収できます。"
+    }
   },
   "setup": {
     "title": "Akagi セットアップ",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -298,7 +298,22 @@
     "ui_scale_hint": "缩放整个应用的字号、间距与控件，仅本机保存。",
     "unsaved_title": "尚未保存的更改",
     "unsaved_desc": "你有尚未保存的设置更改。请选择保存后离开、放弃更改，或留在此页继续编辑。",
-    "save_and_leave": "保存并离开"
+    "save_and_leave": "保存并离开",
+    "autoplay": {
+      "title": "自动打牌",
+      "enable": "启用自动打牌",
+      "enable_help": "启用后 Akagi 会自动在雀魂界面上点击 bot 选定的动作。需要 Chromium 抓包模式以及打开的游戏标签页。",
+      "platform_note": "目前仅支持雀魂。",
+      "requires_chromium": "自动打牌需要使用 Chromium 抓包模式。",
+      "pre_click_delay_min": "点击前延迟 (最小, ms)",
+      "pre_click_delay_max": "点击前延迟 (最大, ms)",
+      "inter_click_delay": "连续点击间延迟 (ms)",
+      "hover_delay": "按下前的悬停时间 (ms)",
+      "hover_delay_hint": "雀魂判定牌面点击需要在 mousedown 前悬停 100ms 以上。低于此值点击可能被吃掉。",
+      "click_hold": "按住时间 (ms)",
+      "dealer_first_discard_extra_delay": "庄家首打额外延迟 (ms)",
+      "dealer_first_discard_extra_delay_hint": "庄家被发 14 张牌时雀魂会播放整理手牌动画，期间的点击会被吃掉。约 2000ms 可覆盖大多数设备。"
+    }
   },
   "setup": {
     "title": "Akagi 设置",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -298,7 +298,22 @@
     "ui_scale_hint": "縮放整個應用的字級、間距與控制元件，僅本機儲存。",
     "unsaved_title": "尚未儲存的變更",
     "unsaved_desc": "你有尚未儲存的設定變更。請選擇儲存後離開、放棄變更，或留在此頁繼續編輯。",
-    "save_and_leave": "儲存並離開"
+    "save_and_leave": "儲存並離開",
+    "autoplay": {
+      "title": "自動打牌",
+      "enable": "啟用自動打牌",
+      "enable_help": "啟用後 Akagi 會自動在雀魂介面上點擊 bot 選定的動作。需要 Chromium 擷取模式以及開啟中的遊戲分頁。",
+      "platform_note": "目前僅支援雀魂。",
+      "requires_chromium": "自動打牌需要使用 Chromium 擷取模式。",
+      "pre_click_delay_min": "點擊前延遲 (最小, ms)",
+      "pre_click_delay_max": "點擊前延遲 (最大, ms)",
+      "inter_click_delay": "連續點擊間延遲 (ms)",
+      "hover_delay": "按下前的滑鼠停留時間 (ms)",
+      "hover_delay_hint": "雀魂判定牌面點擊需要在 mousedown 前停留 100ms 以上。低於此值點擊可能被吃掉。",
+      "click_hold": "按住時間 (ms)",
+      "dealer_first_discard_extra_delay": "莊家初打額外延遲 (ms)",
+      "dealer_first_discard_extra_delay_hint": "莊家被發 14 張牌時雀魂會播放整理手牌動畫，期間的點擊會被吃掉。約 2000ms 可覆蓋一般裝置。"
+    }
   },
   "setup": {
     "title": "Akagi 設定",

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -230,6 +230,8 @@ export function Settings() {
         </CardContent>
       </Card>
 
+      <AutoplayCard draft={draft} setDraft={setDraft} />
+
       <Dialog
         open={blocker.state === 'blocked'}
         onOpenChange={(open) => {
@@ -395,6 +397,144 @@ function PlatformCard({
           </Select>
         </Field>
         <p className="text-xs text-muted-foreground">{t(info.descriptionKey)}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function AutoplayCard({
+  draft,
+  setDraft,
+}: {
+  draft: AppConfig
+  setDraft: (c: AppConfig) => void
+}) {
+  const { t } = useTranslation()
+  const ap = draft.autoplay ?? {
+    enabled: false,
+    majsoul: {
+      pre_click_delay_min_ms: 1000,
+      pre_click_delay_max_ms: 3000,
+      inter_click_delay_ms: 300,
+      hover_delay_ms: 150,
+      click_hold_ms: 50,
+      dealer_first_discard_extra_delay_ms: 2000,
+    },
+  }
+  const captureIsChromium = draft.capture?.mode === 'chromium'
+  const setApField = (patch: Partial<typeof ap>) =>
+    setDraft({ ...draft, autoplay: { ...ap, ...patch } })
+  const setMajsoulField = (patch: Partial<typeof ap.majsoul>) =>
+    setDraft({
+      ...draft,
+      autoplay: { ...ap, majsoul: { ...ap.majsoul, ...patch } },
+    })
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('settings.autoplay.title')}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <Toggle
+          label={t('settings.autoplay.enable')}
+          value={ap.enabled}
+          onChange={(v) => setApField({ enabled: v })}
+        />
+        <p className="text-xs text-muted-foreground">
+          {t('settings.autoplay.enable_help')}
+        </p>
+        {ap.enabled && !captureIsChromium && (
+          <p className="text-xs text-amber-500">
+            {t('settings.autoplay.requires_chromium')}
+          </p>
+        )}
+        <Field label={t('settings.autoplay.pre_click_delay_min')}>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.pre_click_delay_min_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                pre_click_delay_min_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <Field label={t('settings.autoplay.pre_click_delay_max')}>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.pre_click_delay_max_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                pre_click_delay_max_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <Field label={t('settings.autoplay.inter_click_delay')}>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.inter_click_delay_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                inter_click_delay_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <Field
+          label={t('settings.autoplay.hover_delay')}
+          hint={t('settings.autoplay.hover_delay_hint')}
+        >
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.hover_delay_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                hover_delay_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <Field label={t('settings.autoplay.click_hold')}>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.click_hold_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                click_hold_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <Field
+          label={t('settings.autoplay.dealer_first_discard_extra_delay')}
+          hint={t('settings.autoplay.dealer_first_discard_extra_delay_hint')}
+        >
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={ap.majsoul.dealer_first_discard_extra_delay_ms}
+            onChange={(e) =>
+              setMajsoulField({
+                dealer_first_discard_extra_delay_ms: Number(e.target.value || 0),
+              })
+            }
+          />
+        </Field>
+        <p className="text-xs text-muted-foreground">
+          {t('settings.autoplay.platform_note')}
+        </p>
       </CardContent>
     </Card>
   )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -97,6 +97,20 @@ export type DetectedBrowser = {
 /// PascalCase JSON: `"Majsoul"`, `"Tenhou"`).
 export type PlatformKind = 'Majsoul' | 'Tenhou'
 
+export type MajsoulAutoplayConfig = {
+  pre_click_delay_min_ms: number
+  pre_click_delay_max_ms: number
+  inter_click_delay_ms: number
+  hover_delay_ms: number
+  click_hold_ms: number
+  dealer_first_discard_extra_delay_ms: number
+}
+
+export type AutoplayConfig = {
+  enabled: boolean
+  majsoul: MajsoulAutoplayConfig
+}
+
 export type AppConfig = {
   general: { language: string; first_run_completed: boolean }
   logging: { dir: string; level: string; all_level: string }
@@ -104,6 +118,7 @@ export type AppConfig = {
   proxy: { enabled: boolean; addr: string; ca_dir: string }
   bot: { enabled: boolean; active_4p: string; active_3p: string; auto_sync: boolean; dir: string }
   capture: CaptureConfig
+  autoplay: AutoplayConfig
 }
 
 export type FieldKind = 'string' | 'bool' | 'int' | 'float' | 'enum'

--- a/src/autoplay/cdp_input.rs
+++ b/src/autoplay/cdp_input.rs
@@ -1,0 +1,96 @@
+//! Thin wrappers around chromiumoxide for the autoplay manager.
+//!
+//! Centralised so the click + canvas-rect query logic can be unit-mocked
+//! and the manager keeps a single dependency on chromiumoxide types.
+
+use crate::autoplay::context::CanvasRect;
+use anyhow::{anyhow, Context, Result};
+use chromiumoxide::cdp::browser_protocol::input::{
+    DispatchMouseEventParams, DispatchMouseEventType, MouseButton,
+};
+use chromiumoxide::layout::Point;
+use chromiumoxide::page::Page;
+use std::time::Duration;
+
+/// Dispatch a single mouse click at `(x, y)` (CSS pixels) as four CDP
+/// events, with mandatory hover before press:
+///
+/// 1. `mouseMoved` to `(x, y)`
+/// 2. sleep `hover_delay_ms` (≥100ms — Laya's input system samples hover
+///    state before mousedown registers a hit on a tile sprite)
+/// 3. `mousePressed`
+/// 4. sleep `click_hold_ms`
+/// 5. `mouseReleased`
+///
+/// `chromiumoxide::Page::click` collapses 3+5 into back-to-back frames
+/// without the hover delay, which Majsoul drops on the floor for hand
+/// tiles. Hand-rolling the sequence is required.
+pub async fn dispatch_click(
+    page: &Page,
+    x: f64,
+    y: f64,
+    hover_delay_ms: u32,
+    click_hold_ms: u32,
+) -> Result<()> {
+    let pt = Point::new(x, y);
+    page.move_mouse(pt).await.context("CDP move_mouse")?;
+    if hover_delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(hover_delay_ms as u64)).await;
+    }
+
+    let press = DispatchMouseEventParams::builder()
+        .r#type(DispatchMouseEventType::MousePressed)
+        .x(pt.x)
+        .y(pt.y)
+        .button(MouseButton::Left)
+        .click_count(1)
+        .build()
+        .map_err(|e| anyhow!("build mousePressed: {e}"))?;
+    page.execute(press).await.context("CDP mousePressed")?;
+
+    if click_hold_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(click_hold_ms as u64)).await;
+    }
+
+    let release = DispatchMouseEventParams::builder()
+        .r#type(DispatchMouseEventType::MouseReleased)
+        .x(pt.x)
+        .y(pt.y)
+        .button(MouseButton::Left)
+        .click_count(1)
+        .build()
+        .map_err(|e| anyhow!("build mouseReleased: {e}"))?;
+    page.execute(release).await.context("CDP mouseReleased")?;
+
+    Ok(())
+}
+
+/// Read the game canvas's `getBoundingClientRect()` via `Runtime.evaluate`.
+///
+/// Majsoul renders into the first `<canvas>` element on the page; Tenhou
+/// uses the same selector when running in browser mode. We grab the
+/// first canvas indiscriminately — multi-canvas pages aren't a thing on
+/// these platforms.
+pub async fn evaluate_canvas_rect(page: &Page) -> Result<CanvasRect> {
+    // IIFE so `Runtime.evaluate` returns a single value, not a Promise.
+    // `is_likely_js_function` in chromiumoxide picks the right CDP call
+    // based on whether the expression looks like a function — we wrap
+    // in `(()=>{...})()` to ensure plain-expression evaluation.
+    let expr = "(()=>{const c=document.getElementsByTagName('canvas')[0];\
+                if(!c)return null;\
+                const r=c.getBoundingClientRect();\
+                return {x:r.x,y:r.y,width:r.width,height:r.height};})()";
+    let result = page
+        .evaluate(expr)
+        .await
+        .context("CDP evaluate canvas rect")?;
+    let value = result
+        .value()
+        .ok_or_else(|| anyhow!("canvas rect: no value returned"))?;
+    if value.is_null() {
+        return Err(anyhow!("canvas rect: page has no <canvas> element"));
+    }
+    let rect: CanvasRect = serde_json::from_value(value.clone())
+        .context("canvas rect: deserialise from page value")?;
+    Ok(rect)
+}

--- a/src/autoplay/context.rs
+++ b/src/autoplay/context.rs
@@ -1,0 +1,96 @@
+//! Shared state between the chromium capture backend and the autoplay
+//! manager.
+//!
+//! - `page`: the [`chromiumoxide::page::Page`] handle for the tab where
+//!   Majsoul (or another supported platform) is loaded. Written by
+//!   `src/capture/chromium/cdp.rs` when it observes a WebSocket whose URL
+//!   host matches a known platform; cleared when that WS closes. Read by
+//!   `AutoplayManager` whenever it needs to dispatch input.
+//! - `canvas_rect`: cached `getBoundingClientRect()` of the game canvas,
+//!   used to translate 16:9-normalised coordinates into CSS pixels.
+//!   Filled lazily by the autoplay manager (one `Runtime.evaluate` per
+//!   refresh) and invalidated on round transitions.
+//!
+//! Both fields are populated only when the chromium capture backend is
+//! active. The MITM backend leaves the context untouched, so reads return
+//! `None` and the manager skips the click.
+
+use chromiumoxide::page::Page;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Default)]
+pub struct AutoplayContext {
+    pub page: Arc<RwLock<Option<Page>>>,
+    pub canvas_rect: Arc<RwLock<Option<CanvasRect>>>,
+}
+
+impl AutoplayContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// CSS-pixel bounding rect for the game canvas, as reported by
+/// `Element.getBoundingClientRect()`. `(x, y)` is the top-left of the
+/// canvas relative to the viewport.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CanvasRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl CanvasRect {
+    /// Translate a 16:9 normalised point (the coordinate system used by
+    /// `LOCATION` tables ported from the Python reference) to CSS pixels.
+    pub fn pixel(&self, x_norm: f64, y_norm: f64) -> (f64, f64) {
+        (
+            self.x + (x_norm / 16.0) * self.width,
+            self.y + (y_norm / 9.0) * self.height,
+        )
+    }
+
+    /// Sanity check for a normalised point — clamps off-canvas requests
+    /// before we hand them to CDP.
+    pub fn contains(&self, x: f64, y: f64) -> bool {
+        x >= self.x
+            && x <= self.x + self.width
+            && y >= self.y
+            && y <= self.y + self.height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pixel_translation_centre() {
+        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        assert_eq!(rect.pixel(8.0, 4.5), (800.0, 450.0));
+    }
+
+    #[test]
+    fn pixel_translation_with_offset() {
+        let rect = CanvasRect { x: 100.0, y: 50.0, width: 1280.0, height: 720.0 };
+        let (px, py) = rect.pixel(8.0, 4.5);
+        assert!((px - (100.0 + 640.0)).abs() < 1e-9);
+        assert!((py - (50.0 + 360.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn contains_inside() {
+        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        assert!(rect.contains(800.0, 450.0));
+    }
+
+    #[test]
+    fn contains_outside() {
+        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        assert!(!rect.contains(-1.0, 0.0));
+        assert!(!rect.contains(0.0, 1000.0));
+    }
+}

--- a/src/autoplay/majsoul/coords.rs
+++ b/src/autoplay/majsoul/coords.rs
@@ -1,0 +1,340 @@
+//! Hand-calibrated 16:9-normalised coordinates for Majsoul UI elements.
+//!
+//! Ported from `reference/majsoul/autoplay_majsoul.py:13-65`. The Python
+//! file has years of production validation — DO NOT change these values
+//! without screen-tested re-calibration.
+//!
+//! Coordinate system: the Majsoul canvas is laid out in a 16x9 logical
+//! grid regardless of actual pixel resolution (letterboxed). To convert
+//! a `(x_norm, y_norm)` here into CSS pixels, see
+//! `crate::autoplay::context::CanvasRect::pixel`.
+
+use riichienv_core::action::ActionType;
+
+/// 14 hand-tile slots. Index 0..=12 is the closed hand; index 13 is the
+/// drawn tile when one exists (offset by `TSUMO_SPACE`).
+pub const TILES: [(f64, f64); 14] = [
+    (2.231_25, 8.362_5),
+    (3.021_875, 8.362_5),
+    (3.812_5, 8.362_5),
+    (4.603_125, 8.362_5),
+    (5.393_75, 8.362_5),
+    (6.184_375, 8.362_5),
+    (6.975, 8.362_5),
+    (7.765_625, 8.362_5),
+    (8.556_25, 8.362_5),
+    (9.346_875, 8.362_5),
+    (10.137_5, 8.362_5),
+    (10.928_125, 8.362_5),
+    (11.718_75, 8.362_5),
+    (12.509_375, 8.362_5),
+];
+
+/// Horizontal offset between the closed hand's last tile and the
+/// just-drawn tsumohai.
+pub const TSUMO_SPACE: f64 = 0.246_875;
+
+/// Action button positions (3x3 grid). The first two rows (indices 0..=5)
+/// are the only ones in use; rows 3 (indices 6..=8) are dead slots that
+/// Majsoul has reserved but never showed in production.
+pub const ACTIONS: [(f64, f64); 9] = [
+    (10.875, 7.0),
+    (8.637_5, 7.0),
+    (6.4, 7.0),
+    (10.875, 5.9),
+    (8.637_5, 5.9),
+    (6.4, 5.9),
+    (10.875, 4.8),
+    (8.637_5, 4.8),
+    (6.4, 4.8),
+];
+
+/// Candidate-selection row for chi/pon disambiguation. Index formula
+/// from the Python reference: `idx = int((-(len/2) + i + 0.5)*2 + 5)`.
+pub const CANDIDATES: [(f64, f64); 11] = [
+    (3.662_5, 6.3),
+    (4.496_25, 6.3),
+    (5.33, 6.3),
+    (6.163_75, 6.3),
+    (6.997_5, 6.3),
+    (7.831_25, 6.3),
+    (8.665, 6.3),
+    (9.498_75, 6.3),
+    (10.332_5, 6.3),
+    (11.166_25, 6.3),
+    (12.0, 6.3),
+];
+
+/// Candidate row for kan disambiguation (only 7 slots, formula offset
+/// is `+3` instead of `+5`).
+pub const CANDIDATES_KAN: [(f64, f64); 7] = [
+    (4.325, 6.3),
+    (5.491_5, 6.3),
+    (6.658_3, 6.3),
+    (7.825, 6.3),
+    (8.991_7, 6.3),
+    (10.158_3, 6.3),
+    (11.325, 6.3),
+];
+
+/// Action priority for the 3x3 button grid. Lower priority renders
+/// first (rightmost / bottom-rightmost). Source:
+/// `autoplay_majsoul.py:67-81`. Indices align with `MajsoulOpType`.
+pub const ACTION_PRIORITY: [u32; 12] = [
+    0, // None       — pass / cancel button (always rightmost)
+    99, // Discard   — no button
+    4, // Chi
+    3, // Pon
+    3, // Ankan
+    2, // Daiminkan
+    3, // Kakan
+    2, // Reach
+    1, // Zimo (tsumo agari)
+    1, // Ron
+    5, // Ryukyoku
+    4, // Nukidora
+];
+
+/// Numeric type codes used by the priority table above. These match the
+/// values Majsoul's `OptionalOperation.type` field uses on the wire and
+/// the legacy `ACTION2TYPE` table from the Python reference. Kept as a
+/// `repr(u32)` so the table indexing is direct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum MajsoulOpType {
+    None = 0,
+    Discard = 1,
+    Chi = 2,
+    Pon = 3,
+    Ankan = 4,
+    Daiminkan = 5,
+    Kakan = 6,
+    Reach = 7,
+    Zimo = 8,
+    Ron = 9,
+    Ryukyoku = 10,
+    Nukidora = 11,
+}
+
+impl MajsoulOpType {
+    /// Translate a riichi-engine `ActionType` into the Majsoul on-screen
+    /// op-type. Returns `None` if the action type doesn't have a button
+    /// representation (e.g. `Discard` is freeform tile click).
+    ///
+    /// Tsumo vs Ron: in mjai both are `Hora`, but Majsoul renders them
+    /// in different button slots (Zimo on self-discard turn, Ron on
+    /// opponent-discard turn). `riichienv_core::ActionType` distinguishes
+    /// these via `Tsumo` and `Ron` so we map directly.
+    pub fn from_engine(at: ActionType) -> Option<Self> {
+        Some(match at {
+            ActionType::Discard => Self::Discard,
+            ActionType::Chi => Self::Chi,
+            ActionType::Pon => Self::Pon,
+            ActionType::Daiminkan => Self::Daiminkan,
+            ActionType::Ankan => Self::Ankan,
+            ActionType::Kakan => Self::Kakan,
+            ActionType::Riichi => Self::Reach,
+            ActionType::Tsumo => Self::Zimo,
+            ActionType::Ron => Self::Ron,
+            ActionType::KyushuKyuhai => Self::Ryukyoku,
+            ActionType::Kita => Self::Nukidora,
+            ActionType::Pass => Self::None,
+        })
+    }
+}
+
+/// Coordinate of a hand tile, accounting for the optional tsumohai gap.
+///
+/// `idx` is the position in the sorted closed hand 0..=13. `tehai_count`
+/// is the number of closed (non-tsumohai) tiles. When `idx == 13`, the
+/// returned point is offset by `TSUMO_SPACE` to land on the just-drawn
+/// tile.
+pub fn get_pai_coord(idx: usize, tehai_count: usize) -> (f64, f64) {
+    debug_assert!(idx < TILES.len(), "tile index {idx} out of range");
+    if idx == 13 {
+        let base = TILES[tehai_count.min(TILES.len() - 1)];
+        (base.0 + TSUMO_SPACE, base.1)
+    } else {
+        TILES[idx]
+    }
+}
+
+/// Position of an action button, given the deduplicated set of Majsoul
+/// op-types currently legal. The set is sorted by [`ACTION_PRIORITY`]
+/// (ascending) and the index of `target` in that sorted list = the
+/// button slot in [`ACTIONS`].
+///
+/// Returns `None` if `target` isn't in `ops` or the button position
+/// would exceed the rendered grid.
+pub fn action_button_pos(ops: &[MajsoulOpType], target: MajsoulOpType) -> Option<(f64, f64)> {
+    let mut sorted: Vec<MajsoulOpType> = ops.to_vec();
+    sorted.sort_by_key(|op| ACTION_PRIORITY[*op as usize]);
+    let idx = sorted.iter().position(|&op| op == target)?;
+    ACTIONS.get(idx).copied()
+}
+
+/// Candidate-selection slot for chi/pon. Reference formula:
+/// `int((-(len/2) + idx + 0.5)*2 + 5)` → index into [`CANDIDATES`].
+///
+/// Returns `None` if the computed slot is out of [`CANDIDATES`] bounds
+/// (defensive — should never happen with valid inputs).
+pub fn candidate_pos(idx: usize, len: usize) -> Option<(f64, f64)> {
+    if len == 0 {
+        return None;
+    }
+    // Formula taken verbatim from Python reference, line 237:
+    //   candidate_idx = int((-(len/2) + idx + 0.5) * 2 + 5)
+    // The cast in Python truncates toward zero. Replicate with a
+    // float-then-floor pattern that matches positive arguments.
+    let raw = (-((len as f64) / 2.0) + idx as f64 + 0.5) * 2.0 + 5.0;
+    let slot = raw as isize;
+    if slot < 0 || (slot as usize) >= CANDIDATES.len() {
+        return None;
+    }
+    Some(CANDIDATES[slot as usize])
+}
+
+/// Kan-candidate slot. Same formula but offset is `+3` (kan row only
+/// has 7 slots).
+pub fn kan_candidate_pos(idx: usize, len: usize) -> Option<(f64, f64)> {
+    if len == 0 {
+        return None;
+    }
+    let raw = (-((len as f64) / 2.0) + idx as f64 + 0.5) * 2.0 + 3.0;
+    let slot = raw as isize;
+    if slot < 0 || (slot as usize) >= CANDIDATES_KAN.len() {
+        return None;
+    }
+    Some(CANDIDATES_KAN[slot as usize])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pai_coord_closed_hand() {
+        // First tile slot, hand of any size.
+        assert_eq!(get_pai_coord(0, 13), TILES[0]);
+        // Last closed-hand position.
+        assert_eq!(get_pai_coord(12, 13), TILES[12]);
+    }
+
+    #[test]
+    fn pai_coord_tsumohai_offset() {
+        // For a 13-tile closed hand, tsumohai sits past slot 13 by TSUMO_SPACE.
+        let (x, y) = get_pai_coord(13, 13);
+        assert!((x - (TILES[13].0 + TSUMO_SPACE)).abs() < 1e-9);
+        assert!((y - TILES[13].1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pai_coord_tsumohai_after_chi() {
+        // After chi, hand is 10 tiles + tsumohai. The tsumohai position
+        // is past slot 10 by TSUMO_SPACE.
+        let (x, _) = get_pai_coord(13, 10);
+        assert!((x - (TILES[10].0 + TSUMO_SPACE)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn action_button_pos_rightmost_slot_zero() {
+        // Sole "Pass" → goes in slot 0 (rightmost top row).
+        let pos = action_button_pos(&[MajsoulOpType::None], MajsoulOpType::None).unwrap();
+        assert_eq!(pos, ACTIONS[0]);
+    }
+
+    #[test]
+    fn action_button_pos_priority_sort() {
+        // Pass + Chi: priority 0 = Pass first (slot 0), priority 4 = Chi (slot 1).
+        let ops = [MajsoulOpType::None, MajsoulOpType::Chi];
+        let pass_pos = action_button_pos(&ops, MajsoulOpType::None).unwrap();
+        let chi_pos = action_button_pos(&ops, MajsoulOpType::Chi).unwrap();
+        assert_eq!(pass_pos, ACTIONS[0]);
+        assert_eq!(chi_pos, ACTIONS[1]);
+    }
+
+    #[test]
+    fn action_button_pos_three_buttons() {
+        // Pass(0) + Pon(3) + Chi(4): sorted Pass, Pon, Chi → slots 0,1,2.
+        let ops = [MajsoulOpType::None, MajsoulOpType::Pon, MajsoulOpType::Chi];
+        assert_eq!(
+            action_button_pos(&ops, MajsoulOpType::None).unwrap(),
+            ACTIONS[0]
+        );
+        assert_eq!(
+            action_button_pos(&ops, MajsoulOpType::Pon).unwrap(),
+            ACTIONS[1]
+        );
+        assert_eq!(
+            action_button_pos(&ops, MajsoulOpType::Chi).unwrap(),
+            ACTIONS[2]
+        );
+    }
+
+    #[test]
+    fn action_button_pos_zimo_and_pass() {
+        // Tsumo agari turn typically: Pass(0) + Zimo(1). Zimo gets slot 1.
+        let ops = [MajsoulOpType::None, MajsoulOpType::Zimo];
+        assert_eq!(
+            action_button_pos(&ops, MajsoulOpType::Zimo).unwrap(),
+            ACTIONS[1]
+        );
+    }
+
+    #[test]
+    fn action_button_pos_reach_with_pass() {
+        // Reach(2) + Pass(0): Pass slot 0, Reach slot 1.
+        let ops = [MajsoulOpType::None, MajsoulOpType::Reach];
+        assert_eq!(
+            action_button_pos(&ops, MajsoulOpType::Reach).unwrap(),
+            ACTIONS[1]
+        );
+    }
+
+    #[test]
+    fn action_button_pos_missing() {
+        // Asking for an op not in the legal set → None.
+        assert!(action_button_pos(&[MajsoulOpType::None], MajsoulOpType::Chi).is_none());
+    }
+
+    #[test]
+    fn candidate_pos_one_candidate() {
+        // len=1 idx=0 → raw = (-0.5 + 0.5)*2 + 5 = 5 → middle slot.
+        assert_eq!(candidate_pos(0, 1).unwrap(), CANDIDATES[5]);
+    }
+
+    #[test]
+    fn candidate_pos_two_candidates() {
+        // len=2 idx=0 → (-1 + 0.5)*2 + 5 = 4
+        // len=2 idx=1 → (-1 + 1.5)*2 + 5 = 6
+        assert_eq!(candidate_pos(0, 2).unwrap(), CANDIDATES[4]);
+        assert_eq!(candidate_pos(1, 2).unwrap(), CANDIDATES[6]);
+    }
+
+    #[test]
+    fn candidate_pos_three_candidates() {
+        // len=3 idx=0 → (-1.5 + 0.5)*2 + 5 = 3
+        // len=3 idx=1 → (-1.5 + 1.5)*2 + 5 = 5
+        // len=3 idx=2 → (-1.5 + 2.5)*2 + 5 = 7
+        assert_eq!(candidate_pos(0, 3).unwrap(), CANDIDATES[3]);
+        assert_eq!(candidate_pos(1, 3).unwrap(), CANDIDATES[5]);
+        assert_eq!(candidate_pos(2, 3).unwrap(), CANDIDATES[7]);
+    }
+
+    #[test]
+    fn kan_candidate_pos_two() {
+        // len=2 idx=0 → (-1 + 0.5)*2 + 3 = 2
+        // len=2 idx=1 → (-1 + 1.5)*2 + 3 = 4
+        assert_eq!(kan_candidate_pos(0, 2).unwrap(), CANDIDATES_KAN[2]);
+        assert_eq!(kan_candidate_pos(1, 2).unwrap(), CANDIDATES_KAN[4]);
+    }
+
+    #[test]
+    fn op_type_from_engine_action_types() {
+        assert_eq!(MajsoulOpType::from_engine(ActionType::Riichi), Some(MajsoulOpType::Reach));
+        assert_eq!(MajsoulOpType::from_engine(ActionType::Tsumo), Some(MajsoulOpType::Zimo));
+        assert_eq!(MajsoulOpType::from_engine(ActionType::Ron), Some(MajsoulOpType::Ron));
+        assert_eq!(MajsoulOpType::from_engine(ActionType::KyushuKyuhai), Some(MajsoulOpType::Ryukyoku));
+        assert_eq!(MajsoulOpType::from_engine(ActionType::Pass), Some(MajsoulOpType::None));
+    }
+}

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -1,0 +1,915 @@
+//! Majsoul implementation of [`PlatformAutoplay`].
+//!
+//! Coordinate tables in `coords.rs` are the only Majsoul-specific data;
+//! the dispatch logic here translates a bot decision into a [`Step`]
+//! sequence using:
+//!
+//! - The current `legal_actions` from the riichi engine (which buttons
+//!   are visible, plus chi/pon/kan candidate enumeration).
+//! - The current hand from `GameStateSnapshot` (sort-aware tile lookup).
+//! - The reference Akagi flow at
+//!   `reference/majsoul/autoplay_majsoul.py:140-281`.
+
+pub mod coords;
+
+use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};
+use crate::bridge::majsoul::tile::compare_pai;
+use crate::schema::MjaiEvent;
+use coords::{
+    action_button_pos, candidate_pos, get_pai_coord, kan_candidate_pos, MajsoulOpType,
+    ACTION_PRIORITY, TILES,
+};
+#[cfg(test)]
+use coords::TSUMO_SPACE;
+use rand::Rng;
+use riichienv_core::action::{Action, ActionType};
+use riichienv_core::parser::tid_to_mjai;
+
+#[derive(Default)]
+pub struct MajsoulAutoplay;
+
+impl MajsoulAutoplay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PlatformAutoplay for MajsoulAutoplay {
+    fn plan(&self, ctx: &ActionContext) -> PlanResult {
+        let mut result = PlanResult::default();
+
+        match ctx.action {
+            // ----- Dahai (打牌) ---------------------------------------------
+            MjaiEvent::Dahai { actor, pai, .. } if *actor == ctx.our_seat => {
+                // While in riichi, Majsoul auto-discards. Suppress unless
+                // this dahai is the riichi-declaring tile (Path B follow-up).
+                if ctx.self_riichi_accepted && ctx.reach_state != ReachState::AwaitingDahai {
+                    return result;
+                }
+                push_random_pre_delay(&mut result.steps, ctx);
+                if is_dealer_first_discard(ctx) && ctx.cfg.dealer_first_discard_extra_delay_ms > 0 {
+                    // Majsoul plays a hand-sort animation when the dealer
+                    // gets dealt all 14 tiles at once; clicks issued during
+                    // it are dropped. Pad the wait.
+                    result.steps.push(Step::Sleep {
+                        duration_ms: ctx.cfg.dealer_first_discard_extra_delay_ms,
+                    });
+                }
+                if let Some(click) = plan_dahai_click(pai, ctx) {
+                    result.steps.push(click);
+                }
+            }
+
+            // ----- Reach (立直) — two paths -------------------------------
+            MjaiEvent::Reach { actor, pai } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                if let Some(button) = action_button_for(MajsoulOpType::Reach, ctx) {
+                    result.steps.push(Step::Click {
+                        x_norm: button.0,
+                        y_norm: button.1,
+                    });
+                } else {
+                    // Reach not in legal_actions — bridge desync; bail.
+                    return PlanResult::default();
+                }
+
+                match pai {
+                    // Path A: bot pre-filled the riichi tile.
+                    Some(tile) => {
+                        result.steps.push(Step::Sleep {
+                            duration_ms: ctx.cfg.inter_click_delay_ms,
+                        });
+                        if let Some(click) = plan_dahai_click(tile, ctx) {
+                            result.steps.push(click);
+                        }
+                    }
+                    // Path B: bot needs a synthetic Reach event before it
+                    // emits the riichi-declaring dahai. Manager will inject.
+                    None => {
+                        result.inject_reach_for_followup = true;
+                        result.awaiting_riichi_dahai = true;
+                    }
+                }
+            }
+
+            // ----- Chi / Pon / Daiminkan / Ankan / Kakan -------------------
+            // (action button + optional candidate disambiguation)
+            MjaiEvent::Chi { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                plan_meld(MajsoulOpType::Chi, ActionType::Chi, &mut result, ctx);
+            }
+            MjaiEvent::Pon { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                plan_meld(MajsoulOpType::Pon, ActionType::Pon, &mut result, ctx);
+            }
+            MjaiEvent::Daiminkan { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                plan_meld(MajsoulOpType::Daiminkan, ActionType::Daiminkan, &mut result, ctx);
+            }
+            MjaiEvent::Ankan { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                plan_kan(MajsoulOpType::Ankan, ActionType::Ankan, &mut result, ctx);
+            }
+            MjaiEvent::Kakan { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                plan_kan(MajsoulOpType::Kakan, ActionType::Kakan, &mut result, ctx);
+            }
+
+            // ----- Hora — zimo button on own draw, ron on opponent ---------
+            MjaiEvent::Hora { actor, .. } if *actor == ctx.our_seat => {
+                let op = if hora_is_tsumo(ctx) {
+                    MajsoulOpType::Zimo
+                } else {
+                    MajsoulOpType::Ron
+                };
+                push_random_pre_delay(&mut result.steps, ctx);
+                if let Some(button) = action_button_for(op, ctx) {
+                    result.steps.push(Step::Click {
+                        x_norm: button.0,
+                        y_norm: button.1,
+                    });
+                }
+            }
+
+            // ----- Ryukyoku (九種九牌) -------------------------------------
+            MjaiEvent::Ryukyoku { .. } => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                if let Some(button) = action_button_for(MajsoulOpType::Ryukyoku, ctx) {
+                    result.steps.push(Step::Click {
+                        x_norm: button.0,
+                        y_norm: button.1,
+                    });
+                }
+            }
+
+            // ----- Kita (3p 北抜き) ----------------------------------------
+            MjaiEvent::Kita { actor, .. } if *actor == ctx.our_seat => {
+                push_random_pre_delay(&mut result.steps, ctx);
+                if let Some(button) = action_button_for(MajsoulOpType::Nukidora, ctx) {
+                    result.steps.push(Step::Click {
+                        x_norm: button.0,
+                        y_norm: button.1,
+                    });
+                }
+            }
+
+            // ----- None — pass / cancel button -----------------------------
+            //
+            // The bot emits `None` on every mjai event it has nothing to say
+            // about — including pure echoes of other players' tsumo/dahai
+            // notifies, where Majsoul is showing no buttons at all. Without
+            // a gate we'd loop-click the lobby/preview UI's rightmost button
+            // on every other-player turn.
+            //
+            // riichienv only adds `ActionType::Pass` to legal_actions in
+            // `Phase::WaitResponse` (`riichienv-core/src/state/legal_actions.rs:249`)
+            // — i.e. exactly when Majsoul is showing the Pass button after a
+            // claimable discard. Use that as the visibility gate.
+            MjaiEvent::None => {
+                if !pass_button_visible(ctx) {
+                    return result;
+                }
+                push_random_pre_delay(&mut result.steps, ctx);
+                if let Some(button) = action_button_for(MajsoulOpType::None, ctx) {
+                    result.steps.push(Step::Click {
+                        x_norm: button.0,
+                        y_norm: button.1,
+                    });
+                }
+            }
+
+            // Everything else (StartGame, Tsumo, Dora, ReachAccepted,
+            // EndKyoku, EndGame, events from other seats) doesn't drive
+            // a click.
+            _ => {}
+        }
+
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn push_random_pre_delay(steps: &mut Vec<Step>, ctx: &ActionContext) {
+    let lo = ctx.cfg.pre_click_delay_min_ms;
+    let hi = ctx.cfg.pre_click_delay_max_ms.max(lo);
+    let mut delay = if hi == lo {
+        lo
+    } else {
+        rand::rng().random_range(lo..=hi)
+    };
+    // Reference behaviour (`autoplay_majsoul.py:156-157`): if there's no
+    // `last_kawa_tile` (i.e. very first action of a kyoku), use the upper
+    // bound as a fixed delay. Slightly slower but more human-like on the
+    // opening turn.
+    if ctx.last_kawa_tile.is_none() {
+        delay = hi;
+    }
+    steps.push(Step::Sleep { duration_ms: delay });
+}
+
+/// Plan a hand-tile click for a discard or riichi-declaring discard.
+fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
+    let our_seat = ctx.our_seat as usize;
+    if our_seat >= ctx.snapshot.players.len() {
+        return None;
+    }
+
+    // Dealer's first discard: Majsoul lays all 14 tiles continuously on
+    // the rack (sorted) — there's no "tsumohai" gap. Click position is
+    // the index in the fully-sorted 14-tile array, using TILES[i]
+    // directly (not get_pai_coord, which would add TSUMO_SPACE for i=13).
+    if is_dealer_first_discard(ctx) {
+        let mut sorted = ctx.snapshot.players[our_seat].tehai.clone();
+        sorted.sort_by(|a, b| compare_pai(a, b));
+        let idx = sorted.iter().position(|x| x == pai)?;
+        let (x, y) = TILES.get(idx).copied()?;
+        return Some(Step::Click { x_norm: x, y_norm: y });
+    }
+
+    let mut tehai: Vec<String> = ctx.snapshot.players[our_seat].tehai.clone();
+    let tsumohai = ctx.last_self_tsumo;
+
+    // Detect tsumohai: hand sizes that include the just-drawn tile are
+    // 2/5/8/11/14 (mod 3 = 2). When present and known, separate it out.
+    let mut is_tsumohai = false;
+    if matches!(tehai.len(), 14 | 11 | 8 | 5 | 2) {
+        if let Some(t) = tsumohai {
+            if let Some(pos) = tehai.iter().rposition(|x| x == t) {
+                tehai.remove(pos);
+                is_tsumohai = true;
+            }
+        }
+    }
+    tehai.sort_by(|a, b| compare_pai(a, b));
+
+    if is_tsumohai {
+        if let Some(t) = tsumohai {
+            if pai == t {
+                let (x, y) = get_pai_coord(13, tehai.len());
+                return Some(Step::Click { x_norm: x, y_norm: y });
+            }
+        }
+    }
+
+    let idx = tehai.iter().position(|x| x == pai)?;
+    if idx >= TILES.len() - 1 {
+        // No closed-hand slot 13 (only the tsumohai uses that path).
+        return None;
+    }
+    let (x, y) = get_pai_coord(idx, tehai.len());
+    Some(Step::Click { x_norm: x, y_norm: y })
+}
+
+/// True for the dealer's very first discard of a kyoku — the moment
+/// when Mahjong Soul has dealt 14 tiles, played the hand-sort animation,
+/// and is showing all 14 tiles continuously on the rack (no tsumohai
+/// offset). Detected by: we're oya, our hand size is 14, and we have
+/// no discards or melds yet.
+fn is_dealer_first_discard(ctx: &ActionContext) -> bool {
+    let our_seat = ctx.our_seat as usize;
+    let Some(player) = ctx.snapshot.players.get(our_seat) else {
+        return false;
+    };
+    ctx.snapshot.oya == ctx.our_seat
+        && player.tehai.len() == 14
+        && player.river.is_empty()
+        && player.melds.is_empty()
+}
+
+/// Plan a chi/pon/daiminkan: action button click + optional candidate
+/// disambiguation when multiple consume-tile combinations are legal.
+fn plan_meld(
+    op: MajsoulOpType,
+    at: ActionType,
+    result: &mut PlanResult,
+    ctx: &ActionContext,
+) {
+    let Some(button) = action_button_for(op, ctx) else {
+        return;
+    };
+    result.steps.push(Step::Click {
+        x_norm: button.0,
+        y_norm: button.1,
+    });
+
+    let consumed: Vec<String> = match ctx.action {
+        MjaiEvent::Chi { consumed, .. } => consumed.to_vec(),
+        MjaiEvent::Pon { consumed, .. } => consumed.to_vec(),
+        MjaiEvent::Daiminkan { consumed, .. } => consumed.to_vec(),
+        _ => return,
+    };
+
+    let candidates = collect_candidate_consumes(ctx.legal_actions, at);
+    if candidates.len() <= 1 {
+        return; // single option → Majsoul auto-confirms
+    }
+    let mut sorted_consumed = consumed;
+    sorted_consumed.sort_by(|a, b| compare_pai(a, b));
+    if let Some(idx) = candidates
+        .iter()
+        .position(|c| same_consumed(c, &sorted_consumed))
+    {
+        if let Some(p) = candidate_pos(idx, candidates.len()) {
+            result.steps.push(Step::Sleep {
+                duration_ms: ctx.cfg.inter_click_delay_ms,
+            });
+            result.steps.push(Step::Click {
+                x_norm: p.0,
+                y_norm: p.1,
+            });
+        }
+    }
+}
+
+/// Plan an ankan/kakan: kan button click + optional kan-row candidate.
+///
+/// Special case: when both ankan and kakan are simultaneously legal,
+/// Majsoul shows ONE kan button whose candidate row contains the union
+/// of both, ordered `[kakan…, ankan…]`. The candidate index for the
+/// bot's chosen tile is computed against the unified list.
+fn plan_kan(
+    op: MajsoulOpType,
+    at: ActionType,
+    result: &mut PlanResult,
+    ctx: &ActionContext,
+) {
+    let Some(button) = action_button_for(op, ctx) else {
+        return;
+    };
+    result.steps.push(Step::Click {
+        x_norm: button.0,
+        y_norm: button.1,
+    });
+
+    // Collect both ankan and kakan candidates. When the bot is doing
+    // a kakan, kakan candidates are listed first; for ankan, ankan
+    // first. Reference: `autoplay_majsoul.py:262-280`.
+    let kakans = collect_candidate_consumes(ctx.legal_actions, ActionType::Kakan);
+    let ankans = collect_candidate_consumes(ctx.legal_actions, ActionType::Ankan);
+    let unified: Vec<Vec<String>> = kakans.iter().chain(ankans.iter()).cloned().collect();
+    if unified.len() <= 1 {
+        return; // single option → Majsoul auto-confirms
+    }
+
+    // Identify the consumed tile of the bot's action.
+    let consumed_pai = match ctx.action {
+        MjaiEvent::Ankan { consumed, .. } => consumed.first().cloned(),
+        MjaiEvent::Kakan { pai, .. } => Some(pai.clone()),
+        _ => None,
+    };
+    let Some(consumed_pai) = consumed_pai else {
+        return;
+    };
+    // Strip the red-five marker for matching (kan candidate row uses the
+    // base tile name; the engine's consume_tiles include the red-five).
+    let base = if consumed_pai.ends_with('r') {
+        consumed_pai[..consumed_pai.len() - 1].to_string()
+    } else {
+        consumed_pai
+    };
+
+    // Find the candidate index by matching on the first non-red-five
+    // tile of each candidate's consume list. For ankan all four are
+    // copies of the same suit/rank; for kakan the consume is a triplet
+    // of the same tile.
+    let idx = unified.iter().position(|c| {
+        let any = c
+            .iter()
+            .map(|t| if t.ends_with('r') { &t[..t.len() - 1] } else { t.as_str() })
+            .next();
+        any.map(|t| t == base).unwrap_or(false)
+    });
+    let Some(idx) = idx else {
+        return;
+    };
+
+    if let Some(p) = kan_candidate_pos(idx, unified.len()) {
+        // Suppress unused-variable warning when the action type is unused
+        // — kept in the signature so future logic can branch on it.
+        let _ = at;
+        result.steps.push(Step::Sleep {
+            duration_ms: ctx.cfg.inter_click_delay_ms,
+        });
+        result.steps.push(Step::Click {
+            x_norm: p.0,
+            y_norm: p.1,
+        });
+    }
+}
+
+/// Look up the on-screen position of the action button for `op`, given
+/// the currently-legal actions.
+fn action_button_for(op: MajsoulOpType, ctx: &ActionContext) -> Option<(f64, f64)> {
+    let ops = legal_op_set(ctx.legal_actions, ctx.snapshot, ctx.our_seat);
+    action_button_pos(&ops, op)
+}
+
+/// Build the deduplicated set of Majsoul op-types currently legal,
+/// always including [`MajsoulOpType::None`] (the "pass / cancel"
+/// button is always shown when any decision is required).
+fn legal_op_set(
+    legal: &[Action],
+    snapshot: &crate::game_state::snapshot::GameStateSnapshot,
+    our_seat: u8,
+) -> Vec<MajsoulOpType> {
+    use std::collections::HashSet;
+    let mut set: HashSet<MajsoulOpType> = HashSet::new();
+
+    // Pass is always present alongside any prompt.
+    set.insert(MajsoulOpType::None);
+
+    let mut hora_seen_tsumo = false;
+    let mut hora_seen_ron = false;
+
+    for a in legal {
+        match a.action_type {
+            ActionType::Discard => { /* no button */ }
+            ActionType::Tsumo => {
+                hora_seen_tsumo = true;
+                set.insert(MajsoulOpType::Zimo);
+            }
+            ActionType::Ron => {
+                hora_seen_ron = true;
+                set.insert(MajsoulOpType::Ron);
+            }
+            other => {
+                if let Some(op) = MajsoulOpType::from_engine(other) {
+                    if op != MajsoulOpType::None {
+                        set.insert(op);
+                    }
+                }
+            }
+        }
+    }
+
+    // 3p Nukidora isn't always exposed via legal_actions in the engine
+    // (the Python reference checks tehai_vec34 for an N tile directly).
+    // Mirror that: if we have N tiles in hand and the kita meld is
+    // legal in the rules path, surface the button. Conservative: only
+    // add when not already set and we're playing 3p.
+    if snapshot.num_players == 3 {
+        if let Some(player) = snapshot.players.get(our_seat as usize) {
+            if player.tehai.iter().any(|t| t == "N") {
+                set.insert(MajsoulOpType::Nukidora);
+            }
+        }
+    }
+
+    let _ = (hora_seen_tsumo, hora_seen_ron);
+    let mut v: Vec<MajsoulOpType> = set.into_iter().collect();
+    v.sort_by_key(|op| ACTION_PRIORITY[*op as usize]);
+    v
+}
+
+/// Pull all consume-tile combinations for one action type out of the
+/// legal-action list, normalised to mjai tile strings.
+fn collect_candidate_consumes(legal: &[Action], at: ActionType) -> Vec<Vec<String>> {
+    legal
+        .iter()
+        .filter(|a| a.action_type == at)
+        .map(|a| {
+            let mut tiles: Vec<String> = a.consume_tiles.iter().copied().map(tid_to_mjai).collect();
+            tiles.sort_by(|a, b| compare_pai(a, b));
+            tiles
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Equality on consumed-tile lists. Both sides expected pre-sorted with
+/// `compare_pai`, but use a length-aware element check so the comparison
+/// doesn't silently succeed on mismatched lengths.
+fn same_consumed(a: &[String], b: &[String]) -> bool {
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x == y)
+}
+
+/// True when the bot's hora is on its own draw — in mjai both tsumo
+/// agari and ron are emitted as `MjaiEvent::Hora`, but Majsoul's button
+/// position differs. Distinguish by consulting the engine's legal
+/// actions: if Tsumo is legal for our seat, the agari is on our draw.
+fn hora_is_tsumo(ctx: &ActionContext) -> bool {
+    ctx.legal_actions
+        .iter()
+        .any(|a| a.action_type == ActionType::Tsumo)
+}
+
+/// True iff Majsoul is currently showing the Pass button — that is, we
+/// are in `Phase::WaitResponse` for our seat and have at least one
+/// claim option (or just the bare Pass entry that riichienv always
+/// emits in WaitResponse).
+fn pass_button_visible(ctx: &ActionContext) -> bool {
+    ctx.legal_actions
+        .iter()
+        .any(|a| a.action_type == ActionType::Pass)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::autoplay::context::CanvasRect;
+    use crate::config::MajsoulAutoplayConfig;
+    use crate::game_state::snapshot::{GameStateSnapshot, Phase, PlayerSnapshot};
+
+    fn cfg() -> MajsoulAutoplayConfig {
+        MajsoulAutoplayConfig {
+            pre_click_delay_min_ms: 0,
+            pre_click_delay_max_ms: 0,
+            inter_click_delay_ms: 0,
+            hover_delay_ms: 0,
+            click_hold_ms: 0,
+            dealer_first_discard_extra_delay_ms: 0,
+        }
+    }
+
+    fn cfg_with_dealer_delay(ms: u32) -> MajsoulAutoplayConfig {
+        let mut c = cfg();
+        c.dealer_first_discard_extra_delay_ms = ms;
+        c
+    }
+
+    fn snapshot_with_oya(seat: u8, oya: u8, tehai: Vec<&str>) -> GameStateSnapshot {
+        let mut s = snapshot_with_hand(seat, tehai);
+        s.oya = oya;
+        s
+    }
+
+    fn snapshot_with_hand(seat: u8, tehai: Vec<&str>) -> GameStateSnapshot {
+        let players = (0..4u8)
+            .map(|i| PlayerSnapshot {
+                seat: i,
+                tehai: if i == seat {
+                    tehai.iter().map(|s| s.to_string()).collect()
+                } else {
+                    Vec::new()
+                },
+                melds: Vec::new(),
+                river: Vec::new(),
+                score: 25000,
+                riichi_declared: false,
+                riichi_stage: false,
+                double_riichi: false,
+                riichi_declaration_index: None,
+                kita_tiles: Vec::new(),
+            })
+            .collect();
+        GameStateSnapshot {
+            bakaze: "E".into(),
+            kyoku: 1,
+            honba: 0,
+            kyotaku: 0,
+            oya: 0,
+            current_player: seat,
+            turn_count: 0,
+            phase: Phase::WaitAct,
+            is_done: false,
+            num_players: 4,
+            players,
+            dora_markers: Vec::new(),
+            our_seat: Some(seat),
+        }
+    }
+
+    fn ctx_for<'a>(
+        action: &'a MjaiEvent,
+        snapshot: &'a GameStateSnapshot,
+        legal: &'a [Action],
+        last_kawa: Option<&'a str>,
+        last_tsumo: Option<&'a str>,
+        riichi_accepted: bool,
+        reach_state: ReachState,
+        cfg_ref: &'a MajsoulAutoplayConfig,
+    ) -> ActionContext<'a> {
+        ActionContext {
+            action,
+            snapshot,
+            legal_actions: legal,
+            our_seat: snapshot.our_seat.unwrap_or(0),
+            last_kawa_tile: last_kawa,
+            last_self_tsumo: last_tsumo,
+            self_riichi_accepted: riichi_accepted,
+            reach_state,
+            num_players: snapshot.num_players,
+            cfg: cfg_ref,
+        }
+    }
+
+    #[test]
+    fn dahai_simple_click() {
+        // Non-dealer (oya = seat 1, we are seat 0) so the dealer-first-
+        // discard layout doesn't apply — this test exercises the normal
+        // tsumohai-offset path.
+        let snap = snapshot_with_oya(
+            0, 1,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "5p".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg();
+        let ctx = ctx_for(
+            &act, &snap, &[], Some("1m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        // sleep + click
+        assert_eq!(result.steps.len(), 2);
+        match &result.steps[1] {
+            Step::Click { x_norm, .. } => {
+                // Tsumohai (5p) → idx 13, with TSUMO_SPACE offset.
+                let expected = TILES[13].0 + TSUMO_SPACE;
+                assert!(
+                    (*x_norm - expected).abs() < 1e-9,
+                    "expected tsumohai at {expected}, got {x_norm}"
+                );
+            }
+            _ => panic!("second step should be a click"),
+        }
+    }
+
+    #[test]
+    fn dahai_suppressed_under_riichi() {
+        let snap = snapshot_with_hand(
+            0,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "5p".into(),
+            tsumogiri: true,
+        };
+        let cfg_ref = cfg();
+        let ctx = ctx_for(
+            &act,
+            &snap,
+            &[],
+            Some("1m"),
+            Some("5p"),
+            true,
+            ReachState::Idle,
+            &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert!(result.steps.is_empty(), "no click while riichi accepted");
+    }
+
+    #[test]
+    fn dahai_under_riichi_awaiting_riichi_dahai_clicks() {
+        // Path B follow-up: even though manager has self_riichi_accepted=false
+        // (it only flips on ReachAccepted from server), reach_state being
+        // AwaitingDahai means we should click. self_riichi_accepted is
+        // expected to be false here too, but the suppression check is
+        // ANDed with reach_state — verify both false-cases:
+        let snap = snapshot_with_hand(0, vec!["1m", "2m", "3m"]);
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "3m".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg();
+        // Hand of 3 tiles is unusual but the Path B click should not be
+        // suppressed even when self_riichi_accepted=true happens to be set.
+        let ctx = ctx_for(
+            &act,
+            &snap,
+            &[],
+            Some("1m"),
+            None,
+            true,
+            ReachState::AwaitingDahai,
+            &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert!(!result.steps.is_empty(), "Path B follow-up dahai must click");
+    }
+
+    #[test]
+    fn reach_path_a_two_clicks() {
+        let snap = snapshot_with_hand(
+            0,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Reach {
+            actor: 0,
+            pai: Some("5p".into()),
+        };
+        let cfg_ref = cfg();
+        // Reach must be in legal_actions for the button position to resolve.
+        let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
+        let ctx = ctx_for(
+            &act, &snap, &legal, Some("1m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        // sleep + reach btn + sleep + tile click
+        assert_eq!(result.steps.len(), 4);
+        assert!(matches!(result.steps[1], Step::Click { .. }));
+        assert!(matches!(result.steps[3], Step::Click { .. }));
+        assert!(!result.inject_reach_for_followup);
+    }
+
+    #[test]
+    fn reach_path_b_signals_inject() {
+        let snap = snapshot_with_hand(0, vec!["1m"]);
+        let act = MjaiEvent::Reach { actor: 0, pai: None };
+        let cfg_ref = cfg();
+        let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
+        let ctx = ctx_for(
+            &act, &snap, &legal, Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        // sleep + reach btn click only
+        assert_eq!(result.steps.len(), 2);
+        assert!(result.inject_reach_for_followup);
+        assert!(result.awaiting_riichi_dahai);
+    }
+
+    #[test]
+    fn pass_button_clicks_at_slot_zero() {
+        // Pass is in legal_actions only when riichienv is in WaitResponse
+        // and there's something to claim/pass on. Synthesise that state:
+        let snap = snapshot_with_hand(0, vec!["1m"]);
+        let act = MjaiEvent::None;
+        let cfg_ref = cfg();
+        let legal = vec![Action::new(ActionType::Pass, None, vec![], Some(0))];
+        let ctx = ctx_for(
+            &act, &snap, &legal, Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert_eq!(result.steps.len(), 2);
+        match &result.steps[1] {
+            Step::Click { x_norm, y_norm } => {
+                // ACTIONS[0] is the pass slot (rightmost top row).
+                assert_eq!(*x_norm, 10.875);
+                assert_eq!(*y_norm, 7.0);
+            }
+            _ => panic!("expected click"),
+        }
+    }
+
+    #[test]
+    fn none_does_not_click_when_no_pass_in_legal_actions() {
+        // Bot emits None on every event from other players (purely
+        // informational echoes). Without the gate we'd loop-click the
+        // cancel button on every other-player turn.
+        let snap = snapshot_with_hand(0, vec!["1m"]);
+        let act = MjaiEvent::None;
+        let cfg_ref = cfg();
+        let ctx = ctx_for(
+            &act, &snap, &[], Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert!(
+            result.steps.is_empty(),
+            "None must not click when Pass is not in legal_actions"
+        );
+    }
+
+    #[test]
+    fn none_does_not_click_during_our_discard_turn() {
+        // WaitAct phase: legal_actions has Discard but no Pass — a bot
+        // emitting None here is buggy, but the gate must hold.
+        let snap = snapshot_with_hand(0, vec!["1m", "2m"]);
+        let act = MjaiEvent::None;
+        let cfg_ref = cfg();
+        let legal = vec![
+            Action::new(ActionType::Discard, Some(0), vec![], Some(0)),
+            Action::new(ActionType::Discard, Some(4), vec![], Some(0)),
+        ];
+        let ctx = ctx_for(
+            &act, &snap, &legal, Some("1m"), Some("1m"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert!(
+            result.steps.is_empty(),
+            "None must not click during a discard turn (no Pass button shown)"
+        );
+    }
+
+    #[test]
+    fn dealer_first_discard_uses_continuous_layout_no_tsumo_offset() {
+        // Dealer with 14 tiles, empty river, no melds. Mahjong Soul lays
+        // all 14 sorted on the rack — no tsumohai gap. Discarding the
+        // sorted-last tile (5p) must click TILES[13] directly, NOT
+        // TILES[13] + TSUMO_SPACE.
+        let snap = snapshot_with_oya(
+            0, 0,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
+                 "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "5p".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg();
+        // Even with last_self_tsumo set, dealer-first-discard layout
+        // must override the tsumohai-offset path.
+        let ctx = ctx_for(
+            &act, &snap, &[], None, Some("5p"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert_eq!(result.steps.len(), 2);
+        match &result.steps[1] {
+            Step::Click { x_norm, .. } => {
+                assert!(
+                    (*x_norm - TILES[13].0).abs() < 1e-9,
+                    "expected raw TILES[13] (no TSUMO_SPACE), got {x_norm}"
+                );
+            }
+            _ => panic!("expected click"),
+        }
+    }
+
+    #[test]
+    fn dealer_first_discard_pads_extra_delay() {
+        let snap = snapshot_with_oya(
+            0, 0,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
+                 "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "1m".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg_with_dealer_delay(2000);
+        let ctx = ctx_for(
+            &act, &snap, &[], None, None, false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        // [pre-delay sleep, dealer-pad sleep, click]
+        assert_eq!(result.steps.len(), 3);
+        match &result.steps[1] {
+            Step::Sleep { duration_ms } => assert_eq!(*duration_ms, 2000),
+            _ => panic!("expected sleep step at index 1"),
+        }
+    }
+
+    #[test]
+    fn dealer_second_discard_uses_normal_tsumohai_path() {
+        // After dealer's first discard, future turns are 13 closed + 1
+        // tsumohai with the standard offset — same as non-dealer.
+        let mut snap = snapshot_with_oya(
+            0, 0,
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
+                 "1p", "2p", "3p", "4p", "5p"],
+        );
+        // Mark a prior discard so river is non-empty (not first discard).
+        snap.players[0].river.push(crate::game_state::snapshot::DiscardEntry {
+            tile: "9m".into(),
+            tedashi: true,
+            is_riichi: false,
+        });
+        let act = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "5p".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg();
+        let ctx = ctx_for(
+            &act, &snap, &[], Some("9m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        match &result.steps.last().unwrap() {
+            Step::Click { x_norm, .. } => {
+                // Tsumohai click → TILES[13] + TSUMO_SPACE.
+                let expected = TILES[13].0 + TSUMO_SPACE;
+                assert!((*x_norm - expected).abs() < 1e-9);
+            }
+            _ => panic!("expected click"),
+        }
+    }
+
+    #[test]
+    fn non_dealer_first_discard_does_not_pad_or_relayout() {
+        // Non-dealer's first turn: 14 tiles too, but the layout is
+        // 13 closed + 1 tsumohai with TSUMO_SPACE — Majsoul does not
+        // run the dealer-only sort animation.
+        let snap = snapshot_with_oya(
+            1, 0, // we're seat 1, dealer is seat 0
+            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
+                 "1p", "2p", "3p", "4p", "5p"],
+        );
+        let act = MjaiEvent::Dahai {
+            actor: 1,
+            pai: "5p".into(),
+            tsumogiri: false,
+        };
+        let cfg_ref = cfg_with_dealer_delay(2000);
+        let ctx = ctx_for(
+            &act, &snap, &[], None, Some("5p"), false, ReachState::Idle, &cfg_ref,
+        );
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        // No dealer pad: just [pre-delay, click].
+        assert_eq!(result.steps.len(), 2);
+    }
+
+    #[test]
+    fn pixel_translation_in_canvas_rect() {
+        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        // Centre of the canvas at (8.0, 4.5) norm.
+        assert_eq!(rect.pixel(8.0, 4.5), (800.0, 450.0));
+    }
+}

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -1,0 +1,338 @@
+//! Autoplay manager: subscribes to bot decisions + mjai events,
+//! translates them into UI clicks dispatched via CDP.
+//!
+//! Lifecycle:
+//! - Spawned by `crate::lib::run` when `cfg.autoplay.enabled = true`.
+//! - One long-lived `tokio::select!` loop over `BotResponseBus` and
+//!   `MjaiBus`. Bot responses drive clicks; mjai events update local
+//!   per-game tracking state (`last_kawa_tile`, `last_self_tsumo`,
+//!   `self_riichi_accepted`, `reach_state`).
+//!
+//! Failure modes are silent-by-design: if the page handle is missing
+//! (chromium backend not running) or the canvas-rect query fails, the
+//! manager logs a warning and skips the click. The bot pipeline is
+//! untouched; the user can still play the round manually.
+
+use crate::autoplay::cdp_input::{dispatch_click, evaluate_canvas_rect};
+use crate::autoplay::context::{AutoplayContext, CanvasRect};
+use crate::autoplay::majsoul::MajsoulAutoplay;
+use crate::autoplay::platform::{ActionContext, PlatformAutoplay, ReachState, Step};
+use crate::bot::BotResponse;
+use crate::config::AppConfig;
+use crate::event_bus::{BotResponseBus, MjaiBus};
+use crate::game_state::tracker::GameTracker;
+use crate::schema::MjaiEvent;
+use riichienv_core::action::Action;
+use riichienv_core::state::legal_actions::GameStateLegalActions;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast::error::RecvError, Mutex, RwLock};
+use tracing::{debug, info, warn};
+
+/// How long before a cached `CanvasRect` is treated as stale and re-queried.
+const CANVAS_RECT_TTL: Duration = Duration::from_secs(30);
+
+pub struct AutoplayManager {
+    cfg: Arc<RwLock<AppConfig>>,
+    ctx: Arc<AutoplayContext>,
+    tracker: Arc<Mutex<GameTracker>>,
+    mjai_bus: MjaiBus,
+    platform: Arc<dyn PlatformAutoplay>,
+    state: ManagerState,
+}
+
+#[derive(Default)]
+struct ManagerState {
+    last_kawa_tile: Option<String>,
+    last_self_tsumo: Option<String>,
+    self_riichi_accepted: bool,
+    reach_state: ReachState,
+    canvas_rect_at: Option<Instant>,
+}
+
+impl Default for ReachState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl AutoplayManager {
+    pub fn new(
+        cfg: Arc<RwLock<AppConfig>>,
+        ctx: Arc<AutoplayContext>,
+        tracker: Arc<Mutex<GameTracker>>,
+        mjai_bus: MjaiBus,
+    ) -> Self {
+        Self {
+            cfg,
+            ctx,
+            tracker,
+            mjai_bus,
+            // Only Majsoul is wired up today; future Tenhou impl swaps
+            // here based on config.platform.kind at run start.
+            platform: Arc::new(MajsoulAutoplay::new()),
+            state: ManagerState::default(),
+        }
+    }
+
+    /// Run forever. Returns `Err` only on bus closure (process exit).
+    pub async fn run(mut self, response_bus: BotResponseBus) -> anyhow::Result<()> {
+        let mut bot_rx = response_bus.subscribe();
+        let mut mjai_rx = self.mjai_bus.subscribe();
+        info!("autoplay manager started");
+
+        loop {
+            tokio::select! {
+                msg = bot_rx.recv() => match msg {
+                    Ok(resp) => self.handle_bot_response(resp).await,
+                    Err(RecvError::Lagged(n)) => warn!("autoplay: bot bus lagged {n}"),
+                    Err(RecvError::Closed) => {
+                        info!("autoplay: bot bus closed; exiting");
+                        return Ok(());
+                    }
+                },
+                msg = mjai_rx.recv() => match msg {
+                    Ok(ev) => self.handle_mjai_event(&ev),
+                    Err(RecvError::Lagged(n)) => warn!("autoplay: mjai bus lagged {n}"),
+                    Err(RecvError::Closed) => {
+                        info!("autoplay: mjai bus closed; exiting");
+                        return Ok(());
+                    }
+                },
+            }
+        }
+    }
+
+    async fn handle_bot_response(&mut self, resp: BotResponse) {
+        // Re-read config every iteration so `cfg.autoplay.enabled` can be
+        // toggled at runtime via the Settings UI without restarting.
+        let cfg_guard = self.cfg.read().await;
+        if !cfg_guard.autoplay.enabled {
+            return;
+        }
+        let cfg = cfg_guard.autoplay.majsoul.clone();
+        drop(cfg_guard);
+
+        // Pull our seat + legal actions from the live engine state. This
+        // bracket releases the tracker mutex before we sleep/click.
+        let (our_seat, legal_actions, snapshot, num_players) = {
+            let tracker = self.tracker.lock().await;
+            let our_seat = match tracker.our_seat() {
+                Some(s) => s,
+                None => return, // game hasn't started or no perspective tagged
+            };
+            let snapshot = match tracker.snapshot() {
+                Some(s) => s,
+                None => return,
+            };
+            let num_players = snapshot.num_players;
+            let legal_actions: Vec<Action> = if num_players == 3 {
+                tracker
+                    .state_3p()
+                    .map(|s| {
+                        // 3p engine has its own GameStateLegalActions impl —
+                        // import elsewhere if needed; v1 only handles 4p clicks.
+                        let _ = s;
+                        Vec::new()
+                    })
+                    .unwrap_or_default()
+            } else {
+                tracker
+                    .state()
+                    .map(|s| s._get_legal_actions_internal(our_seat))
+                    .unwrap_or_default()
+            };
+            (our_seat, legal_actions, snapshot, num_players)
+        };
+
+        let action_ctx = ActionContext {
+            action: &resp.action,
+            snapshot: &snapshot,
+            legal_actions: &legal_actions,
+            our_seat,
+            last_kawa_tile: self.state.last_kawa_tile.as_deref(),
+            last_self_tsumo: self.state.last_self_tsumo.as_deref(),
+            self_riichi_accepted: self.state.self_riichi_accepted,
+            reach_state: self.state.reach_state,
+            num_players,
+            cfg: &cfg,
+        };
+
+        let plan = self.platform.plan(&action_ctx);
+        if plan.steps.is_empty() && !plan.inject_reach_for_followup {
+            return;
+        }
+
+        debug!(
+            "autoplay: action={:?} steps={} inject_reach={} await_riichi_dahai={}",
+            resp.action,
+            plan.steps.len(),
+            plan.inject_reach_for_followup,
+            plan.awaiting_riichi_dahai
+        );
+
+        // Resolve a canvas rect (cache + TTL). If we can't, drop the
+        // click — the page handle isn't ready yet (e.g. user still on
+        // the lobby), or the chromium backend isn't running at all.
+        let rect = match self.canvas_rect_resolve().await {
+            Some(r) => r,
+            None => {
+                warn!("autoplay: no canvas rect — skipping click for {:?}", resp.action);
+                return;
+            }
+        };
+
+        for step in &plan.steps {
+            match step {
+                Step::Sleep { duration_ms } => {
+                    tokio::time::sleep(Duration::from_millis(*duration_ms as u64)).await;
+                }
+                Step::Click { x_norm, y_norm } => {
+                    let (px, py) = rect.pixel(*x_norm, *y_norm);
+                    if !rect.contains(px, py) {
+                        warn!(
+                            "autoplay: click ({px},{py}) outside canvas rect {:?}; skipping",
+                            rect
+                        );
+                        continue;
+                    }
+                    // Need to re-acquire the page handle on each click;
+                    // it may have been replaced (tab reload) between
+                    // successive clicks within one action.
+                    let page_guard = self.ctx.page.read().await;
+                    let Some(page) = page_guard.as_ref() else {
+                        warn!("autoplay: no page handle — aborting click sequence");
+                        return;
+                    };
+                    if let Err(e) =
+                        dispatch_click(page, px, py, cfg.hover_delay_ms, cfg.click_hold_ms).await
+                    {
+                        warn!("autoplay: dispatch_click failed: {e:#}");
+                        return;
+                    }
+                    drop(page_guard);
+                }
+            }
+        }
+
+        // Path-B side effect: inject synthetic Reach so the bot will
+        // emit the riichi-declaring dahai we need to click next.
+        if plan.inject_reach_for_followup {
+            self.state.reach_state = ReachState::AwaitingDahai;
+            let synthetic = MjaiEvent::Reach { actor: our_seat, pai: None };
+            if let Err(e) = self.mjai_bus.send(synthetic) {
+                // No subscribers (e.g. bot disabled) — nothing to do, but
+                // log for visibility because Path B without a downstream
+                // bot would soft-hang autoplay until reach_state resets.
+                debug!("autoplay: synthetic Reach send had no subscribers: {e:?}");
+            } else {
+                info!("autoplay: injected synthetic Reach (Path B) for seat {our_seat}");
+            }
+        }
+
+        // After a successful Path-B follow-up dahai, return to Idle.
+        // The check is conservative: only flip on Dahai by our seat.
+        if matches!(self.state.reach_state, ReachState::AwaitingDahai) {
+            if let MjaiEvent::Dahai { actor, .. } = &resp.action {
+                if *actor == our_seat {
+                    self.state.reach_state = ReachState::Idle;
+                }
+            }
+        }
+    }
+
+    fn handle_mjai_event(&mut self, ev: &MjaiEvent) {
+        match ev {
+            MjaiEvent::StartGame { .. } | MjaiEvent::EndGame => {
+                self.state = ManagerState::default();
+            }
+            MjaiEvent::StartKyoku { .. } | MjaiEvent::EndKyoku => {
+                // Per-kyoku reset: keep last seen rect cache, drop
+                // everything else.
+                let canvas_at = self.state.canvas_rect_at;
+                self.state = ManagerState::default();
+                self.state.canvas_rect_at = canvas_at;
+            }
+            MjaiEvent::Tsumo { actor, pai } => {
+                if let Some(seat) = self.our_seat_cached() {
+                    if *actor == seat {
+                        self.state.last_self_tsumo = Some(pai.clone());
+                    }
+                }
+            }
+            MjaiEvent::Dahai { actor, pai, .. } => {
+                self.state.last_kawa_tile = Some(pai.clone());
+                if let Some(seat) = self.our_seat_cached() {
+                    if *actor == seat {
+                        self.state.last_self_tsumo = None;
+                    }
+                }
+            }
+            MjaiEvent::ReachAccepted { actor } => {
+                if let Some(seat) = self.our_seat_cached() {
+                    if *actor == seat {
+                        self.state.self_riichi_accepted = true;
+                    }
+                }
+            }
+            MjaiEvent::Chi { actor, .. }
+            | MjaiEvent::Pon { actor, .. }
+            | MjaiEvent::Daiminkan { actor, .. }
+            | MjaiEvent::Ankan { actor, .. }
+            | MjaiEvent::Kakan { actor, .. } => {
+                if let Some(seat) = self.our_seat_cached() {
+                    if *actor == seat {
+                        self.state.last_self_tsumo = None;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Best-effort seat lookup that avoids blocking on the tracker mutex
+    /// inside the mjai event handler (which runs synchronously in the
+    /// select arm). Falls back to `None` if the lock is contended;
+    /// missing the seat once is harmless, the next event will catch up.
+    fn our_seat_cached(&self) -> Option<u8> {
+        self.tracker.try_lock().ok().and_then(|t| t.our_seat())
+    }
+
+    async fn canvas_rect_resolve(&mut self) -> Option<CanvasRect> {
+        let now = Instant::now();
+        if let Some(at) = self.state.canvas_rect_at {
+            if now.duration_since(at) < CANVAS_RECT_TTL {
+                if let Some(r) = *self.ctx.canvas_rect.read().await {
+                    return Some(r);
+                }
+            }
+        }
+        // Re-query.
+        let page_guard = self.ctx.page.read().await;
+        let page = page_guard.as_ref()?.clone();
+        drop(page_guard);
+        match evaluate_canvas_rect(&page).await {
+            Ok(rect) => {
+                *self.ctx.canvas_rect.write().await = Some(rect);
+                self.state.canvas_rect_at = Some(now);
+                Some(rect)
+            }
+            Err(e) => {
+                debug!("autoplay: evaluate_canvas_rect failed: {e:#}");
+                None
+            }
+        }
+    }
+}
+
+/// Spawn point for the autoplay loop. Wired by `crate::lib::run` so the
+/// `tauri::async_runtime` Tokio runtime is the host.
+pub async fn run_autoplay_manager(
+    cfg: Arc<RwLock<AppConfig>>,
+    ctx: Arc<AutoplayContext>,
+    tracker: Arc<Mutex<GameTracker>>,
+    mjai_bus: MjaiBus,
+    response_bus: BotResponseBus,
+) -> anyhow::Result<()> {
+    AutoplayManager::new(cfg, ctx, tracker, mjai_bus).run(response_bus).await
+}

--- a/src/autoplay/mod.rs
+++ b/src/autoplay/mod.rs
@@ -1,0 +1,33 @@
+//! Autoplay: translate bot decisions into UI clicks via CDP.
+//!
+//! Architecture and design rationale:
+//! `claude_plan_autoplay-majsoul-input-mutable-codd.md` (the approved
+//! plan covers data flow, two-step reach handling, and the rationale
+//! for sourcing action availability from `riichienv-core` rather than
+//! the platform-protocol parser).
+//!
+//! Module layout:
+//! - [`context`] — shared state between the chromium capture backend
+//!   and this manager (page handle + canvas rect cache).
+//! - [`platform`] — `PlatformAutoplay` trait + the click-step types.
+//!   Tenhou-ready: a future `tenhou` impl can use a different `Step`
+//!   variant for DOM clicks or WebSocket inject.
+//! - [`majsoul`] — the production Majsoul implementation: 16:9
+//!   coordinate tables ported from the reference Akagi Python file +
+//!   plan dispatch covering all mjai action types.
+//! - [`cdp_input`] — chromiumoxide wrappers (`dispatch_click`,
+//!   `evaluate_canvas_rect`).
+//! - [`manager`] — the long-lived `AutoplayManager` task that owns
+//!   per-game state and drives the click sequence.
+//!
+//! Entry point: [`manager::run_autoplay_manager`].
+
+pub mod cdp_input;
+pub mod context;
+pub mod majsoul;
+pub mod manager;
+pub mod platform;
+
+pub use context::{AutoplayContext, CanvasRect};
+pub use manager::run_autoplay_manager;
+pub use platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};

--- a/src/autoplay/platform.rs
+++ b/src/autoplay/platform.rs
@@ -1,0 +1,103 @@
+//! Platform-agnostic autoplay surface.
+//!
+//! `PlatformAutoplay` is the only thing `AutoplayManager` knows about —
+//! by holding `Arc<dyn PlatformAutoplay>` it can drop in a Tenhou impl
+//! later (DOM-based clicks or direct WS inject) without touching the
+//! manager's bus subscription / timing logic.
+
+use crate::config::MajsoulAutoplayConfig;
+use crate::game_state::snapshot::GameStateSnapshot;
+use crate::schema::MjaiEvent;
+use riichienv_core::action::Action;
+
+/// One step in the click sequence the manager will execute.
+///
+/// The 16:9-normalised coordinates match the convention used by the
+/// reference Akagi `LOCATION` table — see
+/// `reference/majsoul/autoplay_majsoul.py:13-65`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Step {
+    /// Click at a normalised 16:9 point on the game canvas.
+    Click { x_norm: f64, y_norm: f64 },
+    /// Pause for `duration_ms` before the next step. Used for the
+    /// pre-click "thinking" delay and the inter-click gap inside one
+    /// action.
+    Sleep { duration_ms: u32 },
+}
+
+/// State machine for handling Majsoul's fused reach+discard. See
+/// `claude_plan_autoplay-majsoul-input-mutable-codd.md` §7.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReachState {
+    Idle,
+    /// Path B: we clicked the reach button and injected a synthetic
+    /// `Reach` event into MjaiBus. The next `Dahai` from the bot is the
+    /// riichi tile and must be clicked even though the bot didn't pre-fill
+    /// `Reach.pai`.
+    AwaitingDahai,
+}
+
+/// Everything the platform impl needs to translate one bot decision
+/// into a concrete click sequence.
+pub struct ActionContext<'a> {
+    /// The bot's chosen action (from `BotResponseBus`).
+    pub action: &'a MjaiEvent,
+    /// Live game state from the riichi engine.
+    pub snapshot: &'a GameStateSnapshot,
+    /// Currently legal actions for `our_seat`, sourced from the riichi
+    /// engine's `_get_legal_actions_internal`. The platform impl uses
+    /// this to:
+    /// - decide which action button (chi/pon/kan/...) is in which
+    ///   on-screen position, by intersecting with the platform's
+    ///   priority table;
+    /// - enumerate chi/pon/kan candidate combinations when the bot's
+    ///   action is ambiguous (multiple `consume_tiles`).
+    pub legal_actions: &'a [Action],
+    /// Bot's seat.
+    pub our_seat: u8,
+    /// The most recent tile any seat discarded — needed to disambiguate
+    /// chi/pon target.
+    pub last_kawa_tile: Option<&'a str>,
+    /// The tile we drew this turn, if any. Used to detect tsumohai
+    /// position when emitting `dahai`.
+    pub last_self_tsumo: Option<&'a str>,
+    /// True from the moment the server confirms our riichi until the
+    /// kyoku ends. While set, dahai clicks are suppressed (Majsoul auto-
+    /// discards in riichi mode).
+    pub self_riichi_accepted: bool,
+    /// Reach two-step state (see [`ReachState`]).
+    pub reach_state: ReachState,
+    /// 3 (sanma) or 4 (yonma).
+    pub num_players: u8,
+    /// Per-platform config knobs (delays, mouse-move emission, ...).
+    pub cfg: &'a MajsoulAutoplayConfig,
+}
+
+/// Output of `PlatformAutoplay::plan`. Captures both the click sequence
+/// and the side-effect signal the manager needs to fulfil Path B reach
+/// (inject a synthetic `Reach` event back to MjaiBus so the bot emits
+/// the follow-up dahai).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PlanResult {
+    pub steps: Vec<Step>,
+    /// When `true`, the manager should send a synthetic
+    /// `MjaiEvent::Reach { actor: our_seat, pai: None }` onto MjaiBus
+    /// after the steps run, and transition `ReachState` to
+    /// `AwaitingDahai`. Set only when the bot's `Reach` event omits
+    /// `pai` and the platform needs a follow-up dahai.
+    pub inject_reach_for_followup: bool,
+    /// When `true`, the next bot Dahai for our seat is the riichi tile
+    /// and should be clicked even if the manager has flipped its
+    /// `self_riichi_accepted` gate. Currently always set together with
+    /// `inject_reach_for_followup`; kept as a separate flag so future
+    /// platforms can express other "treat next dahai specially"
+    /// situations.
+    pub awaiting_riichi_dahai: bool,
+}
+
+pub trait PlatformAutoplay: Send + Sync {
+    /// Translate the bot's action into a click sequence + side-effect
+    /// hints. Pure: must not perform IO. The manager handles the actual
+    /// CDP dispatch and bus injection.
+    fn plan(&self, ctx: &ActionContext) -> PlanResult;
+}

--- a/src/capture/chromium/cdp.rs
+++ b/src/capture/chromium/cdp.rs
@@ -20,6 +20,7 @@
 //! page-scoped WS today. If real-world testing shows otherwise, expand
 //! the polling to include `browser.targets()` and filter on type.
 
+use crate::autoplay::AutoplayContext;
 use crate::bridge::Direction;
 use crate::capture::flow::{slugify, FlowBridges};
 use crate::event_bus::MjaiBus;
@@ -105,14 +106,29 @@ pub fn diff_pages(prev: &HashSet<String>, current: &HashSet<String>) -> (Vec<Str
     (adds, removes)
 }
 
+/// Hosts whose WebSocket creation hands the page handle to autoplay.
+/// `maj-soul.com` covers en/cn/jp portals; `mahjongsoul.com` is the
+/// Yostar mirror.
+const AUTOPLAY_HOST_HINTS: &[&str] = &["maj-soul.com", "mahjongsoul.com"];
+
+fn is_autoplay_target_url(ws_url: &str) -> bool {
+    AUTOPLAY_HOST_HINTS.iter().any(|h| ws_url.contains(h))
+}
+
 /// Run the CDP loop until the browser disconnects or an unrecoverable
 /// error occurs. Frames flow through `bridges` into `mjai_bus`, and each
 /// frame is also recorded into `inspector` for the Logs → Inspector tab.
+///
+/// `autoplay` is `Some` only on the chromium backend when the autoplay
+/// feature is wired (`AppState.autoplay_context`). On Majsoul WS open
+/// we publish the page handle into it; autoplay reads it back to dispatch
+/// `Input.dispatchMouseEvent`. Passing `None` makes the loop bridge-only.
 pub async fn run(
     endpoint: &str,
     bridges: Arc<FlowBridges<FlowKey>>,
     mjai_bus: MjaiBus,
     inspector: InspectorWriter,
+    autoplay: Option<Arc<AutoplayContext>>,
 ) -> Result<()> {
     info!("CDP connecting to {endpoint}");
     let (browser_owned, mut handler) = Browser::connect(endpoint)
@@ -175,6 +191,7 @@ pub async fn run(
                     bridges.clone(),
                     mjai_bus.clone(),
                     inspector.clone(),
+                    autoplay.clone(),
                 )
                 .await
                 {
@@ -216,6 +233,7 @@ async fn attach_page(
     bridges: Arc<FlowBridges<FlowKey>>,
     mjai_bus: MjaiBus,
     inspector: InspectorWriter,
+    autoplay: Option<Arc<AutoplayContext>>,
 ) -> Result<JoinHandle<()>> {
     page.execute(NetworkEnableParams::default())
         .await
@@ -238,6 +256,10 @@ async fn attach_page(
         .context("subscribe webSocketClosed")?;
 
     let handle = tokio::spawn(async move {
+        // Track the most recent autoplay-target request id for this page,
+        // so we know which WS close to react to when clearing the page
+        // handle from the autoplay context.
+        let mut autoplay_request_id: Option<String> = None;
         loop {
             tokio::select! {
                 Some(ev) = on_created.next() => {
@@ -249,6 +271,27 @@ async fn attach_page(
                     let slug = slugify(&ev.url);
                     let _ = bridges.acquire(key, &slug, &label);
                     debug!("ws created: {} (target {target_id} request {})", ev.url, ev.request_id.inner());
+
+                    // If this is the platform's WS (Majsoul), capture
+                    // the owning page so autoplay can dispatch input
+                    // into it. Multi-tab user: most-recent wins, per
+                    // the plan.
+                    if let Some(ctx) = &autoplay {
+                        if is_autoplay_target_url(&ev.url) {
+                            let mut guard = ctx.page.write().await;
+                            if guard.is_some() {
+                                warn!(
+                                    "autoplay: replacing page handle on new WS for target {target_id}"
+                                );
+                            }
+                            *guard = Some(page.clone());
+                            autoplay_request_id = Some(ev.request_id.inner().clone());
+                            info!(
+                                "autoplay: page handle bound to target {target_id} via WS {}",
+                                ev.url
+                            );
+                        }
+                    }
                 }
                 Some(ev) = on_recv.next() => {
                     let opcode = ev.response.opcode as i64;
@@ -327,6 +370,17 @@ async fn attach_page(
                     // direction's task is holding a clone.
                     let bridge = bridges.acquire(key.clone(), "ws", "ws frame");
                     bridges.release(&key, bridge);
+
+                    // If this is the autoplay-target WS, drop our hold
+                    // on the page handle. The next reconnection (game
+                    // restart, network blip) re-binds it from `on_created`.
+                    if let (Some(ctx), Some(req)) = (&autoplay, &autoplay_request_id) {
+                        if *req == *ev.request_id.inner() {
+                            *ctx.page.write().await = None;
+                            autoplay_request_id = None;
+                            debug!("autoplay: page handle cleared on WS close for target {target_id}");
+                        }
+                    }
                 }
                 else => break,
             }

--- a/src/capture/chromium/mod.rs
+++ b/src/capture/chromium/mod.rs
@@ -111,6 +111,7 @@ impl CaptureBackend for ChromiumBackend {
             bridges.clone(),
             ctx.mjai_bus.clone(),
             ctx.session.inspector(),
+            ctx.autoplay.clone(),
         );
         let mut cdp_fut = Box::pin(cdp_run);
         let shutdown_fut = shutdown.wait();

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -14,6 +14,7 @@ pub mod chromium;
 pub mod flow;
 pub mod hudsucker_backend;
 
+use crate::autoplay::AutoplayContext;
 use crate::config::Platform;
 use crate::event_bus::{MjaiBus, NotifyBus};
 use crate::logger::Session;
@@ -81,6 +82,11 @@ pub struct CaptureCtx {
     pub platform: Platform,
     pub mjai_bus: MjaiBus,
     pub notify_bus: NotifyBus,
+    /// Shared with the autoplay manager. The chromium backend writes the
+    /// per-tab `Page` handle here when it observes a Majsoul WS;
+    /// autoplay reads it to dispatch `Input.dispatchMouseEvent`. The
+    /// MITM backend simply ignores this — it has no `Page`.
+    pub autoplay: Option<Arc<AutoplayContext>>,
 }
 
 /// A capture transport. Implementors run a long-lived I/O loop until

--- a/src/config/autoplay.rs
+++ b/src/config/autoplay.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AutoplayConfig {
+    /// Master switch. When `false`, no `AutoplayManager` is spawned and bot
+    /// responses are not converted into UI clicks.
+    pub enabled: bool,
+    /// Per-platform autoplay knobs. Only the matching platform's section is
+    /// consulted at runtime; the others sit dormant.
+    pub majsoul: MajsoulAutoplayConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MajsoulAutoplayConfig {
+    /// Lower bound of the random pre-click delay (ms). The reference
+    /// Akagi autoplay used `random.uniform(1.0, 3.0)` seconds; the same
+    /// distribution is replicated here as `[1000, 3000]` ms by default.
+    pub pre_click_delay_min_ms: u32,
+    /// Upper bound of the random pre-click delay (ms).
+    pub pre_click_delay_max_ms: u32,
+    /// Inter-click delay between staged clicks within one action (e.g.
+    /// reach button → riichi tile, or chi button → candidate select).
+    pub inter_click_delay_ms: u32,
+    /// How long to hover the mouse over a target before pressing.
+    /// Empirically Laya's input system samples hover state before a
+    /// mousedown registers a hit on the tile sprite — clicks issued
+    /// without a hover delay (or shorter than ~100ms) get dropped on
+    /// the floor. Default 150ms; do not lower below 100ms.
+    pub hover_delay_ms: u32,
+    /// How long to hold the mouse button down between mousePressed and
+    /// mouseReleased. Non-zero so the engine doesn't collapse the pair
+    /// into a single frame.
+    pub click_hold_ms: u32,
+    /// Extra delay tacked onto the dealer's first discard. Mahjong Soul
+    /// plays a hand-sort animation when the dealer receives all 14 tiles
+    /// at once; clicks issued during the animation are dropped. ~2s
+    /// covers the animation across normal device speeds. Set to 0 to
+    /// opt out (e.g. on a fast box where the animation finishes inside
+    /// the regular pre-click delay anyway).
+    pub dealer_first_discard_extra_delay_ms: u32,
+}
+
+impl Default for MajsoulAutoplayConfig {
+    fn default() -> Self {
+        Self {
+            pre_click_delay_min_ms: 1000,
+            pre_click_delay_max_ms: 3000,
+            inter_click_delay_ms: 300,
+            hover_delay_ms: 150,
+            click_hold_ms: 50,
+            dealer_first_discard_extra_delay_ms: 2000,
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod autoplay;
 mod bot;
 mod capture;
 mod general;
@@ -5,6 +6,7 @@ mod logging;
 mod platform;
 mod proxy;
 
+pub use autoplay::{AutoplayConfig, MajsoulAutoplayConfig};
 pub use bot::BotConfig;
 pub use capture::{CaptureConfig, CaptureMode, ChromiumConfig};
 pub use general::GeneralConfig;
@@ -24,6 +26,7 @@ pub struct AppConfig {
     pub proxy: ProxyConfig,
     pub bot: BotConfig,
     pub capture: CaptureConfig,
+    pub autoplay: AutoplayConfig,
 }
 
 enum ResolvedPath {

--- a/src/ipc/capture_supervisor.rs
+++ b/src/ipc/capture_supervisor.rs
@@ -137,6 +137,7 @@ pub async fn spawn_capture_supervisor(state: AppState) -> Result<()> {
         platform,
         mjai_bus: state.mjai_bus.clone(),
         notify_bus: state.notify_bus.clone(),
+        autoplay: Some(state.autoplay_context.clone()),
     };
     let status_bus = state.capture_status_bus.clone();
     let control = state.capture_control.clone();

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -40,6 +40,21 @@ fn claim_bot_manager_spawn(bot_enabled: bool, flag: &std::sync::atomic::AtomicBo
             .is_ok()
 }
 
+/// Same once-per-process gating as the bot variant, but for the autoplay
+/// manager. Toggling `autoplay.enabled` back to false leaves the manager
+/// alive — it just becomes a no-op because every bot response is gated
+/// on a fresh `cfg.autoplay.enabled` read.
+fn claim_autoplay_manager_spawn(
+    autoplay_enabled: bool,
+    flag: &std::sync::atomic::AtomicBool,
+) -> bool {
+    use std::sync::atomic::Ordering;
+    autoplay_enabled
+        && flag
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+}
+
 fn entry_to_info(e: &BotEntry) -> BotInfo {
     BotInfo {
         name: e.name.clone(),
@@ -81,6 +96,7 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
     let new_platform = new_config.platform.kind;
     let bot_cfg = new_config.bot.clone();
     let bot_now_enabled = new_config.bot.enabled;
+    let autoplay_now_enabled = new_config.autoplay.enabled;
     *state.config.write().await = new_config;
 
     // Sync the history recorder's platform tag immediately. Subsequent
@@ -141,6 +157,29 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
                 // Setup failure: clear the flag so a follow-up
                 // update_config (e.g. the user fixing the bot dir and
                 // saving again) gets another shot at spawning.
+                started_flag.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+    }
+
+    if claim_autoplay_manager_spawn(autoplay_now_enabled, &state.autoplay_manager_started) {
+        let cfg_for_ap = state.config.clone();
+        let ctx_for_ap = state.autoplay_context.clone();
+        let tracker_for_ap = state.game_tracker.clone();
+        let mjai_for_ap = state.mjai_bus.clone();
+        let resp_for_ap = state.bot_response_bus.clone();
+        let started_flag = state.autoplay_manager_started.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(e) = crate::autoplay::run_autoplay_manager(
+                cfg_for_ap,
+                ctx_for_ap,
+                tracker_for_ap,
+                mjai_for_ap,
+                resp_for_ap,
+            )
+            .await
+            {
+                tracing::error!("Autoplay manager failed: {e:#}");
                 started_flag.store(false, std::sync::atomic::Ordering::SeqCst);
             }
         });

--- a/src/ipc/state.rs
+++ b/src/ipc/state.rs
@@ -16,6 +16,7 @@
 //! succeeded.
 
 use crate::analysis::runner::AnalysisCache;
+use crate::autoplay::AutoplayContext;
 use crate::bot::PythonRuntime;
 use crate::config::AppConfig;
 use crate::event_bus::{
@@ -105,6 +106,16 @@ pub struct AppState {
     /// finishes) without ever spawning twice. There is no off-switch:
     /// once started, the manager runs for the lifetime of the process.
     pub bot_manager_started: Arc<AtomicBool>,
+    /// Shared with the chromium capture backend (which writes the page
+    /// handle on Majsoul WS open) and the `AutoplayManager` (which reads
+    /// it to dispatch input). Always present; `enabled = false` in
+    /// config simply suppresses the manager spawn — the context still
+    /// exists so a runtime toggle works without re-plumbing.
+    pub autoplay_context: Arc<AutoplayContext>,
+    /// Set to `true` once an `AutoplayManager` has been spawned for this
+    /// process. Used by `update_config` to start the manager on a
+    /// runtime false→true flip of `autoplay.enabled` without re-spawning.
+    pub autoplay_manager_started: Arc<AtomicBool>,
 }
 
 impl AppState {
@@ -146,6 +157,8 @@ impl AppState {
             runtime,
             syncs_in_flight: Arc::new(Mutex::new(HashSet::new())),
             bot_manager_started: Arc::new(AtomicBool::new(false)),
+            autoplay_context: Arc::new(AutoplayContext::new()),
+            autoplay_manager_started: Arc::new(AtomicBool::new(false)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod analysis;
+pub mod autoplay;
 pub mod bot;
 pub mod bridge;
 pub mod capture;
@@ -108,6 +109,7 @@ pub fn run() {
     let bot_enabled = cfg.bot.enabled;
     let proxy_enabled = cfg.proxy.enabled;
     let bot_cfg = cfg.bot.clone();
+    let autoplay_enabled = cfg.autoplay.enabled;
 
     // Game-state tracker handle is built up front so AppState can carry
     // the Arc, but the consumer task is spawned inside `.setup()` once
@@ -222,6 +224,30 @@ pub fn run() {
                         .await
                         {
                             error!("Bot manager failed: {e:#}");
+                        }
+                    });
+                }
+
+                if autoplay_enabled {
+                    let cfg_for_ap = state.config.clone();
+                    let ctx_for_ap = state.autoplay_context.clone();
+                    let tracker_for_ap = state.game_tracker.clone();
+                    let mjai_for_ap = mjai_bus.clone();
+                    let resp_for_ap = bot_response_bus.clone();
+                    state
+                        .autoplay_manager_started
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = autoplay::run_autoplay_manager(
+                            cfg_for_ap,
+                            ctx_for_ap,
+                            tracker_for_ap,
+                            mjai_for_ap,
+                            resp_for_ap,
+                        )
+                        .await
+                        {
+                            error!("Autoplay manager failed: {e:#}");
                         }
                     });
                 }


### PR DESCRIPTION
## Summary

Translates bot decisions into UI clicks inside the V3-spawned Chromium browser via Chrome DevTools Protocol \`Input.dispatchMouseEvent\`. Mahjong Soul only; trait-abstracted so a Tenhou impl can drop in later. Reuses the existing chromium capture session — no new launcher / browser process.

## Highlights

- **Action availability comes from riichienv-core, not the bridge.** The autoplay reads \`GameStateLegalActions::_get_legal_actions_internal\` to know which buttons are visible and to enumerate chi/pon/kan candidate combinations. The Mahjong Soul bridge is untouched.
- **Reach two-path handling.** If the bot fills \`Reach{pai: Some(t)}\` (the V3 mjai schema extension), the autoplay does both clicks immediately. If the bot leaves \`pai: None\`, the autoplay clicks the reach button then injects a synthetic Reach event back to MjaiBus so the bot emits the riichi-declaring dahai, which the autoplay then clicks.
- **Mandatory hover before press.** Laya drops mousedown on tile sprites without a prior hover sample. \`dispatch_click\` is hand-rolled (not \`Page::click\`): \`move_mouse\` → sleep hover_delay_ms (≥100ms; default 150) → \`mousePressed\` → sleep click_hold_ms (default 50) → \`mouseReleased\`.
- **Dealer first-discard fixes.** (a) Mahjong Soul plays a hand-sort animation when the dealer gets all 14 tiles at once; clicks during it are dropped. The Dahai plan pads with \`dealer_first_discard_extra_delay_ms\` (default 2000). (b) The 14 tiles are laid continuously on the rack with no tsumohai gap; \`plan_dahai_click\` takes a separate dealer-first branch that sorts all 14 together and clicks \`TILES[idx]\` directly (no TSUMO_SPACE offset).
- **Pass-button click gated on legal_actions.** The bot emits \`none\` on every event from other players (purely informational echoes). Without a gate the autoplay would loop-click the cancel button on every other-player turn. Fix: only click the Pass button when riichienv's legal_actions contains \`ActionType::Pass\` — riichienv only adds it in \`Phase::WaitResponse\`, exactly when Mahjong Soul shows the button.

## Module layout

New \`src/autoplay/\`:
- \`context.rs\` — \`AutoplayContext { page, canvas_rect }\`. The chromium backend writes the page handle on Mahjong Soul WebSocket open (URL-filtered); autoplay reads it to dispatch input.
- \`platform.rs\` — \`PlatformAutoplay\` trait, \`ActionContext\`, \`Step\`, \`ReachState\`, \`PlanResult\`.
- \`cdp_input.rs\` — \`dispatch_click\`, \`evaluate_canvas_rect\` wrapping chromiumoxide.
- \`majsoul/coords.rs\` — 16:9 normalised \`LOCATION\` table, \`MajsoulOpType\` enum, \`get_pai_coord\`, \`action_button_pos\`, \`candidate_pos\`, \`kan_candidate_pos\`.
- \`majsoul/mod.rs\` — \`MajsoulAutoplay\` impl. Covers Dahai (with riichi suppression + dealer-first-discard layout), Reach Path A/B, Chi/Pon/Daiminkan/Ankan/Kakan with candidate disambiguation, Hora (zimo/ron via legal_actions), Ryukyoku, Kita, None.
- \`manager.rs\` — long-lived \`AutoplayManager\` task. Subscribes BotResponseBus + MjaiBus.

Modified:
- \`src/capture/chromium/cdp.rs\`, \`src/capture/chromium/mod.rs\`, \`src/capture/mod.rs\` — URL-filter Page handle into AutoplayContext; \`CaptureCtx\` carries the optional context.
- \`src/config/{mod,autoplay}.rs\` — new \`AutoplayConfig\` section.
- \`src/ipc/{state,commands,capture_supervisor}.rs\` — AppState gains autoplay context; \`update_config\` hot-spawns the manager on first false→true flip.
- \`src/lib.rs\` — module declaration + spawn at startup.
- \`Cargo.toml\` — \`rand = \"0.9\"\` for jittered pre-click delays.
- \`frontend/src/types.ts\`, \`frontend/src/routes/Settings.tsx\` — new Autoplay card with toggle + 5 number inputs.
- \`frontend/src/i18n/resources/{en,ja,zh-CN,zh-TW}.json\` — \`settings.autoplay.*\` strings.

## Test plan

- [x] \`cargo test --lib\` — 420 tests pass, including 31 new unit tests for the autoplay module:
  - Coordinate tables: tsumohai offset detection, action priority sort across all 11 ActionType combinations, chi/pon/kan candidate slot formula.
  - Plan dispatch: each MjaiEvent variant under varying \`self_riichi_accepted\` + \`reach_state\` values; reach Path A/B sequencing; dealer-first-discard layout swap and extra-delay padding; none-click gating on Pass availability.
  - Pixel translation: \`(8.0, 4.5)\` norm with \`CanvasRect{0,0,1600,900}\` → \`(800, 450)\`.
- [x] \`cargo check --tests\` clean.
- [x] \`tsc --noEmit\` clean.
- [x] All four locale JSON files validate.
- [ ] End-to-end on a live Mahjong Soul session: dealer first turn (sort animation + 14-tile layout), single dahai, chi single candidate, chi multi-candidate, riichi Path A and Path B, capture mode toggle to MITM (autoplay should warn and skip).