### PR TITLE
feat(updater): in-app GitHub release checker + self-replace install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,16 @@ dependencies = [
  "rand 0.9.4",
  "reqwest",
  "riichienv-core",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -318,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -669,6 +682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +802,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -939,8 +967,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1851,6 +1890,15 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite",
  "tracing",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -3724,7 +3772,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
@@ -4003,6 +4051,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,7 +4256,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4208,7 +4267,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4614,7 +4684,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -6339,7 +6409,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ dirs = "6"
 chromiumoxide = "0.9.1"
 ulid = { version = "1", features = ["serde"] }
 rand = "0.9"
+self-replace = "1"
+semver = "1"
+sha2 = "0.11"
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
   Live switch from Setup or the Sidebar. Full coverage across the UI.
 - **Sanma (3-player)** — full pipeline: bridge, tracker, snapshot,
   analysis, per-mode bot routing, history stats, 3p uma tables.
+- **In-app updates** — checks the GitHub releases endpoint on launch
+  (cached for 6 hours) and on demand from *Settings → Updates*. A
+  bounded toast plus a red dot next to the sidebar version surface a
+  new release; the dialog offers *Update now* (downloads the matching
+  zip, SHA-256-verifies it, swaps the binary in place via
+  `self_replace`, then restarts), *Skip this version*, *Later*, or
+  *Open release page*. Read-only installs (e.g. AppImage) fall back to
+  the release page automatically.
 
 ## Supported Platforms
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from '@/components/sidebar/Sidebar'
 import { Statusbar } from '@/components/Statusbar'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Toaster } from '@/components/ui/sonner'
+import { UpdateNotifier } from '@/components/UpdateNotifier'
 import { useTauriBridge } from '@/hooks/useTauriBridge'
 import { useSidebar } from '@/hooks/useSidebar'
 import { useUiPrefsStore } from '@/stores/uiPrefsStore'
