### PR TITLE
fix(capture): unmute CDP Chromium by default

### DIFF
--- a/src/capture/chromium/launch.rs
+++ b/src/capture/chromium/launch.rs
@@ -34,8 +34,7 @@ pub fn spawn(exe: &Path, profile: &Path, cfg: &ChromiumConfig) -> Result<Child> 
         .arg("--disable-background-networking")
         .arg("--disable-sync")
         .arg("--metrics-recording-only")
-        .arg("--no-pings")
-        .arg("--mute-audio");
+        .arg("--no-pings");
     if cfg!(target_os = "linux") {
         // Chromium occasionally crashes on Linux when /dev/shm is small (e.g. Docker).
         cmd.arg("--disable-dev-shm-usage");


### PR DESCRIPTION
Closes #101.

## Summary
- The default flag chain in `src/capture/chromium/launch.rs` unconditionally appended `--mute-audio`, leaving the CDP-controlled Chromium silent — Mahjong Soul BGM, tile-draw / discard SFX, riichi declaration, and call sounds were all suppressed. This was especially wrong for the v3 autoplay flow where the user is actively watching the same window.
- `ChromiumConfig.extra_args` only appends after defaults, and Chromium has no `--no-mute-audio` negation, so end users could not turn audio back on without editing source.
- Drop the flag from the defaults. Anyone who genuinely wants the old silent behavior can set `capture.chromium.extra_args = ["--mute-audio"]` in their config — that opt-in path already exists and is unchanged.

## Test plan
- [x] `cargo test --lib` — 421/421 pass (no count change; no existing test asserted the flag list).
- [ ] End-to-end: set `capture.mode = "chromium"`, launch Akagi, navigate to Mahjong Soul, confirm BGM and in-match SFX are audible.
- [ ] Opt-out check: set `capture.chromium.extra_args = ["--mute-audio"]` and confirm sound is silenced again — proves the override path still works for callers that relied on the old behavior.