### PR TITLE
fix: correct 3p ron honba to 200 pts; populate kita_tiles for accurate kita han scoring

### DIFF
--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -244,29 +244,29 @@ mod tests {
 fn evaluate_hora_3p_honba_ron_is_200_per_stick() {
     use riichienv_core::rule::GameRule;
     use riichienv_core::state_3p::GameState3P;
-    
-    let rule = GameRule::default_tenhou();
-    let mut s = GameState3P::new(0, true, None, 0, rule);
-    s.oya = 1; // non-dealer wins
-    s.honba = 1;
-    // Chiitoitsu hand for seat 0: 11m 22m 33p 44p 66s 77s + 8s wait
-    let hand = vec![36, 37, 40, 41, 44, 45, 48, 49, 56, 57, 60, 61, 64, 65];
-    s.players[0].hand = hand;
-    s.last_discard = Some((2, 65)); // seat 2 discards 8p
 
-    let no_honba = {
-        let mut s2 = GameState3P::new(0, true, None, 0, rule);
-        s2.oya = 1;
-        s2.honba = 0;
-        s2.players[0].hand = vec![36, 37, 40, 41, 44, 45, 48, 49, 56, 57, 60, 61, 64, 65];
-        s2.last_discard = Some((2, 65));
-        evaluate_hora_3p(&s2, 0, false).expect("winning shape")
+    let rule = GameRule::default_tenhou();
+
+    let make_state = |honba: u8| {
+        let mut s = GameState3P::new(0, true, None, 0, rule);
+        s.oya = 1;
+        s.honba = honba;
+        // Chiitoitsu: 11p 22p 33p 44p 66p 77p tenpai on 8p
+        // 136-space: 1p=36,37 2p=40,41 3p=44,45 4p=48,49 6p=56,57 7p=60,61
+        // win tile 8p = tile 64 (second copy = 65, but keep out of hand)
+        s.players[0].hand = vec![36, 37, 40, 41, 44, 45, 48, 49, 56, 57, 60, 61, 64];
+        s.last_discard = Some((2, 65)); // seat 2 discards second 8p
+        s
     };
-    let with_honba = evaluate_hora_3p(&s, 0, false).expect("winning shape");
-    
+
+    let s0 = make_state(0u8);
+    let s1 = make_state(1u8);
+    let no_honba = evaluate_hora_3p(&s0, 0, false).expect("winning shape");
+    let with_honba = evaluate_hora_3p(&s1, 0, false).expect("winning shape");
+
     let diff = with_honba.points as i32 - no_honba.points as i32;
     println!("no_honba={} with_honba={} diff={}", no_honba.points, with_honba.points, diff);
-    assert_eq!(diff, 200);
+    assert_eq!(diff, 200, "3p ron honba must be 200 per stick");
 }
 
     /// Build a closed-hand GameState where seat `actor` is in chiitoitsu

--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -197,7 +197,11 @@ pub fn evaluate_hora_3p(state: &GameState3P, actor: u8, is_tsumo: bool) -> Optio
             result.tsumo_agari_oya.saturating_add(result.tsumo_agari_ko)
         }
     } else {
-        result.ron_agari
+        // Majsoul sanma uses 200 per honba for ron, not the standard 300.
+        // evaluator.calc() bakes in honba*300 into ron_agari regardless of
+        // num_players — subtract the excess 100 per honba to match Majsoul.
+        let honba_correction = state.honba as u32 * 100;
+        result.ron_agari.saturating_sub(honba_correction)
     };
     Some(HoraScoreInfo {
         points,
@@ -236,6 +240,34 @@ pub fn is_tenpai(hand_text: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+fn evaluate_hora_3p_honba_ron_is_200_per_stick() {
+    use riichienv_core::rule::GameRule;
+    use riichienv_core::state_3p::GameState3P;
+    
+    let rule = GameRule::default_tenhou();
+    let mut s = GameState3P::new(0, true, None, 0, rule);
+    s.oya = 1; // non-dealer wins
+    s.honba = 1;
+    // Chiitoitsu hand for seat 0: 11m 22m 33p 44p 66s 77s + 8s wait
+    let hand = vec![36, 37, 40, 41, 44, 45, 48, 49, 56, 57, 60, 61, 64, 65];
+    s.players[0].hand = hand;
+    s.last_discard = Some((2, 65)); // seat 2 discards 8p
+
+    let no_honba = {
+        let mut s2 = GameState3P::new(0, true, None, 0, rule);
+        s2.oya = 1;
+        s2.honba = 0;
+        s2.players[0].hand = vec![36, 37, 40, 41, 44, 45, 48, 49, 56, 57, 60, 61, 64, 65];
+        s2.last_discard = Some((2, 65));
+        evaluate_hora_3p(&s2, 0, false).expect("winning shape")
+    };
+    let with_honba = evaluate_hora_3p(&s, 0, false).expect("winning shape");
+    
+    let diff = with_honba.points as i32 - no_honba.points as i32;
+    println!("no_honba={} with_honba={} diff={}", no_honba.points, with_honba.points, diff);
+    assert_eq!(diff, 200);
+}
 
     /// Build a closed-hand GameState where seat `actor` is in chiitoitsu
     /// tenpai for `8s` (tile id 100, 34-space index 25). Used by the

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -129,6 +129,11 @@ impl GameTracker {
         } else {
             None
         };
+        let kita_patch = if let AkagiEvent::Kita { actor, .. } = ev {
+            Some(*actor as usize)
+        } else {
+            None
+        };
 
         let Some(ri) = convert::to_riichienv(ev)? else {
             return Ok(()); // Skipped (e.g. MjaiEvent::None).
@@ -169,6 +174,11 @@ impl GameTracker {
                         }
                     }
                     apply_ippatsu_patch_3p(s, ev);
+                    if let Some(actor) = kita_patch {
+                        if let Some(p) = s.players.get_mut(actor) {
+                            p.kita_tiles.push(0u8); // value unused; kita_count = len()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
**3p honba is 200 pts**
In standard sanma, honba on ron should add 200 points (2 players × 100), not the 4p standard of 300 points (3 players × 100). This matches both Mahjong Soul and Tenhou sanma rules, and is consistent with how riichienv_core::score::calculate_score already handles 3p honba correctly.
However, HandEvaluator::calc — the path used in evaluate_hora_3p — bakes in 300 per honba into ron_agari regardless of player count. evaluate_hora_3p now subtracts the excess 100 per honba after the fact to correct this.
Tsumo honba is unaffected — 3p tsumo honba naturally totals 200 per stick (2 players × 100) which riichienv already handles correctly.
Verified against a captured Mahjong Soul sanma mjai log: 3 han 40 fu non-dealer ron with 1 honba correctly displays 7900 (7700 base + 200 honba) instead of the previous 8000.
A regression test (evaluate_hora_3p_honba_ron_is_200_per_stick) is included.

**Kita han not counted in score display**
riichienv-core's apply_mjai_event for Kita removes the North tile from the player's hand but does not populate player.kita_tiles. Since evaluate_hora_3p reads player.kita_tiles.len() to set kita_count in the scoring conditions, kita han was silently dropped from the score calculation — a hand with 2 kita would score as if it had 0.
GameTracker::handle now manually pushes a sentinel entry to kita_tiles after each Kita event is applied, mirroring the existing patch for discard_from_hand. The value is unused; only the length matters for kita_count.
Verified: an 8 han hand (riichi + menzen tsumo + 3 dora + red five + 2 kita) now correctly displays as baiman (16000) instead of haneman (12000).