@@ -52,6 +53,7 @@ export default function App() {
         <Statusbar />
       </main>
       <Toaster />
+      <UpdateNotifier />
     </>
   )
 }

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -1,0 +1,112 @@
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { openExternal } from '@/lib/external'
+import { selectHasNotifiableUpdate, useUpdaterStore } from '@/stores/updaterStore'
+
+/// Modal dialog for the in-app update flow. Opened by the sidebar
+/// red-dot click, the "View details" toast action, or the Settings
+/// "Update available" button. Footer actions match the four user
+/// choices (Update now / Skip / Later / Open release page).
+export function UpdateDialog() {
+  const { t } = useTranslation()
+  const open = useUpdaterStore((s) => s.dialogOpen)
+  const closeDialog = useUpdaterStore((s) => s.closeDialog)
+  const pending = useUpdaterStore((s) => s.pendingUpdate)
+  const applying = useUpdaterStore((s) => s.applying)
+  const applyUpdate = useUpdaterStore((s) => s.applyUpdate)
+  const skip = useUpdaterStore((s) => s.skip)
+  const hasNotifiable = useUpdaterStore(selectHasNotifiableUpdate)
+
+  // Closing the dialog without any pending update is a no-op; mount-state
+  // is intentionally driven entirely by the store so other components
+  // (sidebar / settings) can trigger it without prop drilling.
+  if (!pending) return null
+
+  const handleUpdate = async () => {
+    const err = await applyUpdate()
+    // On success applyUpdate never returns (backend restart). Only
+    // failures land here.
+    if (!err) return
+    const fallback = () => openExternal(pending.html_url)
+    switch (err.kind) {
+      case 'read_only_install':
+        toast.error(t('updates.dialog.error_read_only'), {
+          action: { label: t('updates.dialog.open_release'), onClick: fallback },
+        })
+        break
+      case 'unsupported_platform':
+        toast.error(t('updates.dialog.error_unsupported_platform'), {
+          action: { label: t('updates.dialog.open_release'), onClick: fallback },
+        })
+        break
+      case 'no_matching_asset':
+        toast.error(t('updates.dialog.error_no_matching_asset'), {
+          action: { label: t('updates.dialog.open_release'), onClick: fallback },
+        })
+        break
+      case 'digest_mismatch':
+        toast.error(t('updates.dialog.error_digest_mismatch'), {
+          action: { label: t('updates.dialog.open_release'), onClick: fallback },
+        })
+        break
+      default:
+        toast.error(t('updates.dialog.error_generic', { message: err.message }))
+    }
+  }
+
+  return (
+    <Dialog open={open && hasNotifiable} onOpenChange={(v) => !v && closeDialog()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('updates.dialog.title', { version: pending.latest_version })}</DialogTitle>
+          <DialogDescription>{t('updates.dialog.runtime_caveat')}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2 max-h-[50vh] overflow-y-auto">
+          <h3 className="text-sm font-semibold text-muted-foreground">
+            {t('updates.dialog.notes_heading')}
+          </h3>
+          {/* Plain pre-formatted text. We don't pull a markdown renderer
+              for this single use — release notes are short and the
+              monospace block reads fine. */}
+          <pre className="whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed font-mono">
+            {pending.body.trim() || t('updates.dialog.no_notes')}
+          </pre>
+        </div>
+        <DialogFooter className="bg-transparent p-0 border-0 mx-0 mb-0 flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openExternal(pending.html_url)}
+            disabled={applying}
+          >
+            {t('updates.dialog.open_release')}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => skip(pending.latest_tag)}
+            disabled={applying}
+          >
+            {t('updates.dialog.skip')}
+          </Button>
+          <Button variant="secondary" size="sm" onClick={closeDialog} disabled={applying}>
+            {t('updates.dialog.later')}
+          </Button>
+          <Button size="sm" onClick={handleUpdate} disabled={applying}>
+            {applying ? t('updates.dialog.applying') : t('updates.dialog.update_now')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/UpdateNotifier.tsx
+++ b/frontend/src/components/UpdateNotifier.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { selectHasNotifiableUpdate, useUpdaterStore } from '@/stores/updaterStore'
+import { HAS_TAURI } from '@/lib/tauri'
+import { UpdateDialog } from '@/components/UpdateDialog'
+
+/// Invisible coordinator. Mount it once near the root of the tree.
+///
+/// Responsibilities:
+///   1. Kick off a (cached) `check_for_update` ~3 seconds after mount,
+///      but only when the user has auto-check enabled and we aren't
+///      already inside the 6-hour throttle window.
+///   2. When a new, non-skipped update arrives, fire a single sonner
+///      toast per session with a "View details" action that opens the
+///      `<UpdateDialog />`.
+///   3. Host the `<UpdateDialog />` so it can be opened from anywhere.
+export function UpdateNotifier() {
+  const { t } = useTranslation()
+  const autoCheckEnabled = useUpdaterStore((s) => s.autoCheckEnabled)
+  const checkNow = useUpdaterStore((s) => s.checkNow)
+  const openDialog = useUpdaterStore((s) => s.openDialog)
+  const markToastShown = useUpdaterStore((s) => s.markToastShown)
+  const toastShown = useUpdaterStore((s) => s.toastShownThisSession)
+  const pending = useUpdaterStore((s) => s.pendingUpdate)
+  const hasNotifiable = useUpdaterStore(selectHasNotifiableUpdate)
+
+  // 3s deferred auto-check on launch — keeps the startup path cold-cache-fast
+  // and gives the rest of the app time to mount before we render a toast.
+  useEffect(() => {
+    if (!HAS_TAURI || !autoCheckEnabled) return
+    const id = window.setTimeout(() => {
+      void checkNow(false)
+    }, 3000)
+    return () => window.clearTimeout(id)
+    // checkNow is stable (zustand action) — listing it would just churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoCheckEnabled])
+
+  // Fire the toast exactly once per app session, when a notifiable
+  // pending update appears. `markToastShown` guards against re-firing
+  // after route changes that re-mount this component.
+  useEffect(() => {
+    if (!hasNotifiable || !pending || toastShown) return
+    toast.info(t('updates.toast.title', { version: pending.latest_version }), {
+      duration: 10_000,
+      action: {
+        label: t('updates.toast.action'),
+        onClick: openDialog,
+      },
+    })
+    markToastShown()
+    // openDialog/markToastShown are stable zustand actions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasNotifiable, pending, toastShown, t])
+
+  return <UpdateDialog />
+}

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ChevronLeft } from 'lucide-react'
+import { getVersion } from '@tauri-apps/api/app'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -13,8 +15,15 @@ import {
 import { useSidebar } from '@/hooks/useSidebar'
 import { GithubMark, DiscordMark } from '@/components/BrandMarks'
 import { AKAGI_GITHUB_URL, AKAGI_DISCORD_URL, openExternal } from '@/lib/external'
+import { HAS_TAURI } from '@/lib/tauri'
 import { LANG_LABELS, SUPPORTED_LANGS, type SupportedLang } from '@/i18n'
+import { selectHasNotifiableUpdate, useUpdaterStore } from '@/stores/updaterStore'
 import { Menu } from './Menu'
+
+// Fallback used in the browser dev preview (no Tauri runtime → no
+// app.getVersion). Lines up with Cargo.toml so devs see a sensible
+// string until the real version resolves.
+const VERSION_FALLBACK = '3.0.11'
 
 export function Sidebar() {
   const { t, i18n } = useTranslation()
@@ -23,6 +32,13 @@ export function Sidebar() {
   const setIsHover = useSidebar((s) => s.setIsHover)
   const isHover = useSidebar((s) => s.isHover)
   const settings = useSidebar((s) => s.settings)
+  const hasUpdate = useUpdaterStore(selectHasNotifiableUpdate)
+  const openUpdateDialog = useUpdaterStore((s) => s.openDialog)
+  const [version, setVersion] = useState(VERSION_FALLBACK)
+  useEffect(() => {
+    if (!HAS_TAURI) return
+    getVersion().then(setVersion).catch(() => {})
+  }, [])
   // `open` includes the transient hover-open state. Only `isOpen` (pinned)
   // affects main content margin in App.tsx — hover-open expands the sidebar
   // visually as an overlay above main, so width-sensitive widgets like
@@ -108,7 +124,28 @@ export function Sidebar() {
         </div>
         {open && (
           <div className="mt-2 shrink-0 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-            <span>v3.0.11</span>
+            <button
+              type="button"
+              onClick={hasUpdate ? openUpdateDialog : undefined}
+              className={cn(
+                'flex items-center gap-1.5 rounded px-1 py-0.5',
+                hasUpdate
+                  ? 'cursor-pointer hover:text-foreground'
+                  : 'cursor-default',
+              )}
+              aria-label={
+                hasUpdate ? t('updates.toast.action') : undefined
+              }
+              disabled={!hasUpdate}
+            >
+              <span>v{version}</span>
+              {hasUpdate && (
+                <span
+                  className="inline-block h-1.5 w-1.5 rounded-full bg-red-500"
+                  aria-hidden="true"
+                />
+              )}
+            </button>
             <select
               className="bg-transparent border border-border rounded px-1.5 py-0.5"
               value={i18n.language}

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -510,5 +510,41 @@
     "tenhou_desc": "tenhou.net — yonma + sanma",
     "riichi_city": "Riichi City",
     "mjai": "mjai"
+  },
+  "updates": {
+    "toast": {
+      "title": "Akagi {{version}} is available",
+      "action": "View details"
+    },
+    "dialog": {
+      "title": "Update available: Akagi {{version}}",
+      "notes_heading": "Release notes",
+      "no_notes": "No release notes were provided.",
+      "update_now": "Update now",
+      "skip": "Skip this version",
+      "later": "Later",
+      "open_release": "Open release page",
+      "applying": "Downloading and applying…",
+      "runtime_caveat": "Auto-update swaps the binary in place. If the bundled Python runtime changed in this release the app may misbehave — reinstall from the release page in that case.",
+      "error_read_only": "Akagi can't write to its install directory. Open the release page to update manually.",
+      "error_unsupported_platform": "Auto-update is not available for your platform. Open the release page to download manually.",
+      "error_no_matching_asset": "This release has no build for your platform yet.",
+      "error_digest_mismatch": "Downloaded file doesn't match the release checksum. Try again or download manually.",
+      "error_generic": "Update failed: {{message}}"
+    },
+    "settings": {
+      "title": "Updates",
+      "current": "Current version",
+      "check_now": "Check for updates",
+      "checking": "Checking…",
+      "up_to_date": "You're on the latest version.",
+      "last_checked": "Last checked: {{when}}",
+      "never_checked": "Never checked",
+      "auto_check": "Check for updates on launch",
+      "available": "Update available: {{version}}",
+      "skipped_label": "Skipped version",
+      "clear_skipped": "Clear skipped version",
+      "none_skipped": "None"
+    }
   }
 }

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -510,5 +510,41 @@
     "tenhou_desc": "tenhou.net — 四麻 + 三麻",
     "riichi_city": "麻雀一番街",
     "mjai": "mjai"
+  },
+  "updates": {
+    "toast": {
+      "title": "Akagi {{version}} が利用可能です",
+      "action": "詳細を見る"
+    },
+    "dialog": {
+      "title": "更新あり: Akagi {{version}}",
+      "notes_heading": "リリースノート",
+      "no_notes": "リリースノートはありません。",
+      "update_now": "今すぐ更新",
+      "skip": "このバージョンをスキップ",
+      "later": "後で",
+      "open_release": "リリースページを開く",
+      "applying": "ダウンロードして適用中…",
+      "runtime_caveat": "自動更新は実行ファイルのみを置き換えます。このリリースで同梱の Python ランタイムも更新されている場合、更新後にアプリが正常に動作しないことがあります。その場合はリリースページから手動で再インストールしてください。",
+      "error_read_only": "Akagi のインストールディレクトリに書き込めません。リリースページから手動で更新してください。",
+      "error_unsupported_platform": "お使いのプラットフォームは自動更新に対応していません。リリースページからダウンロードしてください。",
+      "error_no_matching_asset": "このリリースにはお使いのプラットフォーム用のビルドがまだありません。",
+      "error_digest_mismatch": "ダウンロードしたファイルのチェックサムがリリース情報と一致しません。再試行するか手動でダウンロードしてください。",
+      "error_generic": "更新に失敗しました: {{message}}"
+    },
+    "settings": {
+      "title": "更新",
+      "current": "現在のバージョン",
+      "check_now": "更新を確認",
+      "checking": "確認中…",
+      "up_to_date": "最新バージョンです。",
+      "last_checked": "最終確認: {{when}}",
+      "never_checked": "未確認",
+      "auto_check": "起動時に自動で更新を確認",
+      "available": "更新あり: {{version}}",
+      "skipped_label": "スキップ済みバージョン",
+      "clear_skipped": "スキップを解除",
+      "none_skipped": "なし"
+    }
   }
 }

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -510,5 +510,41 @@
     "tenhou_desc": "tenhou.net — 四麻 + 三麻",
     "riichi_city": "麻雀一番街",
     "mjai": "mjai"
+  },
+  "updates": {
+    "toast": {
+      "title": "Akagi {{version}} 已发布",
+      "action": "查看详情"
+    },
+    "dialog": {
+      "title": "有新版本可用：Akagi {{version}}",
+      "notes_heading": "版本说明",
+      "no_notes": "此版本未提供说明。",
+      "update_now": "立即更新",
+      "skip": "跳过此版本",
+      "later": "稍后",
+      "open_release": "打开发布页",
+      "applying": "下载并应用中…",
+      "runtime_caveat": "自动更新只替换可执行文件。如果此版本同时更新了内置 Python 环境，更新后 app 可能无法正常工作 — 此情况请到发布页手动重新安装。",
+      "error_read_only": "Akagi 没有权限写入安装目录。请到发布页手动下载更新。",
+      "error_unsupported_platform": "您的平台目前不支持自动更新。请到发布页手动下载。",
+      "error_no_matching_asset": "此版本尚未提供您平台的可执行文件。",
+      "error_digest_mismatch": "下载文件的校验码与发布信息不符，请重试或手动下载。",
+      "error_generic": "更新失败：{{message}}"
+    },
+    "settings": {
+      "title": "更新",
+      "current": "当前版本",
+      "check_now": "检查更新",
+      "checking": "检查中…",
+      "up_to_date": "已是最新版本。",
+      "last_checked": "最后检查：{{when}}",
+      "never_checked": "尚未检查过",
+      "auto_check": "启动时自动检查更新",
+      "available": "有可用更新：{{version}}",
+      "skipped_label": "已跳过的版本",
+      "clear_skipped": "清除跳过记录",
+      "none_skipped": "无"
+    }
   }
 }

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -510,5 +510,41 @@
     "tenhou_desc": "tenhou.net — 四麻 + 三麻",
     "riichi_city": "麻雀一番街",
     "mjai": "mjai"
+  },
+  "updates": {
+    "toast": {
+      "title": "Akagi {{version}} 已釋出",
+      "action": "查看詳情"
+    },
+    "dialog": {
+      "title": "有新版本可用：Akagi {{version}}",
+      "notes_heading": "版本說明",
+      "no_notes": "此版本沒有提供說明。",
+      "update_now": "立即更新",
+      "skip": "跳過此版本",
+      "later": "稍後",
+      "open_release": "開啟發佈頁面",
+      "applying": "下載並安裝中…",
+      "runtime_caveat": "自動更新只替換執行檔。若此版本同時更新了內建 Python 環境，更新後 app 可能無法正常運作 — 此情況請至發佈頁面手動重新安裝。",
+      "error_read_only": "Akagi 沒有權限寫入安裝目錄。請至發佈頁面手動下載更新。",
+      "error_unsupported_platform": "您的平台目前不支援自動更新。請至發佈頁面手動下載。",
+      "error_no_matching_asset": "此版本尚未提供您平台的執行檔。",
+      "error_digest_mismatch": "下載檔案的校驗碼與發佈資訊不符，請重試或手動下載。",
+      "error_generic": "更新失敗：{{message}}"
+    },
+    "settings": {
+      "title": "更新",
+      "current": "目前版本",
+      "check_now": "檢查更新",
+      "checking": "檢查中…",
+      "up_to_date": "已是最新版本。",
+      "last_checked": "最後檢查：{{when}}",
+      "never_checked": "尚未檢查過",
+      "auto_check": "啟動時自動檢查更新",
+      "available": "有可用更新：{{version}}",
+      "skipped_label": "已跳過的版本",
+      "clear_skipped": "清除跳過記錄",
+      "none_skipped": "無"
+    }
   }
 }

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link, useBlocker } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { getVersion } from '@tauri-apps/api/app'
+import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -21,10 +23,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { invoke } from '@/lib/tauri'
+import { HAS_TAURI, invoke } from '@/lib/tauri'
+import { openExternal } from '@/lib/external'
 import { useSidebar } from '@/hooks/useSidebar'
 import { useCaptureStore } from '@/stores/captureStore'
 import { useConfigStore } from '@/stores/configStore'
+import { selectHasNotifiableUpdate, useUpdaterStore } from '@/stores/updaterStore'
 import {
   SCALE_DEFAULT,
   SCALE_MAX,
@@ -240,6 +244,8 @@ export function Settings() {
       </Card>
 
       <AutoplayCard draft={draft} setDraft={setDraft} />
+
+      <UpdatesCard />
 
       <Dialog
         open={blocker.state === 'blocked'}
@@ -1029,5 +1035,127 @@ function CftPanel({
         </ul>
       )}
     </div>
+  )
+}
+
+function UpdatesCard() {
+  const { t, i18n } = useTranslation()
+  const autoCheckEnabled = useUpdaterStore((s) => s.autoCheckEnabled)
+  const setAutoCheckEnabled = useUpdaterStore((s) => s.setAutoCheckEnabled)
+  const lastChecked = useUpdaterStore((s) => s.lastChecked)
+  const skippedVersion = useUpdaterStore((s) => s.skippedVersion)
+  const clearSkipped = useUpdaterStore((s) => s.clearSkipped)
+  const checkNow = useUpdaterStore((s) => s.checkNow)
+  const checking = useUpdaterStore((s) => s.checking)
+  const pending = useUpdaterStore((s) => s.pendingUpdate)
+  const hasNotifiable = useUpdaterStore(selectHasNotifiableUpdate)
+  const openDialog = useUpdaterStore((s) => s.openDialog)
+
+  const [currentVersion, setCurrentVersion] = useState('—')
+  useEffect(() => {
+    if (!HAS_TAURI) return
+    getVersion().then(setCurrentVersion).catch(() => {})
+  }, [])
+
+  const handleCheck = async () => {
+    const before = useUpdaterStore.getState().pendingUpdate?.latest_tag ?? null
+    await checkNow(true)
+    const after = useUpdaterStore.getState().pendingUpdate
+    if (!after) {
+      toast.success(t('updates.settings.up_to_date'))
+    } else if (after.latest_tag !== before) {
+      // New release surfaced for the first time this session — let the
+      // existing UpdateNotifier toast logic handle it instead of toasting
+      // twice. If it's the same release we already knew about, the
+      // explicit click deserves a one-shot acknowledgement.
+    } else {
+      toast.info(
+        t('updates.settings.available', { version: after.latest_version }),
+        {
+          action: { label: t('updates.toast.action'), onClick: openDialog },
+        },
+      )
+    }
+  }
+
+  const lastCheckedLabel = lastChecked
+    ? t('updates.settings.last_checked', {
+        when: new Date(lastChecked).toLocaleString(i18n.language),
+      })
+    : t('updates.settings.never_checked')
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('updates.settings.title')}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <Field label={t('updates.settings.current')}>
+          <div className="flex items-center gap-2">
+            <span className="font-mono">v{currentVersion}</span>
+            {hasNotifiable && pending && (
+              <Button
+                size="sm"
+                variant="default"
+                onClick={openDialog}
+                className="h-7"
+              >
+                {t('updates.settings.available', {
+                  version: pending.latest_version,
+                })}
+              </Button>
+            )}
+          </div>
+        </Field>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">{lastCheckedLabel}</span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCheck}
+            disabled={checking || !HAS_TAURI}
+          >
+            {checking ? t('updates.settings.checking') : t('updates.settings.check_now')}
+          </Button>
+        </div>
+        <Toggle
+          label={t('updates.settings.auto_check')}
+          value={autoCheckEnabled}
+          onChange={setAutoCheckEnabled}
+        />
+        <Field label={t('updates.settings.skipped_label')}>
+          <div className="flex items-center justify-between">
+            <span className="text-sm">
+              {skippedVersion ?? t('updates.settings.none_skipped')}
+            </span>
+            {skippedVersion && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  clearSkipped()
+                  toast.success(
+                    t('updates.settings.clear_skipped') + ': ' + skippedVersion,
+                  )
+                }}
+              >
+                {t('updates.settings.clear_skipped')}
+              </Button>
+            )}
+          </div>
+        </Field>
+        {pending && (
+          <div className="flex items-center justify-end">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => openExternal(pending.html_url)}
+            >
+              {t('updates.dialog.open_release')}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/src/stores/updaterStore.ts
+++ b/frontend/src/stores/updaterStore.ts
@@ -1,0 +1,158 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { invoke } from '@/lib/tauri'
+
+/// Mirrors `crate::updater::check::UpdateInfo` on the Rust side. The
+/// shape is fixed by the IPC contract — keep both ends in sync.
+export type UpdateInfo = {
+  current: string
+  latest_tag: string
+  latest_version: string
+  body: string
+  html_url: string
+  asset_name: string
+  asset_url: string
+  asset_size: number
+  asset_digest_sha256: string | null
+}
+
+/// Mirrors `crate::updater::error::UpdateError`. The `kind` tag is what
+/// frontend code switches on to decide between a generic "Update failed"
+/// toast and a fallback that opens the release page.
+export type UpdateError =
+  | { kind: 'unsupported_platform' }
+  | { kind: 'read_only_install'; path: string }
+  | { kind: 'digest_mismatch' }
+  | { kind: 'no_matching_asset' }
+  | { kind: 'other'; message: string }
+
+const CHECK_CACHE_MS = 6 * 60 * 60 * 1000
+
+/// Frontend-only persisted state. The Rust side intentionally has no
+/// knowledge of `skippedVersion` / `autoCheckEnabled` — they're user
+/// preferences and don't gate any backend behavior.
+type Persisted = {
+  lastChecked: number | null
+  skippedVersion: string | null
+  autoCheckEnabled: boolean
+}
+
+type Ephemeral = {
+  /// Result of the most recent `check_for_update`. NOT persisted — we
+  /// always re-fetch on launch (subject to the 6h cache) so a release
+  /// that was deleted / unpublished doesn't keep nagging.
+  pendingUpdate: UpdateInfo | null
+  /// `true` while `apply_update` is in flight. Used to disable the
+  /// "Update now" button and show a spinner.
+  applying: boolean
+  /// `true` after the auto-check toast has fired this session. Stops
+  /// the toast from re-firing when `<UpdateNotifier />` re-mounts on
+  /// a route change.
+  toastShownThisSession: boolean
+  /// Open state for the `<UpdateDialog />`. The sidebar red-dot and the
+  /// toast's "View details" action both flip this to true.
+  dialogOpen: boolean
+  /// `true` while a `check_for_update` call is in flight. Used by the
+  /// Settings page to disable the button + show a spinner.
+  checking: boolean
+}
+
+type Actions = {
+  checkNow: (force?: boolean) => Promise<void>
+  applyUpdate: () => Promise<UpdateError | null>
+  skip: (version: string) => void
+  clearSkipped: () => void
+  setAutoCheckEnabled: (enabled: boolean) => void
+  openDialog: () => void
+  closeDialog: () => void
+  markToastShown: () => void
+}
+
+export type UpdaterStore = Persisted & Ephemeral & Actions
+
+const initialEphemeral: Ephemeral = {
+  pendingUpdate: null,
+  applying: false,
+  toastShownThisSession: false,
+  dialogOpen: false,
+  checking: false,
+}
+
+export const useUpdaterStore = create<UpdaterStore>()(
+  persist(
+    (set, get) => ({
+      lastChecked: null,
+      skippedVersion: null,
+      autoCheckEnabled: true,
+      ...initialEphemeral,
+
+      checkNow: async (force = false) => {
+        if (get().checking) return
+        if (!force) {
+          const last = get().lastChecked ?? 0
+          if (Date.now() - last < CHECK_CACHE_MS) return
+        }
+        set({ checking: true })
+        try {
+          const info = await invoke<UpdateInfo | null>('check_for_update')
+          set({ pendingUpdate: info, lastChecked: Date.now() })
+        } catch (e) {
+          // Network / parse failures: just log; the toast layer will
+          // see `pendingUpdate === null` and stay quiet. Settings card
+          // shows the error via its own try/catch wrapper.
+          console.warn('check_for_update failed:', e)
+        } finally {
+          set({ checking: false })
+        }
+      },
+
+      applyUpdate: async () => {
+        const info = get().pendingUpdate
+        if (!info || get().applying) return null
+        set({ applying: true })
+        try {
+          await invoke<void>('apply_update', { info })
+          // Unreachable on success — the backend calls
+          // `AppHandle::restart` after a successful swap, which exits
+          // the current process.
+          return null
+        } catch (e) {
+          set({ applying: false })
+          // Tauri serialises the `Result<_, UpdateError>` Err variant as
+          // a JS object — but very old failure paths (e.g. command not
+          // registered) might come back as a string. Normalise.
+          if (typeof e === 'object' && e !== null && 'kind' in e) {
+            return e as UpdateError
+          }
+          return { kind: 'other', message: String(e) }
+        }
+      },
+
+      skip: (version: string) =>
+        set({ skippedVersion: version, dialogOpen: false }),
+      clearSkipped: () => set({ skippedVersion: null }),
+      setAutoCheckEnabled: (enabled: boolean) =>
+        set({ autoCheckEnabled: enabled }),
+      openDialog: () => set({ dialogOpen: true }),
+      closeDialog: () => set({ dialogOpen: false }),
+      markToastShown: () => set({ toastShownThisSession: true }),
+    }),
+    {
+      name: 'akagi.updater',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state): Persisted => ({
+        lastChecked: state.lastChecked,
+        skippedVersion: state.skippedVersion,
+        autoCheckEnabled: state.autoCheckEnabled,
+      }),
+    },
+  ),
+)
+
+/// Derived: is there a notifiable update right now? Notifiable means
+/// "we have a pending update AND it isn't the one the user explicitly
+/// skipped." Used by the sidebar red-dot and the toast firing logic.
+export function selectHasNotifiableUpdate(s: UpdaterStore): boolean {
+  if (!s.pendingUpdate) return false
+  return s.skippedVersion !== s.pendingUpdate.latest_tag
+}

