### PR TITLE
Block UI during bot env install; forbid activating un-synced bots

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Statusbar } from '@/components/Statusbar'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Toaster } from '@/components/ui/sonner'
 import { UpdateNotifier } from '@/components/UpdateNotifier'
+import { InstallBlockingOverlay } from '@/components/InstallBlockingOverlay'
 import { useTauriBridge } from '@/hooks/useTauriBridge'
 import { useSidebar } from '@/hooks/useSidebar'
 import { useUiPrefsStore } from '@/stores/uiPrefsStore'
@@ -54,6 +55,7 @@ export default function App() {
       </main>
       <Toaster />
       <UpdateNotifier />
+      <InstallBlockingOverlay />
     </>
   )
 }

--- a/frontend/src/components/InstallBlockingOverlay.tsx
+++ b/frontend/src/components/InstallBlockingOverlay.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import { useInstallStore } from '@/stores/installStore'
+
+// Full-screen, non-dismissible overlay shown while a bot env install/sync is
+// in progress. Sits above the sidebar (z-20) and dialogs (z-50) at z-[100]
+// and swallows pointer/keyboard events, so in-app navigation and starting a
+// game are impossible until the install completes. There is intentionally no
+// close button or backdrop-click handler.
+export function InstallBlockingOverlay() {
+  const { t } = useTranslation()
+  const active = useInstallStore((s) => s.count > 0)
+  const title = useInstallStore((s) => s.title)
+  const body = useInstallStore((s) => s.body)
+
+  // Block keyboard-driven navigation/shortcuts while the overlay is up.
+  useEffect(() => {
+    if (!active) return
+    const swallow = (e: KeyboardEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+    }
+    window.addEventListener('keydown', swallow, true)
+    return () => window.removeEventListener('keydown', swallow, true)
+  }, [active])
+
+  if (!active) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm"
+      role="alertdialog"
+      aria-modal="true"
+      aria-busy="true"
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <div className="mx-4 flex max-w-md flex-col items-center gap-4 rounded-lg border border-border bg-card p-8 text-center shadow-xl">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg font-semibold">{title ?? t('install_overlay.title')}</h2>
+          {body && <p className="text-sm text-muted-foreground">{body}</p>}
+        </div>
+        <p className="text-xs font-medium text-amber-300">{t('install_overlay.warning')}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useTauriBridge.ts
+++ b/frontend/src/hooks/useTauriBridge.ts
@@ -18,6 +18,7 @@ import { useAnalysisStore } from '@/stores/analysisStore'
 import { useBotStore } from '@/stores/botStore'
 import { useCaptureStore } from '@/stores/captureStore'
 import { useNotifyStore } from '@/stores/notifyStore'
+import { useInstallStore } from '@/stores/installStore'
 import { useConfigStore } from '@/stores/configStore'
 import { useHistoryStore } from '@/stores/historyStore'
 import { toast, type ToastSeverity } from '@/components/ui/sonner'
@@ -123,6 +124,12 @@ export function useTauriBridge() {
 
     listen<Notification>('notify', (n) => {
       useNotifyStore.getState().pushToast(n)
+      // Feed env install/sync progress to the blocking overlay (which is
+      // shown for the duration of `withInstallBlock`). Ids: `bot-install-*`
+      // (GitHub install/reinstall) and `bot-sync-*` ("Reinstall environment").
+      if (n.id && (n.id.startsWith('bot-install-') || n.id.startsWith('bot-sync-'))) {
+        useInstallStore.getState().setProgress(n)
+      }
       toast[TOAST_SEVERITY[n.level]](n.title, {
         description: n.body,
         id: n.id,

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -444,7 +444,8 @@
     "drawer_loading": "Loading…",
     "drawer_reinstall": "Reinstall environment",
     "drawer_reinstall_tooltip": "Wipe and recreate the Python virtualenv for this bot",
-    "drawer_reinstalling": "Reinstalling…"
+    "drawer_reinstalling": "Reinstalling…",
+    "env_not_ready_tooltip": "Environment not installed yet — install or sync it before activating."
   },
   "overview": {
     "title": "Overview",
@@ -546,5 +547,9 @@
       "clear_skipped": "Clear skipped version",
       "none_skipped": "None"
     }
+  },
+  "install_overlay": {
+    "title": "Installing…",
+    "warning": "Please don’t close the app or start a game until the installation finishes."
   }
 }

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -444,7 +444,8 @@
     "drawer_loading": "読み込み中…",
     "drawer_reinstall": "環境を再構築",
     "drawer_reinstall_tooltip": "この Bot の Python virtualenv を消去して再構築",
-    "drawer_reinstalling": "再構築中…"
+    "drawer_reinstalling": "再構築中…",
+    "env_not_ready_tooltip": "環境がまだインストールされていません。有効化する前にインストール／同期してください。"
   },
   "overview": {
     "title": "概要",
@@ -546,5 +547,9 @@
       "clear_skipped": "スキップを解除",
       "none_skipped": "なし"
     }
+  },
+  "install_overlay": {
+    "title": "インストール中…",
+    "warning": "インストールが完了するまで、アプリを閉じたり対局を開始しないでください。"
   }
 }

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -444,7 +444,8 @@
     "drawer_loading": "加载中…",
     "drawer_reinstall": "重建环境",
     "drawer_reinstall_tooltip": "清除并重建这个 Bot 的 Python 虚拟环境",
