### PR TITLE
fix: autoplay seat caching and kita opening hand guard

### DIFF
--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -145,6 +145,15 @@ impl PlatformAutoplay for MajsoulAutoplay {
             // ----- Kita (3p 北抜き) ----------------------------------------
             MjaiEvent::Kita { actor, .. } if *actor == ctx.our_seat => {
                 push_random_pre_delay(&mut result.steps, ctx);
+                // On the opening draw of a kyoku (no kawa tile yet), add the
+                // same extra delay used for dealer first discard. Majsoul plays
+                // a tile-dealing animation after the previous kyoku ends; clicks
+                // issued during it land on the wrong target.
+                if ctx.last_kawa_tile.is_none() && ctx.cfg.dealer_first_discard_extra_delay_ms > 0 {
+                    result.steps.push(Step::Sleep {
+                        duration_ms: ctx.cfg.dealer_first_discard_extra_delay_ms,
+                    });
+                }
                 if let Some(button) = action_button_for(MajsoulOpType::Nukidora, ctx) {
                     result.steps.push(Step::Click {
                         x_norm: button.0,
@@ -591,6 +600,7 @@ mod tests {
                 double_riichi: false,
                 riichi_declaration_index: None,
                 kita_tiles: Vec::new(),
+                drawn_tile: None,
             })
             .collect();
         GameStateSnapshot {

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -49,6 +49,12 @@ struct ManagerState {
     self_riichi_accepted: bool,
     reach_state: ReachState,
     canvas_rect_at: Option<Instant>,
+    /// Cached seat index for our player. Captured directly from
+    /// `StartGame { id }` and kept across kyoku resets. Avoids try_lock
+    /// failures in the synchronous mjai event handler causing missed
+    /// tsumo/dahai updates, and is available from the very first event
+    /// rather than waiting for the first successful `handle_bot_response`.
+    cached_our_seat: Option<u8>,
 }
 
 impl Default for ReachState {
@@ -122,6 +128,8 @@ impl AutoplayManager {
                 Some(s) => s,
                 None => return, // game hasn't started or no perspective tagged
             };
+            // Keep cached_our_seat up to date for handle_mjai_event.
+            self.state.cached_our_seat = Some(our_seat);
             let snapshot = match tracker.snapshot() {
                 Some(s) => s,
                 None => return,
@@ -239,15 +247,27 @@ impl AutoplayManager {
 
     fn handle_mjai_event(&mut self, ev: &MjaiEvent) {
         match ev {
-            MjaiEvent::StartGame { .. } | MjaiEvent::EndGame => {
+            MjaiEvent::StartGame { id, .. } => {
+                // Capture our seat directly from the StartGame event rather
+                // than going through the tracker. This avoids the try_lock
+                // race entirely and makes cached_our_seat available from the
+                // very first event of the game.
+                let seat = *id;
+                self.state = ManagerState::default();
+                self.state.cached_our_seat = seat;
+            }
+            MjaiEvent::EndGame => {
                 self.state = ManagerState::default();
             }
             MjaiEvent::StartKyoku { .. } | MjaiEvent::EndKyoku => {
-                // Per-kyoku reset: keep last seen rect cache, drop
-                // everything else.
+                // Per-kyoku reset: keep last seen rect cache and cached seat,
+                // drop everything else. Keep last_kawa_tile as None so
+                // push_random_pre_delay uses the max delay (opening-hand guard).
                 let canvas_at = self.state.canvas_rect_at;
+                let cached_seat = self.state.cached_our_seat;
                 self.state = ManagerState::default();
                 self.state.canvas_rect_at = canvas_at;
+                self.state.cached_our_seat = cached_seat;
             }
             MjaiEvent::Tsumo { actor, pai } => {
                 if let Some(seat) = self.our_seat_cached() {
@@ -286,12 +306,11 @@ impl AutoplayManager {
         }
     }
 
-    /// Best-effort seat lookup that avoids blocking on the tracker mutex
-    /// inside the mjai event handler (which runs synchronously in the
-    /// select arm). Falls back to `None` if the lock is contended;
-    /// missing the seat once is harmless, the next event will catch up.
+    /// Best-effort seat lookup. Uses the cached seat from `StartGame` first,
+    /// falling back to try_lock on the tracker.
     fn our_seat_cached(&self) -> Option<u8> {
-        self.tracker.try_lock().ok().and_then(|t| t.our_seat())
+        self.state.cached_our_seat
+            .or_else(|| self.tracker.try_lock().ok().and_then(|t| t.our_seat()))
     }
 
     async fn canvas_rect_resolve(&mut self) -> Option<CanvasRect> {
@@ -332,5 +351,3 @@ pub async fn run_autoplay_manager(
 ) -> anyhow::Result<()> {
     AutoplayManager::new(cfg, ctx, tracker, mjai_bus).run(response_bus).await
 }
-
-

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -351,3 +351,117 @@ pub async fn run_autoplay_manager(
 ) -> anyhow::Result<()> {
     AutoplayManager::new(cfg, ctx, tracker, mjai_bus).run(response_bus).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::autoplay::context::AutoplayContext;
+    use crate::event_bus::mjai_bus;
+    use crate::game_state::tracker;
+
+    /// Build a minimal `AutoplayManager` suitable for unit-testing
+    /// `handle_mjai_event`. No CDP page, no config — just enough to
+    /// exercise the mjai event handler without touching async resources.
+    fn make_manager() -> AutoplayManager {
+        let bus = mjai_bus();
+        let tracker = tracker::new_handle();
+        AutoplayManager::new(
+            Arc::new(RwLock::new(AppConfig::default())),
+            Arc::new(AutoplayContext::default()),
+            tracker,
+            bus,
+        )
+    }
+
+    /// Regression: `cached_our_seat` must be populated immediately when
+    /// `StartGame` is received, before any bot response fires. Previously
+    /// the seat was only cached inside `handle_bot_response`, so the first
+    /// `Tsumo` event on the opening draw could arrive before the bot had
+    /// responded and `last_self_tsumo` would be silently missed.
+    #[test]
+    fn start_game_sets_cached_seat_immediately() {
+        let mut m = make_manager();
+
+        // Before any event — no seat cached.
+        assert!(m.state.cached_our_seat.is_none());
+
+        // StartGame with id = Some(1) — seat must be cached right away.
+        m.handle_mjai_event(&MjaiEvent::StartGame {
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            kyoku_first: None,
+            aka_flag: None,
+            id: Some(1),
+            num_players: 4,
+        });
+        assert_eq!(m.state.cached_our_seat, Some(1), "seat must be cached from StartGame");
+
+        // A Tsumo by our seat (1) before any bot response should be recorded.
+        m.handle_mjai_event(&MjaiEvent::Tsumo {
+            actor: 1,
+            pai: "3m".into(),
+        });
+        assert_eq!(
+            m.state.last_self_tsumo.as_deref(),
+            Some("3m"),
+            "last_self_tsumo must be recorded even before first bot response"
+        );
+    }
+
+    /// Seat is preserved across `StartKyoku` and `EndKyoku` resets so
+    /// tsumo tracking continues to work from the first draw of each round.
+    #[test]
+    fn cached_seat_survives_kyoku_reset() {
+        let mut m = make_manager();
+
+        m.handle_mjai_event(&MjaiEvent::StartGame {
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            kyoku_first: None,
+            aka_flag: None,
+            id: Some(2),
+            num_players: 4,
+        });
+        assert_eq!(m.state.cached_our_seat, Some(2));
+
+        m.handle_mjai_event(&MjaiEvent::StartKyoku {
+            bakaze: "E".into(),
+            dora_marker: "1m".into(),
+            kyoku: 1,
+            honba: 0,
+            kyotaku: 0,
+            oya: 0,
+            scores: vec![25_000; 4],
+            tehais: vec![vec!["1m".into(); 13]; 4],
+            num_players: 4,
+        });
+        assert_eq!(m.state.cached_our_seat, Some(2), "seat must survive StartKyoku reset");
+
+        m.handle_mjai_event(&MjaiEvent::EndKyoku);
+        assert_eq!(m.state.cached_our_seat, Some(2), "seat must survive EndKyoku reset");
+    }
+
+    /// Observer/replay mode: `StartGame` with `id: None` must not cache a
+    /// stale seat from a previous game.
+    #[test]
+    fn start_game_without_id_clears_cached_seat() {
+        let mut m = make_manager();
+
+        m.handle_mjai_event(&MjaiEvent::StartGame {
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            kyoku_first: None,
+            aka_flag: None,
+            id: Some(0),
+            num_players: 4,
+        });
+        assert_eq!(m.state.cached_our_seat, Some(0));
+
+        // New game, observer mode — no seat.
+        m.handle_mjai_event(&MjaiEvent::StartGame {
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            kyoku_first: None,
+            aka_flag: None,
+            id: None,
+            num_players: 4,
+        });
+        assert!(m.state.cached_our_seat.is_none(), "stale seat must be cleared");
+    }
+}


### PR DESCRIPTION
1. Autoplay seat lookup race condition (manager.rs)
handle_mjai_event runs synchronously in the tokio::select! arm and previously called tracker.try_lock() to get the player seat. Under contention this returned None, causing last_self_tsumo and last_kawa_tile to be missed for that event.
Fix: ManagerState now captures cached_our_seat directly from StartGame { id } in handle_mjai_event, eliminating the tracker lookup entirely. The seat is available from the very first event of the game rather than waiting for the first successful handle_bot_response. StartKyoku/EndKyoku preserve it across kyoku resets.

2. Kita opening hand guard (majsoul/mod.rs)
When last_kawa_tile is None (no tile has been discarded yet this kyoku), kita now adds dealer_first_discard_extra_delay_ms of extra delay before the button click. Majsoul plays a tile-dealing animation at the start of each kyoku; clicks issued during it land on the wrong target.