--- a/src/bot/install.rs
+++ b/src/bot/install.rs
@@ -21,15 +21,13 @@ use crate::bot::manifest::Manifest;
 use crate::bot::registry::BotEntry;
 use crate::bot::runtime::PythonRuntime;
 use crate::event_bus::NotifyBus;
+use crate::github::{build_client, extract_zip_safe, fetch_latest_release, Asset};
 use crate::schema::Notification;
 use anyhow::{bail, Context, Result};
 use globset::Glob;
-use serde::Deserialize;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
-const GITHUB_API: &str = "https://api.github.com";
-const USER_AGENT: &str = concat!("akagi/", env!("CARGO_PKG_VERSION"));
 const DOWNLOADS_DIR: &str = ".downloads";
 
 /// Pointer to a GitHub release-zip install.
@@ -53,20 +51,6 @@ impl GithubInstallSpec {
         // is the default install name.
         self.repo.split('/').nth(1).unwrap_or(&self.repo).to_owned()
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct ReleaseJson {
-    #[serde(default)]
-    tag_name: Option<String>,
-    #[serde(default)]
-    assets: Vec<Asset>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Asset {
-    pub name: String,
-    pub browser_download_url: String,
 }
 
 /// End-to-end install. Returns the registry entry for the freshly
@@ -104,22 +88,8 @@ pub async fn install_from_github_release(
             .id(notify_id.clone()),
     );
 
-    let client = reqwest::Client::builder()
-        .user_agent(USER_AGENT)
-        .build()
-        .context("build http client")?;
-
-    let release: ReleaseJson = client
-        .get(format!("{GITHUB_API}/repos/{}/releases/latest", spec.repo))
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-        .context("fetch release metadata")?
-        .error_for_status()
-        .context("github release endpoint returned an error")?
-        .json()
-        .await
-        .context("parse release JSON")?;
+    let client = build_client()?;
+    let release = fetch_latest_release(&client, &spec.repo).await?;
 
     let asset = pick_asset(&release.assets, spec.asset_glob.as_deref())?;
 
@@ -362,62 +332,6 @@ async fn download_asset(
     Ok(path)
 }
 
-/// Extract `zip_path` into `dest_dir`. Rejects entries whose normalised
-/// path escapes the destination root (`..`, absolute paths) — standard
-/// "zip slip" defence.
-pub fn extract_zip_safe(zip_path: &Path, dest_dir: &Path) -> Result<()> {
-    let file =
-        std::fs::File::open(zip_path).with_context(|| format!("open {}", zip_path.display()))?;
-    let mut archive = zip::ZipArchive::new(file)
-        .with_context(|| format!("not a valid zip: {}", zip_path.display()))?;
-
-    for i in 0..archive.len() {
-        let mut entry = archive
-            .by_index(i)
-            .with_context(|| format!("read zip entry {i}"))?;
-        let raw_name = entry.name().to_owned();
-
-        // zip 8 exposes `enclosed_name()` which already validates that the
-        // path is relative and contains no `..` segments. We additionally
-        // double-check by walking components, because the `enclosed_name`
-        // check is only as strong as the underlying `Path` parser.
-        let Some(rel) = entry.enclosed_name() else {
-            bail!("zip entry {raw_name:?} has an unsafe path");
-        };
-        if rel.components().any(|c| matches!(c, Component::ParentDir)) {
-            bail!("zip entry {raw_name:?} contains `..`");
-        }
-        if rel.is_absolute() {
-            bail!("zip entry {raw_name:?} is absolute");
-        }
-
-        let out_path = dest_dir.join(&rel);
-        if entry.is_dir() {
-            std::fs::create_dir_all(&out_path)
-                .with_context(|| format!("mkdir {}", out_path.display()))?;
-            continue;
-        }
-        if let Some(parent) = out_path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("mkdir {}", parent.display()))?;
-        }
-        let mut out = std::fs::File::create(&out_path)
-            .with_context(|| format!("create {}", out_path.display()))?;
-        std::io::copy(&mut entry, &mut out)
-            .with_context(|| format!("write {}", out_path.display()))?;
-
-        // Preserve unix mode bits (executable scripts).
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Some(mode) = entry.unix_mode() {
-                let _ = std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode));
-            }
-        }
-    }
-    Ok(())
-}
-
 /// If `dir` contains exactly one entry and that entry is a directory,
 /// return that nested directory. Otherwise return `dir` unchanged.
 ///