-    "drawer_reinstalling": "重建中…"
+    "drawer_reinstalling": "重建中…",
+    "env_not_ready_tooltip": "环境尚未安装完成——启用前请先安装或同步环境。"
   },
   "overview": {
     "title": "总览",
@@ -546,5 +547,9 @@
       "clear_skipped": "清除跳过记录",
       "none_skipped": "无"
     }
+  },
+  "install_overlay": {
+    "title": "安装中…",
+    "warning": "安装完成前，请勿关闭程序或前往对局。"
   }
 }

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -444,7 +444,8 @@
     "drawer_loading": "載入中…",
     "drawer_reinstall": "重建環境",
     "drawer_reinstall_tooltip": "清除並重建這個 Bot 的 Python 虛擬環境",
-    "drawer_reinstalling": "重建中…"
+    "drawer_reinstalling": "重建中…",
+    "env_not_ready_tooltip": "環境尚未安裝完成——啟用前請先安裝或同步環境。"
   },
   "overview": {
     "title": "總覽",
@@ -546,5 +547,9 @@
       "clear_skipped": "清除跳過記錄",
       "none_skipped": "無"
     }
+  },
+  "install_overlay": {
+    "title": "安裝中…",
+    "warning": "安裝完成前，請勿關閉程式或前往對局。"
   }
 }

--- a/frontend/src/lib/install.ts
+++ b/frontend/src/lib/install.ts
@@ -1,0 +1,16 @@
+import { useInstallStore } from '@/stores/installStore'
+
+// Run a long-running bot env install/sync while the global blocking overlay
+// is shown. The overlay (see InstallBlockingOverlay) covers the whole app
+// including the sidebar, so the user can't navigate away or start a game
+// until the environment finishes installing — otherwise the bot's first
+// in-game spawn would run `uv sync` mid-match and blow the react time limit.
+export async function withInstallBlock<T>(fn: () => Promise<T>): Promise<T> {
+  const { begin, end } = useInstallStore.getState()
+  begin()
+  try {
+    return await fn()
+  } finally {
+    end()
+  }
+}

--- a/frontend/src/routes/Bots.tsx
+++ b/frontend/src/routes/Bots.tsx
@@ -190,6 +190,7 @@ export function Bots() {
           name={editing}
           open
           onOpenChange={(open) => !open && setEditing(null)}
+          onEnvChanged={refresh}
         />
       )}
 
@@ -335,7 +336,7 @@ function InstallFromGithubDialog({ onInstalled }: { onInstalled: () => void }) {
   )
 }
 
