### PR TITLE
Warn on GitHub install when pyproject.toml/manifest.toml missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,6 @@ validates `bot.py`, and runs `uv sync` once. Subsequent launches are
 fast — the sync is gated by a stamp at
 `mjai_bot/<name>/.akagi/synced.stamp`.
 
-`bot.py` is the only hard requirement. If the installed archive is also
-missing `pyproject.toml` and/or `manifest.toml`, the install still
-completes but raises a **warning** — those files are what a complete
-Akagi bot ships, so their absence usually means the wrong repo/release
-was selected. Double-check the target if you see it.
-
 > [!IMPORTANT]
 > Because of GitHub's file-size limit, the Mortal weights bundled in
 > the release zip are a small, weak **placeholder model** — useful to

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ validates `bot.py`, and runs `uv sync` once. Subsequent launches are
 fast — the sync is gated by a stamp at
 `mjai_bot/<name>/.akagi/synced.stamp`.
 
+`bot.py` is the only hard requirement. If the installed archive is also
+missing `pyproject.toml` and/or `manifest.toml`, the install still
+completes but raises a **warning** — those files are what a complete
+Akagi bot ships, so their absence usually means the wrong repo/release
+was selected. Double-check the target if you see it.
+
 > [!IMPORTANT]
 > Because of GitHub's file-size limit, the Mortal weights bundled in
 > the release zip are a small, weak **placeholder model** — useful to

--- a/src/bot/README.md
+++ b/src/bot/README.md
@@ -190,6 +190,10 @@ Behaviour:
   zips like `mortal-v0.5.0/…`), strips it.
 - Validates that the extracted layout contains `bot.py` at the top.
 - Atomic rename into `mjai_bot/<name>/`.
+- After the rename, checks for the recommended `pyproject.toml` and
+  `manifest.toml`. These are not required (only `bot.py` is), but if any
+  are absent the install raises a `warn` toast — the target probably
+  isn't the bot the user meant to install. The install still succeeds.
 - Post-install: if a `PythonRuntime` is available and the extracted bot
   has a `pyproject.toml`, runs `uv sync` so dependency failures surface
   here instead of at game-start. On failure the bot dir stays in place

--- a/src/bot/install.rs
+++ b/src/bot/install.rs
@@ -156,6 +156,27 @@ pub async fn install_from_github_release(
 
     install_result?;
 
+    // Heads-up (non-fatal): a complete Akagi bot ships `pyproject.toml`
+    // (deps / `uv sync`) and `manifest.toml` (settings schema). `bot.py`
+    // alone clears `validate_layout`, but if these are also missing the user
+    // most likely pointed the installer at the wrong repo/release. Warn so
+    // they can double-check rather than silently ending up with a bot that
+    // has no deps and no settings.
+    let missing = missing_recommended_files(&dest_dir);
+    if !missing.is_empty() {
+        let _ = notify.send(
+            Notification::warn(format!("{target_name} may not be a valid bot"))
+                .body(format!(
+                    "Installed from {} but it is missing {}. This might not be the \
+                     target you intended to install — a complete Akagi bot ships both \
+                     pyproject.toml and manifest.toml.",
+                    spec.repo,
+                    missing.join(" and "),
+                ))
+                .id(format!("{notify_id}-layout")),
+        );
+    }
+
     // Post-install: run `uv sync` so dependency failures surface here rather
     // than at game-start. Skip silently for pyproject-less bots — only the
     // explicit Reinstall-environment path treats that as an error.
@@ -365,6 +386,23 @@ pub fn validate_layout(bot_root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Files a well-formed Akagi bot is expected to ship alongside `bot.py`:
+/// `pyproject.toml` (Python deps / `uv sync`) and `manifest.toml` (settings
+/// schema + metadata). Recommended, not required — `validate_layout` only
+/// hard-fails on a missing `bot.py`. When these are also absent the install
+/// target is most likely not the bot the user meant to install.
+const RECOMMENDED_FILES: [&str; 2] = ["pyproject.toml", "manifest.toml"];
+
+/// Return the [`RECOMMENDED_FILES`] that are *not* present at the top level
+/// of `bot_root`, in declaration order. An empty vec means the layout looks
+/// like a complete bot.
+pub fn missing_recommended_files(bot_root: &Path) -> Vec<&'static str> {
+    RECOMMENDED_FILES
+        .into_iter()
+        .filter(|name| !bot_root.join(name).is_file())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +550,25 @@ mod tests {
 
         std::fs::write(tmp.path().join("bot.py"), b"").unwrap();
         validate_layout(tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn missing_recommended_files_flags_absent_files() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("bot.py"), b"").unwrap();
+
+        // Neither recommended file present → both reported, in order.
+        assert_eq!(
+            missing_recommended_files(tmp.path()),
+            vec!["pyproject.toml", "manifest.toml"],
+        );
+
+        // Only pyproject present → manifest still flagged.
+        std::fs::write(tmp.path().join("pyproject.toml"), b"").unwrap();
+        assert_eq!(missing_recommended_files(tmp.path()), vec!["manifest.toml"]);
+
+        // Both present → nothing flagged.
+        std::fs::write(tmp.path().join("manifest.toml"), b"").unwrap();
+        assert!(missing_recommended_files(tmp.path()).is_empty());
     }
 }


### PR DESCRIPTION
Closes #121.

## Problem

When installing a bot from a GitHub release, the pipeline only hard-validates that `bot.py` exists (`validate_layout`). A complete Akagi bot also ships `pyproject.toml` (deps / `uv sync`) and `manifest.toml` (settings schema + metadata). If those are missing too, the user most likely pointed the installer at the wrong repo/release — but the install used to succeed silently, leaving them with a bot that has no dependency management and no configurable settings.

## Change

After the atomic rename in `install_from_github_release`, check for the recommended `pyproject.toml` and `manifest.toml`. If any are missing, emit a **warn**-level notification (with a distinct toast `id` so it persists next to the final success toast) naming the missing files. `bot.py` stays the only hard requirement, so the install still completes.

- New `RECOMMENDED_FILES` const and `missing_recommended_files(bot_root) -> Vec<&'static str>` helper.
- Warning wired into the install flow.
- Updated `README.md` and `src/bot/README.md`.

## Tests

- New regression test `missing_recommended_files_flags_absent_files` covering none / partial (pyproject only) / both-present layouts.
- `cargo test --lib bot::install` → 15 passed. `cargo clippy --lib` clean for the touched files (3 pre-existing warnings in `src/schema/inspector.rs` are unrelated).

## Behaviour

- Archive missing one or both recommended files → install succeeds **and** a warn toast names what's missing.
- Complete bot (both present) → no warning.