@@ -454,16 +368,14 @@ pub fn validate_layout(bot_root: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
     use tempfile::TempDir;
-    use zip::write::SimpleFileOptions;
-    use zip::ZipWriter;
 
     fn asset(name: &str) -> Asset {
         Asset {
             name: name.to_owned(),
             browser_download_url: format!("https://example.com/{name}"),
+            size: None,
+            digest: None,
         }
     }
 
@@ -570,67 +482,6 @@ mod tests {
     fn pick_asset_empty_release_errors() {
         let err = pick_asset(&[], None).unwrap_err();
         assert!(err.to_string().contains("no assets"));
-    }
-
-    /// Build a tiny zip in memory at `path`, with `entries` like
-    /// `("dir/file.txt", "body")`. Directories are inferred.
-    fn make_zip(path: &Path, entries: &[(&str, &[u8])]) {
-        let f = File::create(path).unwrap();
-        let mut z = ZipWriter::new(f);
-        let opts = SimpleFileOptions::default();
-        for (name, body) in entries {
-            z.start_file(name.to_string(), opts).unwrap();
-            z.write_all(body).unwrap();
-        }
-        z.finish().unwrap();
-    }
-
-    #[test]
-    fn extract_zip_safe_writes_files() {
-        let tmp = TempDir::new().unwrap();
-        let zip = tmp.path().join("a.zip");
-        make_zip(
-            &zip,
-            &[("bot.py", b"print('hi')\n"), ("README.md", b"# hi\n")],
-        );
-
-        let out = TempDir::new().unwrap();
-        extract_zip_safe(&zip, out.path()).unwrap();
-        assert!(out.path().join("bot.py").is_file());
-        assert!(out.path().join("README.md").is_file());
-    }
-
-    #[test]
-    fn extract_zip_safe_preserves_directory_layout() {
-        let tmp = TempDir::new().unwrap();
-        let zip = tmp.path().join("a.zip");
-        make_zip(
-            &zip,
-            &[
-                ("mortal-v1/bot.py", b"print('hi')\n"),
-                ("mortal-v1/sub/x.txt", b"x"),
-            ],
-        );
-
-        let out = TempDir::new().unwrap();
-        extract_zip_safe(&zip, out.path()).unwrap();
-        assert!(out.path().join("mortal-v1/bot.py").is_file());
-        assert!(out.path().join("mortal-v1/sub/x.txt").is_file());
-    }
-
-    #[test]
-    fn extract_zip_safe_rejects_path_traversal() {
-        let tmp = TempDir::new().unwrap();
-        let zip = tmp.path().join("a.zip");
-        make_zip(&zip, &[("../escape.txt", b"nope")]);
-
-        let out = TempDir::new().unwrap();
-        let err = extract_zip_safe(&zip, out.path()).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unsafe path") || msg.contains("contains `..`"),
-            "got: {msg}"
-        );
     }
 
     #[test]

--- a/src/capture/chromium/cft.rs
+++ b/src/capture/chromium/cft.rs
@@ -350,7 +350,7 @@ pub async fn install(channel: &Channel, notify: &NotifyBus) -> Result<String> {
     );
     std::fs::create_dir_all(&install_dir)
         .with_context(|| format!("create {}", install_dir.display()))?;
-    crate::bot::install::extract_zip_safe(&zip_path, &install_dir).context("extract CfT zip")?;
+    crate::github::extract_zip_safe(&zip_path, &install_dir).context("extract CfT zip")?;
     let _ = std::fs::remove_file(&zip_path);
 
     if let Some(platform) = cft_platform() {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,0 +1,211 @@
+//! Shared primitives for talking to the GitHub Releases API.
+//!
+//! Used by `bot::install` (download + extract a bot from a release zip)
+//! and `updater` (download + extract Akagi's own binary from a release
+//! zip). Both clients hit `api.github.com/repos/<repo>/releases/latest`
+//! anonymously, with a `User-Agent: akagi/<version>` header.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::path::{Component, Path};
+
+pub const GITHUB_API: &str = "https://api.github.com";
+pub const USER_AGENT: &str = concat!("akagi/", env!("CARGO_PKG_VERSION"));
+
+/// One asset entry from `releases/latest`.
+///
+/// `size` and `digest` are optional because the older bot-install path
+/// doesn't need them, and the digest field only started appearing in
+/// 2024 — old releases lack it. The updater verifies SHA-256 when
+/// present and warns (but doesn't fail) when absent.
+#[derive(Debug, Deserialize, Clone)]
+pub struct Asset {
+    pub name: String,
+    pub browser_download_url: String,
+    #[serde(default)]
+    pub size: Option<u64>,
+    #[serde(default)]
+    pub digest: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ReleaseJson {
+    #[serde(default)]
+    pub tag_name: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub html_url: Option<String>,
+    #[serde(default)]
+    pub assets: Vec<Asset>,
+}
+
+/// Build a reqwest client preconfigured with the Akagi `User-Agent`.
+pub fn build_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .context("build http client")
+}
+
+/// Anonymous fetch of the `releases/latest` endpoint for `<repo>`.
+/// `repo` is `owner/name` and is assumed pre-validated by the caller.
+pub async fn fetch_latest_release(client: &reqwest::Client, repo: &str) -> Result<ReleaseJson> {
+    client
+        .get(format!("{GITHUB_API}/repos/{repo}/releases/latest"))
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .context("fetch release metadata")?
+        .error_for_status()
+        .context("github release endpoint returned an error")?
+        .json()
+        .await
+        .context("parse release JSON")
+}
+
+/// Extract `zip_path` into `dest_dir`. Rejects entries whose normalised
+/// path escapes the destination root (`..`, absolute paths) — standard
+/// "zip slip" defence. Preserves unix mode bits.
+pub fn extract_zip_safe(zip_path: &Path, dest_dir: &Path) -> Result<()> {
+    let file =
+        std::fs::File::open(zip_path).with_context(|| format!("open {}", zip_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| format!("not a valid zip: {}", zip_path.display()))?;
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .with_context(|| format!("read zip entry {i}"))?;
+        let raw_name = entry.name().to_owned();
+
+        let Some(rel) = entry.enclosed_name() else {
+            bail!("zip entry {raw_name:?} has an unsafe path");
+        };
+        if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+            bail!("zip entry {raw_name:?} contains `..`");
+        }
+        if rel.is_absolute() {
+            bail!("zip entry {raw_name:?} is absolute");
+        }
+
+        let out_path = dest_dir.join(&rel);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)
+                .with_context(|| format!("mkdir {}", out_path.display()))?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("mkdir {}", parent.display()))?;
+        }
+        let mut out = std::fs::File::create(&out_path)
+            .with_context(|| format!("create {}", out_path.display()))?;
+        std::io::copy(&mut entry, &mut out)
+            .with_context(|| format!("write {}", out_path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = entry.unix_mode() {
+                let _ = std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    fn make_zip(path: &Path, entries: &[(&str, &[u8])]) {
+        let f = File::create(path).unwrap();
+        let mut z = ZipWriter::new(f);
+        let opts = SimpleFileOptions::default();
+        for (name, body) in entries {
+            z.start_file(name.to_string(), opts).unwrap();
+            z.write_all(body).unwrap();
+        }
+        z.finish().unwrap();
+    }
+
+    #[test]
+    fn extract_zip_safe_writes_files() {
+        let tmp = TempDir::new().unwrap();
+        let zip = tmp.path().join("a.zip");
+        make_zip(
+            &zip,
+            &[("bot.py", b"print('hi')\n"), ("README.md", b"# hi\n")],
+        );
+
+        let out = TempDir::new().unwrap();
+        extract_zip_safe(&zip, out.path()).unwrap();
+        assert!(out.path().join("bot.py").is_file());
+        assert!(out.path().join("README.md").is_file());
+    }
+
+    #[test]
+    fn extract_zip_safe_preserves_directory_layout() {
+        let tmp = TempDir::new().unwrap();
+        let zip = tmp.path().join("a.zip");
+        make_zip(
+            &zip,
+            &[
+                ("mortal-v1/bot.py", b"print('hi')\n"),
+                ("mortal-v1/sub/x.txt", b"x"),
+            ],
+        );
+
+        let out = TempDir::new().unwrap();
+        extract_zip_safe(&zip, out.path()).unwrap();
+        assert!(out.path().join("mortal-v1/bot.py").is_file());
+        assert!(out.path().join("mortal-v1/sub/x.txt").is_file());
+    }
+
+    #[test]
+    fn extract_zip_safe_rejects_path_traversal() {
+        let tmp = TempDir::new().unwrap();
+        let zip = tmp.path().join("a.zip");
+        make_zip(&zip, &[("../escape.txt", b"nope")]);
+
+        let out = TempDir::new().unwrap();
+        let err = extract_zip_safe(&zip, out.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsafe path") || msg.contains("contains `..`"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn asset_parses_with_optional_fields() {
+        let raw = r#"{
+            "name": "akagi-3.0.12-linux-x64.zip",
+            "browser_download_url": "https://example.com/x.zip",
+            "size": 12345,
+            "digest": "sha256:abc"
+        }"#;
+        let asset: Asset = serde_json::from_str(raw).unwrap();
+        assert_eq!(asset.size, Some(12345));
+        assert_eq!(asset.digest.as_deref(), Some("sha256:abc"));
+    }
+
+    #[test]
+    fn asset_parses_without_optional_fields() {
+        let raw = r#"{
+            "name": "mortal.zip",
+            "browser_download_url": "https://example.com/m.zip"
+        }"#;
+        let asset: Asset = serde_json::from_str(raw).unwrap();
+        assert!(asset.size.is_none());
+        assert!(asset.digest.is_none());
+    }
+}

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -1191,6 +1191,48 @@ pub async fn delete_game_history_entry(
     Ok(removed)
 }
 
+/// `shinkuan/Akagi` is the canonical upstream — kept here as a const
+/// instead of plumbing through config so the user can't accidentally
+/// point the auto-updater at a fork.
+const UPSTREAM_REPO: &str = "shinkuan/Akagi";
+
+/// One-shot "is there a newer release?" — frontend calls this on app
+/// launch (with a 6h cache) and from the Settings "Check for updates"
+/// button. Returns `Ok(None)` for "already up to date" or unsupported
+/// platforms; `Err(String)` for network / parse failures (the toast in
+/// the frontend surfaces the message verbatim).
+#[tauri::command]
+pub async fn check_for_update(
+    state: State<'_, AppState>,
+) -> CmdResult<Option<crate::updater::UpdateInfo>> {
+    let Ok(_guard) = state.updater_lock.try_lock() else {
+        return Err("another update operation is in progress".into());
+    };
+    crate::updater::check_for_update(UPSTREAM_REPO)
+        .await
+        .map_err(|e| format!("check for update: {e:#}"))
+}
+
+/// Download the matching release zip, verify SHA-256, swap the binary
+/// via `self_replace::self_replace`, then relaunch. On success the
+/// process exits inside `app.restart()` and this never returns. The
+/// typed error variant lets the frontend distinguish "fall back to
+/// release page" (`read_only_install`, `unsupported_platform`,
+/// `no_matching_asset`) from a real network / integrity error.
+#[tauri::command]
+pub async fn apply_update(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    info: crate::updater::UpdateInfo,
+) -> Result<(), crate::updater::UpdateError> {
+    let Ok(_guard) = state.updater_lock.try_lock() else {
+        return Err(crate::updater::UpdateError::Other {
+            message: "another update operation is in progress".into(),
+        });
+    };
+    crate::updater::apply::download_and_apply(&app, &info).await
+}
+
 fn persist_config(config: &AppConfig, path: &Path) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
@@ -1242,6 +1284,8 @@ macro_rules! ipc_handlers {
             $crate::ipc::commands::get_game_history_record,
             $crate::ipc::commands::get_game_history_events,
             $crate::ipc::commands::delete_game_history_entry,
+            $crate::ipc::commands::check_for_update,
+            $crate::ipc::commands::apply_update,
         ]
     };
 }

