### PR TITLE
build: switch release pipeline to portable zip only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,10 @@ jobs:
   build:
     needs: guard
     if: ${{ always() && (needs.guard.result == 'success' || needs.guard.result == 'skipped') }}
-    name: ${{ matrix.target }} (${{ matrix.variant }})
+    name: ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
-        variant: [with-runtime, no-runtime]
         include:
           # Linux: ubuntu-22.04 keeps glibc old enough that the binaries
           # run on most user machines without forced glibc upgrades.
@@ -67,11 +65,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # Per-(target,variant) cache
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.target }}-${{ matrix.variant }}
+          shared-key: ${{ matrix.target }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -114,9 +111,9 @@ jobs:
             patchelf \
             libfuse2
 
-      # Cache fetched python + uv tarballs by version triple.
+      # Cache fetched python + uv tarballs by version triple. The runtime
+      # is shipped inside every zip, so the fetch is unconditional.
       - name: Cache bundled runtime
-        if: matrix.variant == 'with-runtime'
         uses: actions/cache@v4
         with:
           path: |
@@ -125,7 +122,6 @@ jobs:
           key: runtime-${{ matrix.target }}-py${{ env.PYTHON_VERSION }}-pbs${{ env.PBS_RELEASE }}-uv${{ env.UV_VERSION }}
 
       - name: Fetch python+uv
-        if: matrix.variant == 'with-runtime'
         shell: bash
         env:
           PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
@@ -133,45 +129,25 @@ jobs:
           UV_VERSION: ${{ env.UV_VERSION }}
         run: bash scripts/fetch-runtime.sh "${{ matrix.target }}"
 
+      # `--no-bundle` skips the (now empty) installer phase. We keep
+      # `cargo tauri build` (vs. plain `cargo build`) so the
+      # `beforeBuildCommand` in tauri.conf.json — `npm ci && npm run
+      # build` — still runs and the frontend is rebuilt fresh.
       - name: Build
         shell: bash
         env:
           NO_STRIP: '1'
-        run: cargo tauri build --target ${{ matrix.target }}
+        run: cargo tauri build --no-bundle --target ${{ matrix.target }}
 
-      # Rename outputs with the variant suffix so artifacts from both
-      # lanes can coexist in the same release. Uses `find` instead of
-      # bash globstar — macOS ships bash 3.2 which has no globstar.
-      #
-      # `-setup.exe` (not `*.exe`): NSIS drops `t32.exe`, `t64.exe`,
-      # `w32.exe`, `w64.exe` plugin/bootstrap binaries next to the main
-      # installer; only the `*-setup.exe` is the actual user-facing one.
-      - name: Collect artifacts
+      - name: Package zip
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir dist
-          OUT="target/${{ matrix.target }}/release/bundle"
-          find "$OUT" -type f \( \
-              -name '*.deb' -o \
-              -name '*.rpm' -o \
-              -name '*.AppImage' -o \
-              -name '*.dmg' -o \
-              -name '*.msi' -o \
-              -name '*-setup.exe' \
-            \) -print0 | while IFS= read -r -d '' f; do
-            base="$(basename "$f")"
-            name="${base%.*}"
-            ext="${base##*.}"
-            cp "$f" "dist/${name}-${{ matrix.variant }}.${ext}"
-          done
-          ls -la dist
+        run: bash scripts/package-zip.sh "${{ matrix.target }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: akagi-${{ matrix.target }}-${{ matrix.variant }}
-          path: dist/*
+          name: akagi-${{ matrix.target }}
+          path: dist/*.zip
           if-no-files-found: error
           retention-days: 14
 

--- a/README.md
+++ b/README.md
@@ -153,22 +153,22 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 
 ### A. Install a release
 
-Grab the latest build from
-[Releases](https://github.com/shinkuan/Akagi/releases) and pick the
-file for your OS:
+Akagi ships as a portable zip — one self-contained folder per platform.
+Download the file for your OS from
+[Releases](https://github.com/shinkuan/Akagi/releases), unzip anywhere
+you have write permission (e.g. `~/Apps/`, Desktop), and run the binary.
+Configuration, logs, history, the CA cert, and bots all live next to
+the binary, so moving / backing up / uninstalling is just moving /
+copying / deleting the folder.
 
 | OS | File | Notes |
 |---|---|---|
-| Windows | `*.msi` or `*-setup.exe` | x86_64; double-click and follow the installer. |
-| macOS | `*.dmg` | Apple Silicon (aarch64). Drag into `/Applications`. |
-| Linux | `*.AppImage` / `*.deb` / `*.rpm` | Built on `ubuntu-22.04` (glibc 2.35). |
+| Windows | `akagi-<version>-windows-x64.zip` | x86_64. Requires WebView2 (preinstalled on Win10 1803+ / Win11). SmartScreen will warn — *More info → Run anyway*. |
+| macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon. Unsigned: run `xattr -cr <unzipped folder>` once, or right-click → *Open* the first time. |
+| Linux | `akagi-<version>-linux-x64.zip` | Built on `ubuntu-22.04` (glibc 2.35+). Requires WebKit2GTK 4.1 (`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`). |
 
-Two release variants are published:
-
-- **`with-runtime`** — bundles `python-build-standalone` 3.12 + `uv`
-  (~150 MB). Bots run out of the box.
-- **`no-runtime`** — slimmer; expects a system Python 3.12 +
-  `uv` on `PATH`.
+Each zip bundles `python-build-standalone` 3.12 + `uv` next to the
+binary, so bots run out of the box without any system Python install.
 
 On first launch the **Setup wizard** walks you through language,
 platform, capture mode, optional bot install (Mortal), and CA trust
@@ -569,20 +569,25 @@ cargo run
 # Pass a custom config path
 cargo run -- --config ./my-config.toml
 
-# Release bundle (.deb / .rpm / .AppImage / .dmg / .msi / .exe)
+# Build a portable zip for the current target
 cargo install tauri-cli --locked          # if not already installed
-cargo tauri build
+bash scripts/fetch-runtime.sh             # populate runtime/<triple>/
+cargo tauri build --no-bundle             # writes target/<triple>/release/akagi
+bash scripts/package-zip.sh <target-triple>
+# → dist/akagi-<version>-<os>-<arch>.zip
 
 # Frontend dev only (Vite on :1420)
 cd frontend && npm ci && npm run dev
 ```
 
-**Optional bundled runtime**
+**Bundled runtime**
 
 `scripts/fetch-runtime.sh <target-triple>` downloads
 `python-build-standalone` 3.12 + `uv` for the target and stages them
-under `runtime/`. Tauri picks them up via `bundle.resources` so the
-shipped app works without a system Python.
+under `runtime/`. `scripts/package-zip.sh` then copies that tree next
+to the binary inside the zip; `src/bot/runtime.rs` finds it
+exe-adjacent at runtime, so the shipped app works without a system
+Python install.
 
 ## Testing
 
@@ -604,19 +609,16 @@ cargo test --release     # for the perf bench
 ## Releases & CI
 
 GitHub Actions [`release.yml`](./.github/workflows/release.yml) builds
-on tag push (`v3.*`) or manual dispatch:
+on tag push (`v3.*`) or manual dispatch. One portable zip per target:
 
-| OS runner | Targets |
-|---|---|
-| `ubuntu-22.04` (glibc 2.35) | `.deb`, `.rpm`, `.AppImage` |
-| `macos-14` (aarch64) | `.dmg` |
-| `windows-latest` | `.msi`, `-setup.exe` |
+| OS runner | Target | Artifact |
+|---|---|---|
+| `ubuntu-22.04` (glibc 2.35) | `x86_64-unknown-linux-gnu` | `akagi-<version>-linux-x64.zip` |
+| `macos-14` | `aarch64-apple-darwin` | `akagi-<version>-macos-arm64.zip` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `akagi-<version>-windows-x64.zip` |
 
-Two variants per OS:
-
-- **`with-runtime`** — bundles `python-build-standalone` 3.12 + `uv`.
-- **`no-runtime`** — slim; expects system Python 3.12 + `uv` on
-  `PATH`.
+Each zip ships `python-build-standalone` 3.12 + `uv` next to the
+binary, so bots run without a system Python install.
 
 Tags must be on the `v3` branch.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,25 +147,25 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 
 ### A. 安装官方 Release
 
+Akagi 以 portable zip 形式发布 — 每个平台一个自带所需文件的目录。
 从 [Releases](https://github.com/shinkuan/Akagi/releases) 下载
-最新版本，并按你的操作系统选择文件：
+对应操作系统的 zip,解压到任何你有写入权限的位置(例如
+`~/Apps/`、桌面),然后直接运行里面的 binary 即可。配置文件、
+日志、对局历史、CA 证书以及 bot 都会建立在 binary 旁边,所以
+迁移 / 备份 / 卸载就是迁移 / 复制 / 删除整个目录。
 
 | OS | 文件 | 备注 |
 |---|---|---|
-| Windows | `*.msi` 或 `*-setup.exe` | x86_64；双击运行安装程序即可。 |
-| macOS | `*.dmg` | Apple Silicon（aarch64）。拖入 `/Applications`。 |
-| Linux | `*.AppImage` / `*.deb` / `*.rpm` | 在 `ubuntu-22.04` 上构建（glibc 2.35）。 |
+| Windows | `akagi-<version>-windows-x64.zip` | x86_64。需要 WebView2(Win10 1803+ 与 Win11 已预装)。SmartScreen 会警告 — 点 *More info → Run anyway*。 |
+| macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未签名,解压后执行一次 `xattr -cr <解压后目录>`,或第一次右键 → *Open*。 |
+| Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上构建(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-每个版本均有两种变体：
+每个 zip 都将 `python-build-standalone` 3.12 + `uv` 一并放在
+binary 旁边,bot 开箱即用,不需要额外安装系统 Python。
 
-- **`with-runtime`** — 内置 `python-build-standalone` 3.12 +
-  `uv`（约 150 MB）。bot 开箱即用。
-- **`no-runtime`** — 更精简；需系统已安装 Python 3.12 与
-  `uv` 并能在 `PATH` 中找到。
-
-首次启动时，**配置向导** 会引导你完成语言、平台、抓包
-模式、可选的 bot 安装（Mortal）以及 CA 信任（仅 MITM
-模式才需要）。
+首次启动时,**配置向导** 会引导你完成语言、平台、抓包
+模式、可选的 bot 安装(Mortal)以及 CA 信任(仅 MITM
+模式才需要)。
 
 ### B. Chromium 模式（无需信任 CA）
 
@@ -557,26 +557,30 @@ alpha.8 已完成：
 **运行 / 构建**
 
 ```bash
-# Debug — 启动 GUI；Vite dev-server 由 Tauri 代理
+# Debug — 启动 GUI;Vite dev-server 由 Tauri 代理
 cargo run
 
 # 指定配置文件路径
 cargo run -- --config ./my-config.toml
 
-# Release bundle（.deb / .rpm / .AppImage / .dmg / .msi / .exe）
+# 为当前目标构建 portable zip
 cargo install tauri-cli --locked          # 若尚未安装
-cargo tauri build
+bash scripts/fetch-runtime.sh             # 抓取 runtime/<triple>/
+cargo tauri build --no-bundle             # 产出 target/<triple>/release/akagi
+bash scripts/package-zip.sh <target-triple>
+# → dist/akagi-<version>-<os>-<arch>.zip
 
-# 仅启动前端 dev（Vite 在 :1420）
+# 仅启动前端 dev(Vite 在 :1420)
 cd frontend && npm ci && npm run dev
 ```
 
-**可选：内置运行环境**
+**内置运行环境**
 
 `scripts/fetch-runtime.sh <target-triple>` 会下载对应目标的
-`python-build-standalone` 3.12 与 `uv`，并放置在 `runtime/`。
-Tauri 会通过 `bundle.resources` 把它们打包进去，使最终
-App 即使没有系统 Python 也能运行。
+`python-build-standalone` 3.12 与 `uv`,并放置在 `runtime/`。
+`scripts/package-zip.sh` 接着会把这个目录复制到 zip 中 binary
+旁边;`src/bot/runtime.rs` 会在运行时以 exe-adjacent 的方式
+找到它,因此最终的 App 即使用户没有系统 Python 也能运行。
 
 ## 测试
 
@@ -598,19 +602,17 @@ cargo test --release     # 用于性能 bench
 ## Releases 与 CI
 
 GitHub Actions [`release.yml`](./.github/workflows/release.yml)
-会在 tag 推送（`v3.*`）或手动触发时构建：
+会在 tag 推送(`v3.*`)或手动触发时构建,每个目标产出一个
+portable zip:
 
-| OS runner | 目标 |
-|---|---|
-| `ubuntu-22.04`（glibc 2.35） | `.deb`、`.rpm`、`.AppImage` |
-| `macos-14`（aarch64） | `.dmg` |
-| `windows-latest` | `.msi`、`-setup.exe` |
+| OS runner | 目标 | 产出文件 |
+|---|---|---|
+| `ubuntu-22.04`(glibc 2.35) | `x86_64-unknown-linux-gnu` | `akagi-<version>-linux-x64.zip` |
+| `macos-14` | `aarch64-apple-darwin` | `akagi-<version>-macos-arm64.zip` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `akagi-<version>-windows-x64.zip` |
 
-每个 OS 两种变体：
-
-- **`with-runtime`** — 内置 `python-build-standalone` 3.12 + `uv`。
-- **`no-runtime`** — 较精简；需系统已有 Python 3.12 与
-  `uv` 并能在 `PATH` 中找到。
+每个 zip 都将 `python-build-standalone` 3.12 + `uv` 一并放在
+binary 旁边,bot 不需要额外安装系统 Python 即可运行。
 
 Tag 必须位于 `v3` 分支。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -147,25 +147,25 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 
 ### A. 安裝官方 Release
 
+Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料夾。
 從 [Releases](https://github.com/shinkuan/Akagi/releases) 下載
-最新版本，並依照你的作業系統挑選檔案：
+對應作業系統的 zip,解壓縮到任何你有寫入權限的位置(例如
+`~/Apps/`、桌面),然後直接執行裡面的 binary 即可。設定檔、紀錄、
+歷史對局、CA 憑證以及 bot 都會建立在 binary 旁邊,所以搬移 /
+備份 / 解除安裝就只是搬移 / 複製 / 刪除整個資料夾。
 
 | OS | 檔案 | 備註 |
 |---|---|---|
-| Windows | `*.msi` 或 `*-setup.exe` | x86_64；雙擊執行安裝程式即可。 |
-| macOS | `*.dmg` | Apple Silicon（aarch64）。拖入 `/Applications`。 |
-| Linux | `*.AppImage` / `*.deb` / `*.rpm` | 在 `ubuntu-22.04` 上建置（glibc 2.35）。 |
+| Windows | `akagi-<version>-windows-x64.zip` | x86_64。需要 WebView2(Win10 1803+ 與 Win11 已預載)。SmartScreen 會警告 — 點 *More info → Run anyway*。 |
+| macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未簽章,解壓後執行一次 `xattr -cr <解壓後資料夾>`,或第一次右鍵 → *Open*。 |
+| Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上建置(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-每個版本皆有兩種變體：
-
-- **`with-runtime`** — 內建 `python-build-standalone` 3.12 +
-  `uv`（約 150 MB）。bot 開箱即用。
-- **`no-runtime`** — 較精簡；需系統已安裝 Python 3.12 與
-  `uv` 並可在 `PATH` 找到。
+每個 zip 都將 `python-build-standalone` 3.12 + `uv` 一併放在
+binary 旁邊,bot 開箱即用,不需另外安裝系統 Python。
 
 首次啟動時會引導你完成語言、平台、抓包
-模式、選用的 bot 安裝（Mortal）以及 CA 信任（僅 MITM
-模式才需要）。
+模式、選用的 bot 安裝(Mortal)以及 CA 信任(僅 MITM
+模式才需要)。
 
 ### B. Chromium 模式（不需信任 CA）
 
@@ -549,26 +549,30 @@ alpha.8 已完成：
 **執行 / 建置**
 
 ```bash
-# Debug — 啟動 GUI；Vite dev-server 由 Tauri 代理
+# Debug — 啟動 GUI;Vite dev-server 由 Tauri 代理
 cargo run
 
 # 指定設定檔路徑
 cargo run -- --config ./my-config.toml
 
-# Release bundle（.deb / .rpm / .AppImage / .dmg / .msi / .exe）
+# 為當前目標建置 portable zip
 cargo install tauri-cli --locked          # 若尚未安裝
-cargo tauri build
+bash scripts/fetch-runtime.sh             # 抓取 runtime/<triple>/
+cargo tauri build --no-bundle             # 產出 target/<triple>/release/akagi
+bash scripts/package-zip.sh <target-triple>
+# → dist/akagi-<version>-<os>-<arch>.zip
 
-# 僅啟動前端 dev（Vite 在 :1420）
+# 僅啟動前端 dev(Vite 在 :1420)
 cd frontend && npm ci && npm run dev
 ```
 
-**選用：內建執行環境**
+**內建執行環境**
 
 `scripts/fetch-runtime.sh <target-triple>` 會下載對應目標的
-`python-build-standalone` 3.12 與 `uv`，並放置於 `runtime/`。
-Tauri 會透過 `bundle.resources` 把它們納入打包，使最終
-App 即使沒有系統 Python 也能運作。
+`python-build-standalone` 3.12 與 `uv`,並放置於 `runtime/`。
+`scripts/package-zip.sh` 接著會把這個目錄複製到 zip 內的
+binary 旁邊;`src/bot/runtime.rs` 在執行時會用 exe-adjacent
+方式找到它,因此最終的 App 即使使用者沒有系統 Python 也能運作。
 
 ## 測試
 
@@ -590,19 +594,17 @@ cargo test --release     # 用於效能 bench
 ## Releases 與 CI
 
 GitHub Actions [`release.yml`](./.github/workflows/release.yml)
-會在 tag 推送（`v3.*`）或手動觸發時建置：
+會在 tag 推送(`v3.*`)或手動觸發時建置,每個目標產出一個
+portable zip:
 
-| OS runner | 目標 |
-|---|---|
-| `ubuntu-22.04`（glibc 2.35） | `.deb`、`.rpm`、`.AppImage` |
-| `macos-14`（aarch64） | `.dmg` |
-| `windows-latest` | `.msi`、`-setup.exe` |
+| OS runner | 目標 | 產出檔案 |
+|---|---|---|
+| `ubuntu-22.04`(glibc 2.35) | `x86_64-unknown-linux-gnu` | `akagi-<version>-linux-x64.zip` |
+| `macos-14` | `aarch64-apple-darwin` | `akagi-<version>-macos-arm64.zip` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `akagi-<version>-windows-x64.zip` |
 
-每個 OS 兩種變體：
-
-- **`with-runtime`** — 內附 `python-build-standalone` 3.12 + `uv`。
-- **`no-runtime`** — 較精簡；需系統已有 Python 3.12 與
-  `uv` 並可在 `PATH` 找到。
+每個 zip 都將 `python-build-standalone` 3.12 + `uv` 一併放在
+binary 旁邊,bot 不需另外安裝系統 Python 即可運作。
 
 Tag 必須位於 `v3` 分支。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,71 @@
+# scripts/
+
+Build / release / protocol-update tooling. Each script is invoked from
+the repo root.
+
+## `fetch-runtime.sh`
+
+Downloads `python-build-standalone` and `uv` for a target triple, into
+`runtime/python/<triple>/` and `runtime/uv/<triple>/`. Idempotent —
+re-running with the same versions is a no-op (`--force` to wipe and
+re-fetch).
+
+```sh
+scripts/fetch-runtime.sh                         # host triple
+scripts/fetch-runtime.sh x86_64-pc-windows-msvc  # cross-target
+```
+
+Versions come from env vars (`PYTHON_VERSION`, `PBS_RELEASE`,
+`UV_VERSION`) with built-in defaults. CI sets them via the `env:` block
+at the top of `.github/workflows/release.yml`.
+
+The `runtime/` tree is gitignored. Each per-triple subtree caches under
+the same key in CI (`Cache bundled runtime` step), so a second run on
+the same target hits the cache and skips network entirely.
+
+## `package-zip.sh`
+
+Stages a portable zip in `dist/akagi-<version>-<os>-<arch>.zip` from a
+prebuilt binary plus the fetched runtime tree.
+
+```sh
+scripts/package-zip.sh x86_64-unknown-linux-gnu
+```
+
+Prerequisites:
+
+- The binary exists at `target/<triple>/release/akagi[.exe]`. Produce it
+  with `cargo tauri build --no-bundle --target <triple>` (or plain
+  `cargo build --release --target <triple>` if you already ran the
+  frontend build separately).
+- `runtime/python/<triple>/` and `runtime/uv/<triple>/` are populated by
+  `fetch-runtime.sh`.
+
+Outputs a single zip named `akagi-<version>-<os>-<arch>.zip` containing
+a top-level folder of the same name with the binary, `runtime/`,
+`LICENSE.txt`, `NOTICE`, and a generated `README.txt` with
+platform-specific quick-start notes (Gatekeeper xattr on macOS,
+SmartScreen on Windows, WebKit2GTK package names on Linux).
+
+The version is parsed from the first `version = "..."` line of
+`Cargo.toml` (the `[package]` table is the first table, so this is
+unambiguous).
+
+Symlink preservation matters: `python-build-standalone` ships internal
+symlinks (`bin/python3.12 → bin/python`). `cp -RP` and `zip -y` are
+used so the zip stays small (~half the size of a flattened copy).
+
+## `fetch_liqi.py`
+
+Polled daily by `.github/workflows/auto-liqi.yml`. Fetches the latest
+Mahjong Soul `liqi.json` schema from the game CDN and exposes
+`changed=true/false` as a GHA output. The workflow then regenerates
+`src/bridge/majsoul/proto/liqi.proto` via `pbjs` and opens a PR on `v3`
+when the schema moved.
+
+## CI integration
+
+`.github/workflows/release.yml` ties `fetch-runtime.sh` and
+`package-zip.sh` together: fetch → `cargo tauri build --no-bundle` →
+package → upload `dist/*.zip`. One zip per target (linux-x64,
+macos-arm64, windows-x64).

--- a/scripts/fetch-runtime.sh
+++ b/scripts/fetch-runtime.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # Fetch python-build-standalone + uv for a target triple and drop them
-# into <repo-root>/runtime/{python,uv}/<triple>/ so the Tauri bundler
-# (and `cargo tauri dev`) ships them as resources. `try_bundled` in
-# src/bot/runtime.rs picks them up via `resource_dir/runtime/...`.
+# into <repo-root>/runtime/{python,uv}/<triple>/. `scripts/package-zip.sh`
+# copies that tree next to the binary in the portable zip; `try_bundled`
+# in src/bot/runtime.rs then picks it up exe-adjacent at runtime.
 #
 # Usage:
 #   scripts/fetch-runtime.sh                         # host triple

--- a/scripts/package-zip.sh
+++ b/scripts/package-zip.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Package a portable zip for the given target triple.
+#
+# Layout:
+#   dist/akagi-<version>-<os>-<arch>.zip
+#     akagi-<version>-<os>-<arch>/
+#       akagi[.exe]
+#       runtime/python/<triple>/...
+#       runtime/uv/<triple>/...
+#       LICENSE.txt
+#       NOTICE
+#       README.txt
+#
+# Usage:
+#   scripts/package-zip.sh <target-triple>
+#
+# Prerequisites:
+#   1. Binary built into target/<triple>/release/akagi[.exe]
+#      (e.g. via `cargo tauri build --no-bundle --target <triple>`)
+#   2. Runtime fetched into runtime/{python,uv}/<triple>/
+#      (e.g. via `scripts/fetch-runtime.sh <triple>`)
+#
+# Reads the package version from the first `version = "..."` line in
+# Cargo.toml — that's the [package] version because [package] is the
+# first table.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <target-triple>" >&2
+  exit 2
+fi
+
+TARGET="$1"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="$(grep -m1 '^version = ' "$ROOT/Cargo.toml" | cut -d'"' -f2)"
+
+case "$TARGET" in
+  x86_64-unknown-linux-gnu) OS=linux;   ARCH=x64;   EXE=akagi ;;
+  aarch64-apple-darwin)     OS=macos;   ARCH=arm64; EXE=akagi ;;
+  x86_64-pc-windows-msvc)   OS=windows; ARCH=x64;   EXE=akagi.exe ;;
+  *)
+    echo "unknown target triple: $TARGET" >&2
+    exit 2
+    ;;
+esac
+
+PKG="akagi-${VERSION}-${OS}-${ARCH}"
+STAGE_ROOT="$ROOT/dist/staging"
+STAGE="$STAGE_ROOT/$PKG"
+ARCHIVE="$ROOT/dist/${PKG}.zip"
+
+BIN_SRC="$ROOT/target/$TARGET/release/$EXE"
+PY_SRC="$ROOT/runtime/python/$TARGET"
+UV_SRC="$ROOT/runtime/uv/$TARGET"
+
+if [[ ! -f "$BIN_SRC" ]]; then
+  echo "binary not found at $BIN_SRC — run cargo build / tauri build first" >&2
+  exit 1
+fi
+if [[ ! -d "$PY_SRC" ]] || [[ ! -d "$UV_SRC" ]]; then
+  echo "runtime tree missing — run scripts/fetch-runtime.sh $TARGET first" >&2
+  exit 1
+fi
+
+rm -rf "$STAGE"
+mkdir -p "$STAGE/runtime/python" "$STAGE/runtime/uv"
+
+cp "$BIN_SRC" "$STAGE/$EXE"
+if [[ "$OS" != "windows" ]]; then
+  chmod +x "$STAGE/$EXE"
+fi
+
+# -RP preserves symlinks (python-build-standalone uses internal symlinks
+# like bin/python3.12 -> bin/python on linux/mac; without -P they get
+# duplicated and the zip nearly doubles).
+cp -RP "$PY_SRC" "$STAGE/runtime/python/$TARGET"
+cp -RP "$UV_SRC" "$STAGE/runtime/uv/$TARGET"
+
+cp "$ROOT/LICENSE.txt" "$STAGE/LICENSE.txt"
+cp "$ROOT/NOTICE"      "$STAGE/NOTICE"
+
+cat > "$STAGE/README.txt" <<EOF
+Akagi $VERSION — portable build ($OS-$ARCH)
+
+Quick start
+-----------
+1. Move this folder anywhere you have write permission (e.g. ~/Apps/, Desktop, etc.).
+2. Run the binary:
+     Linux/macOS:  ./akagi
+     Windows:      akagi.exe
+3. On first launch, Akagi creates these directories alongside the binary:
+     config.toml   logs/   history/   ca/   mjai_bot/
+
+Platform notes
+--------------
+EOF
+
+case "$OS" in
+  windows)
+    cat >> "$STAGE/README.txt" <<'EOF'
+- WebView2 runtime is required. Windows 10 1803+ and Windows 11 ship it
+  by default; older systems can install it from
+  https://developer.microsoft.com/microsoft-edge/webview2/
+- The binary is unsigned, so SmartScreen will warn on first launch.
+  Click "More info" then "Run anyway".
+EOF
+    ;;
+  macos)
+    cat >> "$STAGE/README.txt" <<EOF
+- The binary is unsigned. macOS Gatekeeper will block the first launch.
+  Either run once with the quarantine bit removed:
+    xattr -cr "\$(pwd)/$PKG"
+  or right-click the binary and choose "Open" the first time.
+- Apple Silicon only — no Intel build.
+EOF
+    ;;
+  linux)
+    cat >> "$STAGE/README.txt" <<'EOF'
+- Built on ubuntu-22.04, requires glibc 2.35 or newer.
+- Requires WebKit2GTK 4.1:
+    Debian/Ubuntu:  apt install libwebkit2gtk-4.1-0
+    Fedora:         dnf install webkit2gtk4.1
+    Arch:           pacman -S webkit2gtk-4.1
+EOF
+    ;;
+esac
+
+cat >> "$STAGE/README.txt" <<'EOF'
+
+Full documentation: https://github.com/shinkuan/AkagiV3
+EOF
+
+# Pick a zip tool. windows-latest GHA runners ship 7z but not zip;
+# linux/macos runners (and most user shells) ship the `zip` command.
+mkdir -p "$ROOT/dist"
+rm -f "$ARCHIVE"
+
+if [[ "$OS" == "windows" ]]; then
+  # 7z preserves the directory tree and is faster than PowerShell's
+  # Compress-Archive on this many small files.
+  (cd "$STAGE_ROOT" && 7z a -tzip -mx=5 "$ARCHIVE" "$PKG/" >/dev/null)
+else
+  # -y preserves the symlinks inside the python-build-standalone tree.
+  (cd "$STAGE_ROOT" && zip -r -y -9 "$ARCHIVE" "$PKG/" >/dev/null)
+fi
+
+echo "wrote $ARCHIVE"

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -2,13 +2,16 @@
 //!
 //! Two modes:
 //!
-//! - **Bundled**: `<resource_dir>/runtime/python/<triple>/...` and
-//!   `<resource_dir>/runtime/uv/<triple>/uv` are shipped inside the Tauri
-//!   resource bundle. This is what end users get from a packaged build —
-//!   zero Python install required.
+//! - **Bundled**: `runtime/python/<triple>/...` and `runtime/uv/<triple>/uv`
+//!   ship next to the binary in the portable zip distribution. The locator
+//!   checks the exe-adjacent layout first; the Tauri-managed
+//!   `app.path().resource_dir()` is checked as a secondary fallback so
+//!   `cargo run` from a checkout (and any future Tauri-bundled target) keeps
+//!   working. Zero Python install required for end users.
 //! - **System**: `python3` and `uv` are looked up on `PATH` via the `which`
-//!   crate. Used during development (`cargo run` from a checkout) and as a
-//!   graceful fallback if the bundled binaries are missing.
+//!   crate. Used during development (`cargo run` from a checkout without a
+//!   populated `runtime/`) and as a graceful fallback if the bundled
+//!   binaries are missing.
 //!
 //! Per-bot venvs live under `<bot_dir>/.akagi/venv` so they don't clash with
 //! a developer's own `.venv` if they happen to keep one in the bot folder.
@@ -52,9 +55,20 @@ impl PythonRuntime {
 
     /// Locate bundled binaries first, then fall back to system PATH.
     ///
-    /// `resource_dir` is the Tauri-managed resource path (e.g.
-    /// `app.path().resource_dir()`); pass `None` outside Tauri.
+    /// Lookup order:
+    /// 1. **Exe-adjacent**: `<exe_parent>/runtime/{python,uv}/<triple>/...` —
+    ///    this is the portable zip layout users get from Releases.
+    /// 2. **Resource dir**: the Tauri-managed `app.path().resource_dir()` —
+    ///    secondary fallback so `cargo run` and any future Tauri-bundled
+    ///    install (`/usr/lib/akagi/`, `.app/Contents/Resources/`) keep
+    ///    working.
+    /// 3. **System PATH**: `python3` and `uv` resolved via the `which` crate.
+    ///
+    /// Pass `None` for `resource_dir` outside Tauri (tests, CLI tools).
     pub fn locate(resource_dir: Option<&Path>) -> Result<Self> {
+        if let Some(rt) = try_bundled_exe_adjacent() {
+            return Ok(rt);
+        }
         if let Some(rd) = resource_dir {
             if let Some(rt) = try_bundled(rd) {
                 return Ok(rt);
@@ -186,6 +200,21 @@ pub async fn reset_sync_state(bot_dir: &Path) {
     let akagi = bot_dir.join(AKAGI_DIR);
     let _ = tokio::fs::remove_file(akagi.join(STAMP_FILE)).await;
     let _ = tokio::fs::remove_dir_all(akagi.join(VENV_DIR)).await;
+}
+
+/// Look for the bundled runtime in the directory containing the running
+/// executable. This is the layout shipped by the portable zip
+/// distribution: `<exe_parent>/runtime/{python,uv}/<triple>/...`.
+///
+/// On Linux/macOS, `tauri::path::resource_dir()` does not return
+/// exe-adjacent paths in a portable layout — it tries Tauri-bundled
+/// install locations like `/usr/lib/akagi/` and returns `Err` or a
+/// non-existent path otherwise. Checking exe-adjacent here ensures the
+/// portable zip works without depending on Tauri's resource resolution.
+fn try_bundled_exe_adjacent() -> Option<PythonRuntime> {
+    let exe = std::env::current_exe().ok()?;
+    let exe_dir = exe.parent()?;
+    try_bundled(exe_dir)
 }
 
 fn try_bundled(resource_dir: &Path) -> Option<PythonRuntime> {
@@ -440,6 +469,17 @@ mod tests {
     fn try_bundled_returns_none_when_runtime_dir_empty() {
         let tmp = TempDir::new().unwrap();
         assert!(try_bundled(tmp.path()).is_none());
+    }
+
+    /// Regression: portable zip relies on `try_bundled_exe_adjacent` to
+    /// find `<exe_parent>/runtime/...` because Tauri's `resource_dir()`
+    /// doesn't return exe-adjacent on Linux/macOS in a portable layout.
+    /// In the test runner the binary lives in `target/<profile>/deps/`
+    /// with no `runtime/` next to it, so this must return `None` (and
+    /// must not panic on the optional chain).
+    #[test]
+    fn try_bundled_exe_adjacent_returns_none_when_runtime_missing() {
+        assert!(try_bundled_exe_adjacent().is_none());
     }
 
     /// Regression: AppImage runtimes export `PYTHONHOME` / `PYTHONPATH`

--- a/src/capture/README.md
+++ b/src/capture/README.md
@@ -61,14 +61,20 @@ Lazy create on first frame, ref-count clean-up on close.
 
 ## Path conventions
 
-For data the backend writes at runtime (Chromium profile, future
+For data the backend writes at runtime (Chromium profile, downloaded
 Chrome-for-Testing install, etc.):
 
-- Use `crate::util::user_subdir(name)` — always returns
-  `<user_config_root>/<name>` (XDG on Linux, Application Support on
-  macOS, AppData\Roaming on Windows).
-- Do **not** use `crate::util::resolve_dir` — its exe-dir-first
-  fallback is wrong for AppImage (read-only squashfs).
+- Use `crate::util::resolve_dir(Path::new("./<name>"))` — exe-adjacent
+  first, with an AppImage / user-config fallback baked in. This keeps
+  the portable zip distribution single-folder: the chrome profile and
+  the downloaded CfT browser sit next to the binary alongside `logs/`,
+  `history/`, `ca/`, `mjai_bot/`, so moving / backing up / removing the
+  app is one folder operation.
+- `crate::util::user_subdir(name)` is still available for callers that
+  *must* use the OS user-config dir regardless of where the binary
+  lives. None of the capture code currently needs that — `resolve_dir`
+  already routes to user-config under AppImage and similar read-only
+  mounts.
 
 ## Phasing
 

--- a/src/capture/chromium/cft.rs
+++ b/src/capture/chromium/cft.rs
@@ -2,14 +2,15 @@
 //!
 //! Lets users without a system Chrome install one on demand from
 //! Google's official CfT distribution. Avoids bundling a ~150MB browser
-//! in the Akagi installer; downloads are runtime-only into the user's
-//! config dir, never the read-only AppImage squashfs.
+//! with the Akagi binary; downloads are runtime-only into a
+//! `chrome-for-testing/` directory next to the binary (or the user
+//! config dir as a fallback — see [`install_root`]).
 //!
 //! Manifest URLs (Google):
 //! - All versions: <https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json>
 //! - Channel pins: <https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json>
 //!
-//! Install layout under `<user_config_root>/chrome-for-testing/<version>/`:
+//! Install layout under `<install_root>/<version>/`:
 //! - Linux: `chrome-linux64/chrome`
 //! - macOS: `chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`
 //!   (or `chrome-mac-x64/...` on Intel)
@@ -75,10 +76,16 @@ pub fn cft_platform() -> Option<&'static str> {
     }
 }
 
-/// Top-level CfT install dir: `<user_config_root>/chrome-for-testing/`.
+/// Top-level CfT install dir.
+///
+/// Resolved via [`crate::util::resolve_dir`] so a portable zip keeps the
+/// downloaded browser next to the binary (single-folder install). On
+/// AppImage / read-only mounts the resolver falls back to
+/// `<user_config_root>/chrome-for-testing/`.
 pub fn install_root() -> Result<PathBuf> {
-    crate::util::user_subdir("chrome-for-testing")
-        .ok_or_else(|| anyhow!("could not resolve user config dir"))
+    Ok(crate::util::resolve_dir(Path::new(
+        "./chrome-for-testing",
+    )))
 }
 
 /// Per-version install dir: `<install_root>/<version>/`.

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -17,9 +17,11 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
 /// Resolve the user-data-dir path for the controlled Chromium instance.
-/// `configured` empty → `<user_config_root>/chrome-profile`. Otherwise
-/// `configured` is treated as an absolute path (relative paths are not
-/// supported here — there's no meaningful root for them).
+/// `configured` empty → exe-adjacent `chrome-profile/` via
+/// [`crate::util::resolve_dir`], so a portable zip keeps everything
+/// (config, logs, profile) in one folder. Otherwise `configured` is
+/// treated as an absolute path (relative paths are not supported here
+/// — there's no meaningful root for them).
 pub fn resolve_profile_dir(configured: &str) -> Result<PathBuf> {
     if !configured.is_empty() {
         let p = PathBuf::from(configured);
@@ -30,8 +32,7 @@ pub fn resolve_profile_dir(configured: &str) -> Result<PathBuf> {
         }
         return Ok(p);
     }
-    crate::util::user_subdir("chrome-profile")
-        .ok_or_else(|| anyhow!("could not resolve user config dir for chrome profile"))
+    Ok(crate::util::resolve_dir(Path::new("./chrome-profile")))
 }
 
 /// Detect and clear `SingletonLock` / `SingletonSocket` / `SingletonCookie`
@@ -177,9 +178,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_default_uses_user_subdir() {
+    fn resolve_default_lands_at_chrome_profile() {
         let p = resolve_profile_dir("").unwrap();
-        // ends with chrome-profile, regardless of OS-specific prefix
+        // ends with chrome-profile regardless of which arm of resolve_dir
+        // fired (exe-adjacent on portable, user_root on AppImage).
         assert!(
             p.ends_with("chrome-profile"),
             "expected ending in chrome-profile: {}",

--- a/src/config/capture.rs
+++ b/src/config/capture.rs
@@ -28,7 +28,9 @@ pub enum CaptureMode {
 pub struct ChromiumConfig {
     /// Absolute path to a chrome/chromium binary. `""` = auto-detect.
     pub executable: String,
-    /// User-data-dir for the controlled profile. `""` = `<user_config_root>/chrome-profile`.
+    /// User-data-dir for the controlled profile. `""` = exe-adjacent
+    /// `chrome-profile/` (resolved via `util::resolve_dir`, with an
+    /// AppImage / read-only fallback to `<user_config_root>/chrome-profile`).
     pub user_data_dir: String,
     /// URL to navigate to on launch. `""` = don't auto-navigate (open new tab page).
     pub start_url: String,

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -27,8 +27,8 @@
     ]
   },
   "bundle": {
-    "active": true,
-    "targets": "all",
+    "active": false,
+    "targets": [],
     "icon": [
       "icons/32x32.png",
       "icons/64x64.png",
@@ -36,14 +36,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "resources": [
-      "runtime/**/*"
-    ],
-    "linux": {
-      "rpm": {
-        "compression": { "type": "gzip", "level": 1 }
-      }
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the rpm/deb/AppImage/MSI/dmg/.app installer matrix with one portable zip per platform: `akagi-<version>-<os>-<arch>.zip`. Users unzip anywhere they have write permission and run the binary.
- Closes #99 — the Fedora 43 RPM bug where `/usr/bin/{history,ca,mjai_bot}` were being created. Same latent bug existed on Windows MSI (`Program Files`) and macOS `.app` (signed bundle dir).
- Required runtime-locator change: `tauri::path::resource_dir()` does not return exe-adjacent on Linux/macOS in a portable layout (Linux tries `/usr/lib/akagi`; macOS tries `<exe_dir>/../Resources` and returns `Err` if `canonicalize` fails). `src/bot/runtime.rs` now checks `<exe_parent>/runtime/...` first before falling back to the resource dir.
- Drops the `no-runtime` CI variant — the portable zip always ships `python-build-standalone` 3.12 + `uv` next to the binary.

## Files

| File | Change |
|---|---|
| `src/bot/runtime.rs` | New `try_bundled_exe_adjacent()`; `PythonRuntime::locate` checks exe-adjacent first, then resource_dir, then PATH. New regression test. |
| `tauri.conf.json` | `bundle.active: false`, `bundle.targets: []`. Dropped `bundle.resources` and `bundle.linux.rpm`. Kept `bundle.icon`. |
| `scripts/package-zip.sh` (new) | Stages `dist/akagi-<version>-<os>-<arch>.zip` from `target/<triple>/release/akagi[.exe]` + `runtime/<triple>/`. Symlink-preserving `cp -RP` and `zip -y` so python-build-standalone's internal symlinks stay symlinks. |
| `scripts/README.md` (new) | Module README. |
| `scripts/fetch-runtime.sh` | Updated header doc comment to reflect the new flow. |
| `.github/workflows/release.yml` | Dropped the `with-runtime / no-runtime` axis (6 jobs → 3); replaced installer collection step with `scripts/package-zip.sh`; build now `cargo tauri build --no-bundle`. |
| `README.md`, `README.zh-CN.md`, `README.zh-TW.md` | Install table → one zip per platform with caveats (WebView2 / `xattr -cr` / WebKit2GTK). Build section + CI matrix table updated. |

## Verification

Local Linux smoke test — all pass criteria from the design doc met:

- `NO_STRIP=1 cargo tauri build --no-bundle --target x86_64-unknown-linux-gnu` — clean build, no bundle phase ran (confirms `--no-bundle` + `bundle.active: false` work in tauri-cli 2.10.1).
- `bash scripts/package-zip.sh x86_64-unknown-linux-gnu` — staged layout correct, symlinks preserved (`bin/python3 -> python3.12`), version parsed from Cargo.toml.
- Copied staged dir to a fresh `/tmp/tmp.*/`, ran `./akagi`. Logs:
  ```
  bot runtime: python=/tmp/.../runtime/python/x86_64-unknown-linux-gnu/bin/python3
               uv=/tmp/.../runtime/uv/x86_64-unknown-linux-gnu/uv
               mode=Bundled
  ```
- `history/`, `ca/`, `logs/`, `configs/` all created exe-adjacent inside the unzipped folder. **No `/usr/bin/` writes.**
- `cargo test --lib` — 421/421 pass, including the new `try_bundled_exe_adjacent_returns_none_when_runtime_missing` regression test.

`zip` is preinstalled on `ubuntu-22.04` and `macos-14` GHA runners; `windows-latest` uses `7z` (preinstalled). Local users on minimal distros may need to install `zip` (documented in `scripts/README.md`).

## Test plan

- [ ] Trigger `release.yml` via `workflow_dispatch` with `publish_release: false`.
- [ ] All 3 matrix jobs green.
- [ ] Each artifact contains exactly one `akagi-<version>-<os>-<arch>.zip` (3 zips total, down from 6 mixed installers).
- [ ] Download `akagi-x86_64-pc-windows-msvc` artifact, unzip on Windows host: `akagi.exe` launches, frontend loads, `mode=Bundled` in log.
- [ ] Download `akagi-aarch64-apple-darwin` artifact, unzip on Apple Silicon Mac (after `xattr -cr`): `akagi` launches, frontend loads, `mode=Bundled` in log.

## Out of scope (deferred)

- macOS code signing / notarization.
- Auto-update (`tauri-plugin-updater`).
- `x86_64-apple-darwin` (Intel macOS).
- Removing AppImage branches in `src/util/mod.rs` / `src/config/mod.rs` — kept as harmless dead code so AppImage can be revived later.
- Bundling WebView2 fixed runtime on Windows — documented requirement instead (Win10 1803+ / Win11 ship it).