-function BotSettingsDrawer({ name, open, onOpenChange }: { name: string; open: boolean; onOpenChange: (open: boolean) => void }) {
+function BotSettingsDrawer({ name, open, onOpenChange, onEnvChanged }: { name: string; open: boolean; onOpenChange: (open: boolean) => void; onEnvChanged: () => void }) {
   const { t } = useTranslation()
   const [data, setData] = useState<BotSettings | null>(null)
   const [values, setValues] = useState<Record<string, unknown>>({})
@@ -371,6 +372,9 @@ function BotSettingsDrawer({ name, open, onOpenChange }: { name: string; open: b
     setErr(null)
     try {
       await withInstallBlock(() => invoke('sync_bot_deps', { name, force: true }))
+      // Re-list bots so `env_ready` reflects the freshly-synced env and the
+      // activation switch becomes enabled without a manual refresh.
+      onEnvChanged()
     } catch (e) {
       setErr(String(e))
     } finally {

--- a/frontend/src/routes/Bots.tsx
+++ b/frontend/src/routes/Bots.tsx
@@ -29,6 +29,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { invoke } from '@/lib/tauri'
+import { withInstallBlock } from '@/lib/install'
 import { useBotStore } from '@/stores/botStore'
 import { useConfigStore } from '@/stores/configStore'
 import type { AppConfig, BotInfo, BotSettings } from '@/types'
@@ -134,18 +135,25 @@ export function Bots() {
                 <TableCell className="font-mono text-xs">{bot.manifest?.bot.version ?? '—'}</TableCell>
                 <TableCell>{bot.manifest ? <CheckCircle2 className="h-4 w-4 text-emerald-400" /> : '—'}</TableCell>
                 <TableCell>
-                  <Switch
-                    checked={isActive4p}
-                    disabled={!supportsMode(bot, '4p')}
-                    onCheckedChange={(v) => void setActive('4p', v ? bot.name : '')}
-                  />
+                  <span title={!bot.env_ready && !isActive4p ? t('bots.env_not_ready_tooltip') : undefined}>
+                    <Switch
+                      checked={isActive4p}
+                      // Block activating a bot whose env isn't installed yet,
+                      // but still allow turning one OFF (env may have been
+                      // wiped while it was active).
+                      disabled={!supportsMode(bot, '4p') || (!bot.env_ready && !isActive4p)}
+                      onCheckedChange={(v) => void setActive('4p', v ? bot.name : '')}
+                    />
+                  </span>
                 </TableCell>
                 <TableCell>
-                  <Switch
-                    checked={isActive3p}
-                    disabled={!supportsMode(bot, '3p')}
-                    onCheckedChange={(v) => void setActive('3p', v ? bot.name : '')}
-                  />
+                  <span title={!bot.env_ready && !isActive3p ? t('bots.env_not_ready_tooltip') : undefined}>
+                    <Switch
+                      checked={isActive3p}
+                      disabled={!supportsMode(bot, '3p') || (!bot.env_ready && !isActive3p)}
+                      onCheckedChange={(v) => void setActive('3p', v ? bot.name : '')}
+                    />
+                  </span>
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-1">
@@ -257,11 +265,13 @@ function InstallFromGithubDialog({ onInstalled }: { onInstalled: () => void }) {
     setBusy(true)
     setErr(null)
     try {
-      await invoke('install_bot_from_github', {
-        repo,
-        assetGlob: glob || undefined,
-        name: name || undefined,
-      })
+      await withInstallBlock(() =>
+        invoke('install_bot_from_github', {
+          repo,
+          assetGlob: glob || undefined,
+          name: name || undefined,
+        }),
+      )
       setOpen(false)
       setRepo('')
       setName('')
@@ -360,7 +370,7 @@ function BotSettingsDrawer({ name, open, onOpenChange }: { name: string; open: b
     setResyncing(true)
     setErr(null)
     try {
-      await invoke('sync_bot_deps', { name, force: true })
+      await withInstallBlock(() => invoke('sync_bot_deps', { name, force: true }))
     } catch (e) {
       setErr(String(e))
     } finally {

--- a/frontend/src/routes/Setup.tsx
+++ b/frontend/src/routes/Setup.tsx
@@ -13,7 +13,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Toaster } from '@/components/ui/sonner'
+import { InstallBlockingOverlay } from '@/components/InstallBlockingOverlay'
 import { invoke } from '@/lib/tauri'
+import { withInstallBlock } from '@/lib/install'
 import { useTauriBridge } from '@/hooks/useTauriBridge'
 import { useConfigStore } from '@/stores/configStore'
 import { ManifestField } from '@/components/ManifestField'
@@ -154,6 +156,7 @@ export function Setup() {
   return (
     <div className="min-h-screen w-full flex items-center justify-center p-6">
       <Toaster />
+      <InstallBlockingOverlay />
       <Card className="w-full max-w-2xl">
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -605,11 +608,13 @@ function BotsStep() {
       return rest
     })
     try {
-      await invoke('install_bot_from_github', {
-        repo: BOT_REPO,
-        assetGlob: mode === '4p' ? BOT_4P_ASSET : BOT_3P_ASSET,
-        name: mode === '4p' ? BOT_4P_NAME : BOT_3P_NAME,
-      })
+      await withInstallBlock(() =>
+        invoke('install_bot_from_github', {
+          repo: BOT_REPO,
+          assetGlob: mode === '4p' ? BOT_4P_ASSET : BOT_3P_ASSET,
+          name: mode === '4p' ? BOT_4P_NAME : BOT_3P_NAME,
+        }),
+      )
       await refresh()
     } catch (e) {
       setErrors((prev) => ({ ...prev, [mode]: String(e) }))

--- a/frontend/src/stores/installStore.ts
+++ b/frontend/src/stores/installStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+// Drives the global blocking overlay shown while a bot's Python environment
+// is being installed (GitHub install / reinstall / "Reinstall environment"
+// sync). `count` is a counter rather than a bool so overlapping operations
+// don't clear the overlay early. `title`/`body` mirror the latest backend
+// progress notification (ids `bot-install-*` / `bot-sync-*`).
+type InstallStore = {
+  count: number
+  title: string | null
+  body: string | null
+  begin: () => void
+  end: () => void
+  setProgress: (n: { title: string; body?: string | null }) => void
+}
+
+export const useInstallStore = create<InstallStore>((set) => ({
+  count: 0,
+  title: null,
+  body: null,
+  begin: () => set((s) => ({ count: s.count + 1 })),
+  end: () =>
+    set((s) => {
+      const count = Math.max(0, s.count - 1)
+      return count === 0 ? { count, title: null, body: null } : { count }
+    }),
+  setProgress: (n) => set({ title: n.title, body: n.body ?? null }),
+}))

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -153,6 +153,8 @@ export type BotInfo = {
   name: string
   dir: string
   has_pyproject: boolean
+  /** Bot's Python environment is installed and ready (no slow first-spawn sync). */
+  env_ready: boolean
   manifest?: Manifest
 }
 

--- a/src/bot/README.md
+++ b/src/bot/README.md
@@ -282,6 +282,17 @@ Frontend → backend: `set_active_bot(mode, name)` IPC command, where
 `mode` is `"4p"` or `"3p"` and `name` is the bot subdir name (or `""`
 to clear the slot). The Bots route shows two switches per row.
 
+`set_active_bot` refuses to activate a bot whose Python environment isn't
+installed yet (`runtime::is_synced` is false — `pyproject.toml` present but
+no up-to-date `.akagi/venv` + `synced.stamp`). Otherwise the bot's first
+in-game spawn would run `uv sync`, which can exceed the react time limit and
+error. `BotInfo.env_ready` surfaces this to the frontend, which disables the
+activation switch (and shows a tooltip) until the env is installed. A bot with
+no `pyproject.toml` has nothing to install and is always `env_ready`. The
+install/sync IPC paths run `uv sync` to completion before returning, and the
+frontend shows a non-dismissible blocking overlay for their whole duration, so
+the user can't navigate away or start a game mid-install.
+
 Pre-3p config files with a single `[bot] active = "..."` key are
 migrated on load: the legacy value is moved to `active_4p` once via
 `BotConfig::migrate_legacy_active`, and the on-disk file is rewritten

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -190,6 +190,35 @@ fn scrub_python_env(cmd: &mut Command) {
     cmd.env_remove("PYTHONHOME").env_remove("PYTHONPATH");
 }
 
+/// True when `bot_dir`'s Python environment is already installed — i.e.
+/// `ensure_synced` would short-circuit instead of running `uv sync`. A bot
+/// with no `pyproject.toml` has nothing to install and is always ready.
+///
+/// Inspects only the on-disk stamp + venv (no `uv`, no async), so it's cheap
+/// enough to call while listing bots or gating activation. Deliberately does
+/// NOT require `venv_python_alive`: a dangling venv symlink (the AppImage
+/// mount-changed case) is repaired by a cheap repoint inside `ensure_synced`,
+/// not a slow full re-sync, so it shouldn't block a bot from being activated.
+pub fn is_synced(bot_dir: &Path) -> bool {
+    let pyproject = bot_dir.join("pyproject.toml");
+    if !pyproject.is_file() {
+        return true;
+    }
+    let lock = bot_dir.join("uv.lock");
+    let venv = bot_dir.join(AKAGI_DIR).join(VENV_DIR);
+    let stamp_path = bot_dir.join(AKAGI_DIR).join(STAMP_FILE);
+    let Ok(current) = current_signature(&pyproject, &lock) else {
+        return false;
+    };
+    if !venv.is_dir() {
+        return false;
+    }
+    match std::fs::read_to_string(&stamp_path) {
+        Ok(saved) => saved.trim() == current,
+        Err(_) => false,
+    }
+}
+
 /// Wipe the stamp file and the venv so the next `ensure_synced` runs from
 /// scratch. Used by the user-triggered "Reinstall environment" path —
 /// stamp-only invalidation lets `uv sync` re-run, but uv's sync is
@@ -567,6 +596,52 @@ mod tests {
             !cfg.contains("mount_OLD"),
             "pyvenv.cfg must not retain the stale mount path, got:\n{cfg}"
         );
+    }
+
+    #[test]
+    fn is_synced_true_without_pyproject() {
+        let tmp = TempDir::new().unwrap();
+        // No pyproject.toml → nothing to install → always ready.
+        assert!(is_synced(tmp.path()));
+    }
+
+    #[test]
+    fn is_synced_false_when_venv_and_stamp_missing() {
+        let tmp = TempDir::new().unwrap();
+        write(&tmp.path().join("pyproject.toml"), "[project]\nname='a'\n");
+        // Has deps but no venv / stamp → not installed yet.
+        assert!(!is_synced(tmp.path()));
+    }
+
+    #[test]
+    fn is_synced_tracks_stamp_signature() {
+        let tmp = TempDir::new().unwrap();
+        let py = tmp.path().join("pyproject.toml");
+        write(&py, "[project]\nname='a'\n");
+        let lock = tmp.path().join("uv.lock");
+        let sig = current_signature(&py, &lock).unwrap();
+
+        let akagi = tmp.path().join(AKAGI_DIR);
+        std::fs::create_dir_all(akagi.join(VENV_DIR)).unwrap();
+        std::fs::write(akagi.join(STAMP_FILE), &sig).unwrap();
+        assert!(is_synced(tmp.path()), "matching stamp + venv → ready");
+
+        // Stale stamp (e.g. pyproject changed since last sync) → not ready.
+        std::fs::write(akagi.join(STAMP_FILE), "v1|stale").unwrap();
+        assert!(!is_synced(tmp.path()));
+    }
+
+    #[test]
+    fn is_synced_false_when_stamp_present_but_venv_missing() {
+        let tmp = TempDir::new().unwrap();
+        let py = tmp.path().join("pyproject.toml");
+        write(&py, "[project]\nname='a'\n");
+        let sig = current_signature(&py, &tmp.path().join("uv.lock")).unwrap();
+        let akagi = tmp.path().join(AKAGI_DIR);
+        std::fs::create_dir_all(&akagi).unwrap();
+        std::fs::write(akagi.join(STAMP_FILE), &sig).unwrap();
+        // Stamp matches but the venv dir is gone → must re-sync.
+        assert!(!is_synced(tmp.path()));
     }
 
     #[tokio::test]

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -60,6 +60,7 @@ fn entry_to_info(e: &BotEntry) -> BotInfo {
         name: e.name.clone(),
         dir: e.dir.to_string_lossy().into_owned(),
         has_pyproject: e.pyproject.is_some(),
+        env_ready: runtime::is_synced(&e.dir),
         manifest: e.manifest.clone(),
     }
 }
@@ -252,12 +253,30 @@ pub async fn update_bot_settings(
 /// next `start_game` event anyway, and picks the matching mode bot then.
 ///
 /// Empty `name` clears that mode's active bot (analysis-only in that mode).
+///
+/// Refuses to activate a bot whose Python environment isn't installed yet:
+/// otherwise the bot's first in-game spawn would run `uv sync`, which can
+/// exceed the react time limit and error. Clearing (empty `name`) is always
+/// allowed.
 #[tauri::command]
 pub async fn set_active_bot(
     mode: String,
     name: String,
     state: State<'_, AppState>,
 ) -> CmdResult<()> {
+    if !name.is_empty() {
+        let dir = state.config.read().await.bot.dir.clone();
+        let resolved = resolve_dir(Path::new(&dir));
+        let registry = BotRegistry::scan(&resolved).map_err(|e| format!("scan bots: {e:#}"))?;
+        let entry = registry
+            .find(&name)
+            .ok_or_else(|| format!("bot {name:?} not found"))?;
+        if !runtime::is_synced(&entry.dir) {
+            return Err(format!(
+                "Bot {name:?}'s Python environment isn't installed yet — install or sync it before setting it active."
+            ));
+        }
+    }
     {
         let mut cfg = state.config.write().await;
         match mode.as_str() {

--- a/src/schema/ipc.rs
+++ b/src/schema/ipc.rs
@@ -201,6 +201,12 @@ pub struct BotInfo {
     pub name: String,
     pub dir: String,
     pub has_pyproject: bool,
+    /// `true` when the bot's Python environment is already installed (no
+    /// `pyproject.toml`, or its venv + sync stamp are up to date). The UI
+    /// blocks activating a bot whose env isn't ready so a game never picks
+    /// a bot that would need a slow first-spawn `uv sync`.
+    #[serde(default)]
+    pub env_ready: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest: Option<crate::bot::manifest::Manifest>,
 }


### PR DESCRIPTION
Closes #123.

## Problem

Installing a bot from a GitHub release already runs `uv sync` (awaited) as part of the install, so the Python environment is set up during install. But nothing forced the user to wait: they could navigate away or start a game while the install (incl. `uv sync`) was still running. When a game started early, the bot's first spawn ran `uv sync` mid-match, which can take tens of seconds and **exceed the bot react time limit, causing errors**.

## Changes

### 1. Blocking install overlay
- `stores/installStore.ts` — in-flight counter + latest progress `title`/`body`.
- `lib/install.ts` — `withInstallBlock(fn)` brackets a long install/sync with begin/end.
- `components/InstallBlockingOverlay.tsx` — non-dismissible full-screen overlay (`z-[100]`, above sidebar `z-20` and dialogs `z-50`), spinner + live progress + amber warning; swallows clicks and keydown. Mounted in `App.tsx` and `Setup.tsx`.
- `useTauriBridge.ts` — routes `bot-install-*` / `bot-sync-*` notifications to the overlay.
- Wrapped the GitHub install (Bots + Setup wizard) and `sync_bot_deps` (Reinstall environment) call sites.

While the overlay is up, in-app navigation and starting a game are impossible until the env finishes installing.

### 2. Env-readiness activation gate
- `runtime::is_synced(bot_dir)` — cheap on-disk check (no `uv`): `true` when there's no `pyproject.toml`, or the `.akagi/venv` + `synced.stamp` are up to date. Skips the `venv_python_alive` check on purpose — a stale AppImage symlink is repaired by a cheap repoint, not a full sync.
- `BotInfo.env_ready` exposes it; `entry_to_info` fills it in.
- `set_active_bot` rejects activating a bot whose env isn't ready (clearing always allowed).
- Bots route disables the 4p/3p activation switch (with a tooltip) when `!env_ready`, unless that mode is already active (so an active-but-wiped bot can still be turned off).

A game therefore never picks a bot that would need a slow first-spawn sync.

## Tests / checks
- `cargo test --lib bot::` → 68 passed (incl. 4 new `is_synced` tests). `cargo clippy --lib` clean for touched files.
- Frontend `tsc -b` clean; `vite build` succeeds. New files add no eslint errors.

i18n added for en / zh-TW / zh-CN / ja.