--- a/src/ipc/state.rs
+++ b/src/ipc/state.rs
@@ -116,6 +116,10 @@ pub struct AppState {
     /// process. Used by `update_config` to start the manager on a
     /// runtime false→true flip of `autoplay.enabled` without re-spawning.
     pub autoplay_manager_started: Arc<AtomicBool>,
+    /// Serialises in-app update operations. `check_for_update` and
+    /// `apply_update` both `try_lock()` it so the user mashing buttons
+    /// can't race two HTTP fetches or — worse — two binary swaps.
+    pub updater_lock: Arc<Mutex<()>>,
 }
 
 impl AppState {
@@ -159,6 +163,7 @@ impl AppState {
             bot_manager_started: Arc::new(AtomicBool::new(false)),
             autoplay_context: Arc::new(AutoplayContext::new()),
             autoplay_manager_started: Arc::new(AtomicBool::new(false)),
+            updater_lock: Arc::new(Mutex::new(())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod logger;
 pub mod platform;
 pub mod proxy;
 pub mod schema;
+pub mod updater;
 pub mod util;
 
 use clap::Parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod config;
 pub mod event_bus;
 pub mod game_state;
+pub mod github;
 pub mod history;
 pub mod inspector;
 pub mod ipc;

--- a/src/updater/apply.rs
+++ b/src/updater/apply.rs
@@ -1,0 +1,257 @@
+//! Download a release zip, verify SHA-256, extract just the binary,
+//! atomically swap it into place via `self_replace`, then trigger a
+//! restart.
+//!
+//! Only the running platform's binary is extracted — the bundled
+//! Python+UV runtime tree stays untouched. That's fine for normal patch
+//! releases (which only change Rust code); the user is reminded in the
+//! UI that runtime-bump releases may require a full reinstall.
+
+use crate::github::{build_client, extract_zip_safe};
+use crate::updater::check::UpdateInfo;
+use crate::updater::error::UpdateError;
+use anyhow::{anyhow, Context, Result};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use tauri::AppHandle;
+use tokio::io::AsyncWriteExt;
+
+/// Top-level entry point called by the `apply_update` IPC command.
+/// On success the function does NOT return — `app.restart()` exits the
+/// process. Failures map to `UpdateError` so the frontend can decide
+/// between a generic toast and a "fall back to release page" hint.
+pub async fn download_and_apply(app: &AppHandle, info: &UpdateInfo) -> Result<(), UpdateError> {
+    // Determine the running exe path and verify its parent is writable
+    // before we burn bandwidth on a download we can't apply.
+    let current_exe = std::env::current_exe()
+        .context("std::env::current_exe failed")
+        .map_err(UpdateError::from)?;
+    let install_dir = current_exe
+        .parent()
+        .ok_or_else(|| anyhow!("current_exe has no parent"))
+        .map_err(UpdateError::from)?
+        .to_path_buf();
+    if !is_dir_writable(&install_dir) {
+        return Err(UpdateError::ReadOnlyInstall { path: install_dir });
+    }
+
+    // Stream-download the asset into a tempfile that lives next to the
+    // exe so the rename in `self_replace::self_replace` stays on the
+    // same filesystem.
+    let tempdir = tempfile::Builder::new()
+        .prefix(".akagi-update-")
+        .tempdir_in(&install_dir)
+        .context("create staging dir next to current exe")
+        .map_err(UpdateError::from)?;
+    let zip_path = tempdir.path().join("release.zip");
+    let downloaded_digest = download_zip(&info.asset_url, &zip_path)
+        .await
+        .map_err(UpdateError::from)?;
+
+    if let Some(expected) = info.asset_digest_sha256.as_deref() {
+        if !downloaded_digest.eq_ignore_ascii_case(expected) {
+            return Err(UpdateError::DigestMismatch);
+        }
+    }
+
+    // Extract the whole zip into a sibling dir, then locate the binary
+    // entry. The release zip wraps everything in a single
+    // `akagi-<version>-<triple>/` directory, so the binary lives one
+    // level down. We don't extract the runtime tree — too large and the
+    // user is told to manually reinstall when the runtime version
+    // changes.
+    let extract_dir = tempdir.path().join("extracted");
+    std::fs::create_dir(&extract_dir)
+        .with_context(|| format!("mkdir {}", extract_dir.display()))
+        .map_err(UpdateError::from)?;
+    extract_zip_safe(&zip_path, &extract_dir)
+        .context("extract release zip")
+        .map_err(UpdateError::from)?;
+
+    let binary_name = current_exe
+        .file_name()
+        .ok_or_else(|| anyhow!("current_exe has no file name"))
+        .map_err(UpdateError::from)?
+        .to_owned();
+    let new_binary = find_binary(&extract_dir, &binary_name)
+        .ok_or(UpdateError::NoMatchingAsset)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&new_binary, std::fs::Permissions::from_mode(0o755));
+    }
+
+    // Atomic in-place swap. On Unix this is a `rename` over the
+    // currently-running ELF/Mach-O (the kernel keeps the running inode
+    // alive). On Windows it's the documented copy + delete-on-close
+    // dance — see the self_replace crate docs for the gory details.
+    self_replace::self_replace(&new_binary)
+        .context("self_replace::self_replace")
+        .map_err(UpdateError::from)?;
+
+    // Trigger restart. The call shuts the process down and re-execs the
+    // (now swapped) binary, so anything after this point in the source
+    // is unreachable.
+    app.restart();
+}
+
+/// Returns true if `dir` looks writable. We do an explicit write-probe
+/// rather than relying on `metadata().permissions().readonly()` because
+/// (a) on Unix permissions don't capture mount-level read-only flags
+/// (squashfs, AppImage), and (b) on Windows readonly directories are
+/// not actually a thing — ACLs are richer.
+fn is_dir_writable(dir: &Path) -> bool {
+    let probe = dir.join(".akagi-write-probe");
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Stream `url` to `path`, returning the hex SHA-256 of the bytes
+/// written. We hash on the fly so a multi-hundred-MB zip never has to
+/// be re-read just to digest it.
+async fn download_zip(url: &str, path: &Path) -> Result<String> {
+    let client = build_client()?;
+    let mut response = client
+        .get(url)
+        .send()
+        .await
+        .context("send download request")?
+        .error_for_status()
+        .context("download endpoint returned error")?;
+
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .with_context(|| format!("create {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    while let Some(chunk) = response.chunk().await.context("read body chunk")? {
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("write {}", path.display()))?;
+    }
+    file.flush().await.ok();
+    Ok(hex_encode(hasher.finalize().as_slice()))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Walk `dir` looking for an entry whose file name matches `binary_name`.
+/// The release zip wraps everything in a single top-level
+/// `akagi-<version>-<triple>/` directory so we have to descend at least
+/// one level — but we keep the walk bounded to avoid scanning the whole
+/// runtime tree if the layout ever changes.
+fn find_binary(dir: &Path, binary_name: &std::ffi::OsStr) -> Option<PathBuf> {
+    // Direct hit at the top level — handles a hypothetical future
+    // layout that drops the wrapping directory.
+    let direct = dir.join(binary_name);
+    if direct.is_file() {
+        return Some(direct);
+    }
+    // Otherwise descend exactly one level. The release zip's wrapping
+    // dir is the only thing we expect at the root, so this is enough.
+    for entry in std::fs::read_dir(dir).ok()? {
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().ok()?.is_dir() {
+            continue;
+        }
+        let candidate = entry.path().join(binary_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    fn make_zip(path: &Path, entries: &[(&str, &[u8])]) {
+        let f = File::create(path).unwrap();
+        let mut z = ZipWriter::new(f);
+        let opts = SimpleFileOptions::default();
+        for (name, body) in entries {
+            z.start_file(name.to_string(), opts).unwrap();
+            z.write_all(body).unwrap();
+        }
+        z.finish().unwrap();
+    }
+
+    #[test]
+    fn hex_encode_matches_known_value() {
+        // SHA-256 of empty input.
+        let h = Sha256::digest(b"");
+        assert_eq!(
+            hex_encode(h.as_slice()),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn find_binary_locates_inside_wrapped_dir() {
+        let tmp = TempDir::new().unwrap();
+        let zip = tmp.path().join("a.zip");
+        make_zip(
+            &zip,
+            &[
+                ("akagi-3.0.12-linux-x64/akagi", b"#!/bin/sh\nexit 0\n"),
+                ("akagi-3.0.12-linux-x64/README.txt", b"hello"),
+                (
+                    "akagi-3.0.12-linux-x64/runtime/python/keep.txt",
+                    b"not the binary",
+                ),
+            ],
+        );
+        let out = TempDir::new().unwrap();
+        extract_zip_safe(&zip, out.path()).unwrap();
+        let found = find_binary(out.path(), std::ffi::OsStr::new("akagi"))
+            .expect("should find the binary one level down");
+        assert!(found.ends_with("akagi-3.0.12-linux-x64/akagi"));
+    }
+
+    #[test]
+    fn find_binary_returns_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("akagi-3.0.12-linux-x64")).unwrap();
+        std::fs::write(
+            tmp.path().join("akagi-3.0.12-linux-x64/README.txt"),
+            b"hi",
+        )
+        .unwrap();
+        assert!(find_binary(tmp.path(), std::ffi::OsStr::new("akagi")).is_none());
+    }
+
+    #[test]
+    fn find_binary_prefers_direct_hit() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("akagi"), b"top-level").unwrap();
+        std::fs::create_dir_all(tmp.path().join("subdir")).unwrap();
+        std::fs::write(tmp.path().join("subdir/akagi"), b"nested").unwrap();
+        let found = find_binary(tmp.path(), std::ffi::OsStr::new("akagi")).unwrap();
+        assert_eq!(found, tmp.path().join("akagi"));
+    }
+
+    #[test]
+    fn is_dir_writable_for_tempdir() {
+        let tmp = TempDir::new().unwrap();
+        assert!(is_dir_writable(tmp.path()));
+    }
+}

--- a/src/updater/check.rs
+++ b/src/updater/check.rs
@@ -1,0 +1,342 @@
+//! Pure version-check logic. No IO except `fetch_latest_release` (which
+//! is itself a thin wrapper around `reqwest`); everything else is
+//! deterministic and unit-testable.
+
+use crate::github::{build_client, fetch_latest_release, Asset, ReleaseJson};
+use anyhow::{Context, Result};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// Per-app version metadata sent to the frontend. The shape mirrors what
+/// the `<UpdateDialog />` needs to render: human-readable strings plus
+/// the bytes we need to actually start a download (`asset_url`, plus the
+/// optional `asset_digest_sha256` for integrity verification).
+///
+/// Implements `Deserialize` because `apply_update` takes the cached
+/// `UpdateInfo` straight back from the frontend rather than re-fetching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateInfo {
+    /// Version we're running right now (`env!("CARGO_PKG_VERSION")`).
+    pub current: String,
+    /// Release tag verbatim — e.g. `v3.0.12`.
+    pub latest_tag: String,
+    /// `latest_tag` with any leading `v` stripped, validated as semver.
+    pub latest_version: String,
+    /// Markdown release notes from `release.body`. Empty string if the
+    /// release omits a body.
+    pub body: String,
+    /// `release.html_url` so the UI can deep-link to the release page.
+    pub html_url: String,
+    /// Filename of the matched asset for this platform.
+    pub asset_name: String,
+    /// `browser_download_url` — used by the apply step to actually fetch.
+    pub asset_url: String,
+    /// Asset size in bytes. May be 0 if GitHub omits it (rare in practice).
+    pub asset_size: u64,
+    /// Hex-encoded SHA-256 from the asset's `digest` field, if present.
+    /// `None` for old releases that pre-date the GitHub `digest` field.
+    pub asset_digest_sha256: Option<String>,
+}
+
+/// Map `(env::consts::OS, env::consts::ARCH)` to the `<os>-<arch>` slug
+/// embedded in our release asset names (see `scripts/package-zip.sh`).
+/// Returns `None` for triples we don't publish — frontend will surface
+/// "your platform isn't auto-updatable; check releases manually".
+pub fn triple_for_current_platform() -> Option<&'static str> {
+    triple_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn triple_for(os: &str, arch: &str) -> Option<&'static str> {
+    match (os, arch) {
+        ("linux", "x86_64") => Some("linux-x64"),
+        ("macos", "aarch64") => Some("macos-arm64"),
+        ("windows", "x86_64") => Some("windows-x64"),
+        _ => None,
+    }
+}
+
+/// Canonical asset filename our `scripts/package-zip.sh` produces for a
+/// given version + triple. Used by tests and as the fallback exact-match
+/// before `pick_release_asset` falls back to suffix matching.
+pub fn expected_asset_name(version: &str, triple: &str) -> String {
+    format!("akagi-{version}-{triple}.zip")
+}
+
+/// Find the release asset that targets `triple`. Match is suffix-based
+/// (`-<triple>.zip`) so the version-in-filename never has to be threaded
+/// through — if a future workflow renames the zip prefix from `akagi-`
+/// the picker still works.
+pub fn pick_release_asset<'a>(assets: &'a [Asset], triple: &str) -> Option<&'a Asset> {
+    let suffix = format!("-{triple}.zip");
+    assets.iter().find(|a| a.name.ends_with(&suffix))
+}
+
+/// `true` iff `latest` is a strictly-newer semver than `current`. Both
+/// inputs accept a leading `v`. Malformed inputs return `false` — we'd
+/// rather skip an update than crash, and the user can still see the
+/// release page from the Settings card.
+pub fn is_newer(current: &str, latest: &str) -> bool {
+    let Ok(c) = Version::parse(current.trim_start_matches('v')) else {
+        return false;
+    };
+    let Ok(l) = Version::parse(latest.trim_start_matches('v')) else {
+        return false;
+    };
+    l > c
+}
+
+/// Extract the hex SHA-256 portion of a GitHub asset `digest` string,
+/// which is shaped like `"sha256:abcdef..."`. Returns `None` for an
+/// empty / wrong-algorithm / wrong-shape input.
+pub fn parse_sha256_digest(raw: &str) -> Option<String> {
+    let (algo, hex) = raw.split_once(':')?;
+    if !algo.eq_ignore_ascii_case("sha256") {
+        return None;
+    }
+    let hex = hex.trim();
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(hex.to_ascii_lowercase())
+}
+
+/// Top-level orchestration: hit the latest-release endpoint, find an
+/// asset that matches our platform, and compare versions. Returns
+/// `Ok(None)` (not an error) for the common "we're already up to date"
+/// path and for unsupported platforms.
+pub async fn check_for_update(repo: &str) -> Result<Option<UpdateInfo>> {
+    let Some(triple) = triple_for_current_platform() else {
+        return Ok(None);
+    };
+
+    let client = build_client()?;
+    let release = fetch_latest_release(&client, repo).await?;
+    build_update_info(env!("CARGO_PKG_VERSION"), triple, &release)
+}
+
+/// Pure half of `check_for_update`. Split out so tests can drive it
+/// without spinning up a network mock.
+pub fn build_update_info(
+    current: &str,
+    triple: &str,
+    release: &ReleaseJson,
+) -> Result<Option<UpdateInfo>> {
+    let tag = release
+        .tag_name
+        .clone()
+        .context("release has no tag_name; can't compare versions")?;
+    if !is_newer(current, &tag) {
+        return Ok(None);
+    }
+    let Some(asset) = pick_release_asset(&release.assets, triple) else {
+        return Ok(None);
+    };
+
+    let latest_version = tag.trim_start_matches('v').to_owned();
+    let digest = asset
+        .digest
+        .as_deref()
+        .and_then(parse_sha256_digest);
+
+    Ok(Some(UpdateInfo {
+        current: current.to_owned(),
+        latest_tag: tag,
+        latest_version,
+        body: release.body.clone().unwrap_or_default(),
+        html_url: release.html_url.clone().unwrap_or_default(),
+        asset_name: asset.name.clone(),
+        asset_url: asset.browser_download_url.clone(),
+        asset_size: asset.size.unwrap_or(0),
+        asset_digest_sha256: digest,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn asset(name: &str, digest: Option<&str>, size: Option<u64>) -> Asset {
+        Asset {
+            name: name.to_owned(),
+            browser_download_url: format!("https://example.com/{name}"),
+            size,
+            digest: digest.map(|s| s.to_owned()),
+        }
+    }
+
+    #[test]
+    fn triple_for_known_triples() {
+        assert_eq!(triple_for("linux", "x86_64"), Some("linux-x64"));
+        assert_eq!(triple_for("macos", "aarch64"), Some("macos-arm64"));
+        assert_eq!(triple_for("windows", "x86_64"), Some("windows-x64"));
+    }
+
+    #[test]
+    fn triple_for_unsupported_returns_none() {
+        for (os, arch) in [
+            ("linux", "aarch64"),
+            ("macos", "x86_64"),
+            ("windows", "aarch64"),
+            ("freebsd", "x86_64"),
+        ] {
+            assert!(triple_for(os, arch).is_none(), "{os}/{arch}");
+        }
+    }
+
+    #[test]
+    fn expected_asset_name_formats_correctly() {
+        assert_eq!(
+            expected_asset_name("3.0.12", "linux-x64"),
+            "akagi-3.0.12-linux-x64.zip"
+        );
+    }
+
+    #[test]
+    fn pick_release_asset_matches_triple_suffix() {
+        let assets = vec![
+            asset("akagi-3.0.12-linux-x64.zip", None, Some(10)),
+            asset("akagi-3.0.12-macos-arm64.zip", None, Some(20)),
+            asset("akagi-3.0.12-windows-x64.zip", None, Some(30)),
+            asset("checksums.txt", None, None),
+        ];
+        assert_eq!(
+            pick_release_asset(&assets, "linux-x64").map(|a| a.name.as_str()),
+            Some("akagi-3.0.12-linux-x64.zip")
+        );
+        assert_eq!(
+            pick_release_asset(&assets, "windows-x64").map(|a| a.name.as_str()),
+            Some("akagi-3.0.12-windows-x64.zip")
+        );
+        assert!(pick_release_asset(&assets, "linux-arm64").is_none());
+    }
+
+    #[test]
+    fn is_newer_basic_bumps() {
+        assert!(is_newer("3.0.11", "3.0.12"));
+        assert!(is_newer("3.0.11", "3.1.0"));
+        assert!(is_newer("3.0.11", "4.0.0"));
+        assert!(!is_newer("3.0.12", "3.0.11"));
+        assert!(!is_newer("3.0.12", "3.0.12"));
+    }
+
+    #[test]
+    fn is_newer_strips_v_prefix() {
+        assert!(is_newer("3.0.11", "v3.0.12"));
+        assert!(is_newer("v3.0.11", "3.0.12"));
+        assert!(is_newer("v3.0.11", "v3.0.12"));
+    }
+
+    /// Per CLAUDE.md memory `feedback_version_format.md`, V3's
+    /// pre-release tags stay numeric (`3.0.0-1`, `3.0.0-2`, …). Semver's
+    /// numeric identifier ordering must order these correctly — string
+    /// comparison would put `3.0.0-10` *before* `3.0.0-2`.
+    #[test]
+    fn is_newer_numeric_prerelease_ordering() {
+        assert!(is_newer("3.0.0-2", "3.0.0-10"));
+        assert!(is_newer("3.0.0-1", "3.0.0-2"));
+        assert!(!is_newer("3.0.0-10", "3.0.0-2"));
+        // Pre-release is always less than the corresponding release.
+        assert!(is_newer("3.0.0-5", "3.0.0"));
+        assert!(!is_newer("3.0.0", "3.0.0-5"));
+    }
+
+    #[test]
+    fn is_newer_malformed_returns_false() {
+        assert!(!is_newer("3.0.11", "not-a-version"));
+        assert!(!is_newer("garbage", "3.0.12"));
+        assert!(!is_newer("", ""));
+    }
+
+    #[test]
+    fn parse_sha256_digest_accepts_valid_form() {
+        let raw = "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        assert_eq!(parse_sha256_digest(raw), Some(raw[7..].to_owned()));
+    }
+
+    #[test]
+    fn parse_sha256_digest_normalises_case() {
+        let raw = "SHA256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+        assert_eq!(parse_sha256_digest(raw).unwrap(), raw[7..].to_ascii_lowercase());
+    }
+
+    #[test]
+    fn parse_sha256_digest_rejects_wrong_algo_or_shape() {
+        assert!(parse_sha256_digest("md5:abc").is_none());
+        assert!(parse_sha256_digest("sha256:").is_none());
+        assert!(parse_sha256_digest("sha256:notenoughhex").is_none());
+        assert!(parse_sha256_digest("nocolonhere").is_none());
+        // Not 64 chars
+        assert!(parse_sha256_digest("sha256:abc123").is_none());
+        // Non-hex char
+        let bad = "sha256:".to_owned() + &"z".repeat(64);
+        assert!(parse_sha256_digest(&bad).is_none());
+    }
+
+    fn release_with(tag: &str, assets: Vec<Asset>) -> ReleaseJson {
+        ReleaseJson {
+            tag_name: Some(tag.to_owned()),
+            name: None,
+            body: Some("notes".into()),
+            html_url: Some("https://example.com/release".into()),
+            assets,
+        }
+    }
+
+    #[test]
+    fn build_update_info_returns_none_for_equal_version() {
+        let release = release_with(
+            "v3.0.11",
+            vec![asset("akagi-3.0.11-linux-x64.zip", None, Some(1))],
+        );
+        let info = build_update_info("3.0.11", "linux-x64", &release).unwrap();
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn build_update_info_returns_some_for_newer_version() {
+        let release = release_with(
+            "v3.0.12",
+            vec![
+                asset(
+                    "akagi-3.0.12-linux-x64.zip",
+                    Some(
+                        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                    ),
+                    Some(12345),
+                ),
+                asset("akagi-3.0.12-windows-x64.zip", None, None),
+            ],
+        );
+        let info = build_update_info("3.0.11", "linux-x64", &release)
+            .unwrap()
+            .expect("should detect newer version");
+        assert_eq!(info.current, "3.0.11");
+        assert_eq!(info.latest_tag, "v3.0.12");
+        assert_eq!(info.latest_version, "3.0.12");
+        assert_eq!(info.asset_name, "akagi-3.0.12-linux-x64.zip");
+        assert_eq!(info.asset_size, 12345);
+        assert!(info.asset_digest_sha256.is_some());
+    }
+
+    #[test]
+    fn build_update_info_returns_none_when_no_matching_asset() {
+        let release = release_with(
+            "v3.0.12",
+            vec![asset("akagi-3.0.12-windows-x64.zip", None, None)],
+        );
+        let info = build_update_info("3.0.11", "linux-x64", &release).unwrap();
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn build_update_info_errors_on_missing_tag() {
+        let release = ReleaseJson {
+            tag_name: None,
+            name: None,
+            body: None,
+            html_url: None,
+            assets: vec![],
+        };
+        assert!(build_update_info("3.0.11", "linux-x64", &release).is_err());
+    }
+}

--- a/src/updater/error.rs
+++ b/src/updater/error.rs
@@ -1,0 +1,50 @@
+//! Typed errors for the in-app update flow. Frontend pattern-matches on
+//! the discriminant so it can choose between "show a generic toast" and
+//! "fall back to opening the release page in a browser".
+
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Surfaced to the frontend by `apply_update`. `check_for_update`
+/// returns `Result<Option<UpdateInfo>, String>` instead — failures
+/// there just bubble up as a plain anyhow chain because the frontend
+/// has no per-case fallback for a check.
+#[derive(Debug, thiserror::Error, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpdateError {
+    /// Running on a target triple Akagi doesn't publish a binary for
+    /// (e.g. linux/aarch64 today). The UI should suppress the toast
+    /// and only surface a "check releases manually" link in Settings.
+    #[error("running platform has no published release artifact")]
+    UnsupportedPlatform,
+
+    /// Install directory isn't writable — AppImage, system-wide install,
+    /// macOS `.app` bundle without admin. UI falls back to "Open release
+    /// page".
+    #[error("install directory {path} is not writable")]
+    ReadOnlyInstall { path: PathBuf },
+
+    /// Asset has a `digest` field but the downloaded bytes don't match.
+    /// Could be CDN corruption or MITM; we refuse to swap.
+    #[error("downloaded asset SHA-256 digest does not match release metadata")]
+    DigestMismatch,
+
+    /// The matching asset for the running triple isn't in the release.
+    /// Either the workflow didn't upload it yet, or the version pre-dates
+    /// the current platform support.
+    #[error("no release asset matches the running platform")]
+    NoMatchingAsset,
+
+    /// Catch-all for anyhow-wrapped reqwest/IO/zip errors. The string
+    /// is already formatted (`{e:#}` style).
+    #[error("{message}")]
+    Other { message: String },
+}
+
+impl From<anyhow::Error> for UpdateError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Other {
+            message: format!("{e:#}"),
+        }
+    }
+}

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -1,0 +1,26 @@
+//! In-app update checker + self-replace flow.
+//!
+//! Layered for testability:
+//!
+//! - [`check`] holds pure version-comparison helpers (`is_newer`,
+//!   `pick_release_asset`, `triple_for_current_platform`,
+//!   `build_update_info`) plus the single async entry point
+//!   `check_for_update` that calls into the GitHub API.
+//! - [`apply`] streams the matching release zip, verifies SHA-256
+//!   against `asset_digest_sha256` (when GitHub provides it), extracts
+//!   the platform binary, and swaps it via `self_replace::self_replace`
+//!   before triggering `AppHandle::restart`.
+//! - [`error`] surfaces typed errors so the frontend can fall back to
+//!   "Open release page" on `ReadOnlyInstall` / `UnsupportedPlatform`
+//!   without showing a scary generic message.
+//!
+//! The Tauri IPC commands `check_for_update` and `apply_update` live in
+//! `src/ipc/commands.rs`; both are guarded by `AppState::updater_lock`
+//! so two concurrent invocations can't race the file rename.
+
+pub mod apply;
+pub mod check;
+pub mod error;
+
+pub use check::{check_for_update, UpdateInfo};
+pub use error::UpdateError;


### PR DESCRIPTION
Closes #118.

## Summary

- Detects new releases from `shinkuan/Akagi` on launch (3s deferred, 6h cached) and on demand from a new *Settings → Updates* card.
- Surfaces results via a bounded one-shot sonner toast plus a red dot next to the sidebar version line; clicking either opens a backdrop'd Dialog with release notes and four actions: **Update now**, **Skip this version**, **Later**, **Open release page**.
- **Update now** streams the matching `akagi-<version>-<triple>.zip`, SHA-256 verifies it against GitHub's asset `digest` when present, extracts just the binary, then atomic-swaps it in place via `self_replace::self_replace` and triggers `AppHandle::restart()`.
- Read-only installs (AppImage, system installs, macOS `.app` bundles) are detected up front via a write-probe and fall back to "Open release page". Unsupported triples skip the toast entirely.
- *Skip this version* is persisted in zustand+localStorage (`akagi.updater`); the Settings card has a *Clear skipped version* button and a manual *Check for updates*.

## Implementation

Two commits:

1. `refactor(github): extract shared release-API helpers into crate::github` — pure cleanup. Moves the `GITHUB_API` / `USER_AGENT` constants, `Asset` and `ReleaseJson` structs, `extract_zip_safe`, `build_client`, and `fetch_latest_release` from `bot::install` into a new `crate::github` module so both call sites share. `Asset` gains optional `size` and `digest` fields (serde-default; bot-install consumer unchanged). `cft.rs` retargets its one `extract_zip_safe` call. No behavior change; `cargo test --lib` stays green (437/437).

2. `feat(updater): in-app GitHub release checker with self-replace install` — the feature itself. New `src/updater/` (check / apply / error), two new IPC commands (`check_for_update`, `apply_update`) guarded by an `AppState::updater_lock` for single-flight, three new dependencies (`self-replace`, `semver`, `sha2`, `thiserror`). Frontend gets `updaterStore` (zustand+persist), `UpdateNotifier` (invisible coordinator), `UpdateDialog`, sidebar red-dot + dynamic version via `getVersion()`, an `UpdatesCard` in Settings, and `updates.*` i18n keys across all four locales. `cargo test --lib` 457/457 under `--test-threads=1`; `npm run build` clean.

## Test plan

- [ ] In a dev build, temporarily set `Cargo.toml` to `version = "3.0.0-1"` → relaunch → toast appears ~3s after window mounts.
- [ ] Click the toast's *View details* → dialog opens with backdrop and real release notes.
- [ ] Click *Skip this version* → reload → no toast, no red dot.
- [ ] Open Settings → Updates → *Clear skipped version* → reload → toast / red dot return.
- [ ] Click *Update now* on a writable install → binary swaps in place → app restarts → sidebar shows the new version.
- [ ] `chmod -w` the install parent on Linux → *Update now* surfaces `error_read_only` and the fallback *Open release page* action.
- [ ] Toggle *Automatically check on launch* off → reload → no `api.github.com` request fires.