### PR TITLE
Apply Zen Inspired default theme; enlarge Overview wordmark

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,8 +53,10 @@
  * ------------------------------------------------------------
  * Each named palette declares the full shadcn CSS variable set for both
  * light (`:root[...]`) and dark (`.dark[...]`). The base `:root` / `.dark`
- * blocks below are the Akagi default theme; named themes (`crimson`,
- * `slate`) layer over them via the `data-theme` attribute on <html>.
+ * blocks below are the default theme ("Zen Inspired" — a neutral
+ * monochrome palette with cool-blue chart accents); named themes
+ * (`crimson`, `slate`) layer over them via the `data-theme` attribute
+ * on <html>.
  *
  * Variable inventory follows ui.shadcn.com/docs/theming — adding a new
  * theme means redeclaring all of these in both modes.
@@ -67,76 +69,77 @@
  *   geometry    : radius (set once, not theme-dependent)
  * ============================================================ */
 
-/* ---------------- Akagi (default) — light ---------------- */
+/* ---------------- Zen Inspired (default) — light ---------------- */
 :root {
-    --background: oklch(0.985 0.003 180);
-    --foreground: oklch(0.20 0.014 200);
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
-    --card-foreground: oklch(0.20 0.014 200);
+    --card-foreground: oklch(0.145 0 0);
     --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.20 0.014 200);
-    --primary: oklch(0.55 0.13 162);
-    --primary-foreground: oklch(0.99 0.005 162);
-    --secondary: oklch(0.94 0.012 180);
-    --secondary-foreground: oklch(0.25 0.015 200);
-    --muted: oklch(0.95 0.008 180);
-    --muted-foreground: oklch(0.48 0.022 200);
-    --accent: oklch(0.92 0.04 162);
-    --accent-foreground: oklch(0.30 0.08 162);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.85 0.015 200);
-    --input: oklch(0.88 0.012 200);
-    --ring: oklch(0.55 0.13 162);
-    --chart-1: oklch(0.67 0.16 162);
-    --chart-2: oklch(0.60 0.15 200);
-    --chart-3: oklch(0.55 0.14 240);
-    --chart-4: oklch(0.70 0.16 80);
-    --chart-5: oklch(0.65 0.17 30);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --chart-1: oklch(0.81 0.10 252);
+    --chart-2: oklch(0.62 0.19 260);
+    --chart-3: oklch(0.55 0.22 263);
+    --chart-4: oklch(0.49 0.22 264);
+    --chart-5: oklch(0.42 0.18 266);
     --radius: 0.625rem;
-    --sidebar: oklch(0.97 0.005 180);
-    --sidebar-foreground: oklch(0.20 0.014 200);
-    --sidebar-primary: oklch(0.55 0.13 162);
-    --sidebar-primary-foreground: oklch(0.99 0.005 162);
-    --sidebar-accent: oklch(0.92 0.04 162);
-    --sidebar-accent-foreground: oklch(0.30 0.08 162);
-    --sidebar-border: oklch(0.85 0.015 200);
-    --sidebar-ring: oklch(0.55 0.13 162);
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
 }
 
-/* ---------------- Akagi (default) — dark ---------------- */
+/* ---------------- Zen Inspired (default) — dark ---------------- */
 .dark {
-    /* Akagi brand: emerald primary, deep teal-tinted surfaces */
-    --background: oklch(0.16 0.012 200);
-    --foreground: oklch(0.96 0.005 180);
-    --card: oklch(0.20 0.014 200);
-    --card-foreground: oklch(0.96 0.005 180);
-    --popover: oklch(0.20 0.014 200);
-    --popover-foreground: oklch(0.96 0.005 180);
-    --primary: oklch(0.78 0.16 162);
-    --primary-foreground: oklch(0.18 0.014 200);
-    --secondary: oklch(0.26 0.018 200);
-    --secondary-foreground: oklch(0.985 0.005 180);
-    --muted: oklch(0.26 0.018 200);
-    --muted-foreground: oklch(0.72 0.018 200);
-    --accent: oklch(0.30 0.04 162);
-    --accent-foreground: oklch(0.96 0.005 180);
+    /* Neutral monochrome surfaces; light primary on near-black background.
+     * Chart palette stays cool blue/indigo for continuity with light mode. */
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.269 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.371 0 0);
+    --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 12%);
-    --input: oklch(1 0 0 / 16%);
-    --ring: oklch(0.78 0.16 162);
-    --chart-1: oklch(0.78 0.16 162);
-    --chart-2: oklch(0.70 0.14 200);
-    --chart-3: oklch(0.65 0.13 240);
-    --chart-4: oklch(0.78 0.15 80);
-    --chart-5: oklch(0.72 0.17 30);
-    --sidebar: oklch(0.18 0.013 200);
-    --sidebar-foreground: oklch(0.96 0.005 180);
-    --sidebar-primary: oklch(0.78 0.16 162);
-    --sidebar-primary-foreground: oklch(0.18 0.014 200);
-    --sidebar-accent: oklch(0.26 0.018 200);
-    --sidebar-accent-foreground: oklch(0.96 0.005 180);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.78 0.16 162);
+    --border: oklch(0.275 0 0);
+    --input: oklch(0.325 0 0);
+    --ring: oklch(0.556 0 0);
+    --chart-1: oklch(0.81 0.10 252);
+    --chart-2: oklch(0.62 0.19 260);
+    --chart-3: oklch(0.55 0.22 263);
+    --chart-4: oklch(0.49 0.22 264);
+    --chart-5: oklch(0.42 0.18 266);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(0.275 0 0);
+    --sidebar-ring: oklch(0.439 0 0);
 }
 
 /* ---------------- Crimson — light ---------------- */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -71,7 +71,12 @@
 
 /* ---------------- Zen Inspired (default) — light ---------------- */
 :root {
-    --background: oklch(1 0 0);
+    /* Page background is dropped one notch below pure white so `--card`
+     * (still `oklch(1 0 0)`) reads as a distinct surface — the tweakcn
+     * source ships both at pure white and relies on `--border` alone,
+     * which is too faint on the dense GameDashboard grid. The sidebar
+     * shares this value, keeping the page/sidebar continuity intact. */
+    --background: oklch(0.985 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
     --card-foreground: oklch(0.145 0 0);

--- a/frontend/src/routes/Overview.tsx
+++ b/frontend/src/routes/Overview.tsx
@@ -33,7 +33,7 @@ export function Overview() {
   return (
     <div className="p-6 flex flex-col gap-6 w-full">
       <div className="flex justify-center pt-2 pb-1">
-        <AkagiWordmark className="h-14" />
+        <AkagiWordmark className="h-28" />
       </div>
       <header>
         <h1 className="text-2xl font-semibold">{t('overview.title')}</h1>


### PR DESCRIPTION
Closes #127.

## What changed

### 1. New default theme — "Zen Inspired"
Replaced the `:root` (light) and `.dark` blocks in `frontend/src/index.css` with the [Zen Inspired](https://tweakcn.com/themes/cmlm03etv000204lh15608kec) palette from tweakcn:

- **Surfaces**: neutral monochrome (background / card / popover / muted / accent all on a pure-gray scale; previous default was teal-tinted).
- **Primary**: near-black on light (`oklch(0.205 0 0)`), near-white on dark (`oklch(0.922 0 0)`). The previous default was emerald (`oklch(0.55 0.13 162)` / `oklch(0.78 0.16 162)`).
- **Charts 1..5**: cool blue→indigo ramp (`oklch(0.81 0.10 252)` → `oklch(0.42 0.18 266)`) — identical between light and dark, replacing the previous mixed green/blue/yellow/red set.
- **Dark popover** is intentionally lighter (`oklch(0.269 0 0)`) than the card (`oklch(0.205 0 0)`); the previous default tied them together.
- **Dark sidebar-primary** is an indigo accent (`oklch(0.488 0.243 264.376)`) — the one place colour breaks through the monochrome surfaces, matching the tweakcn source.

The `[data-theme=\"crimson\"]` and `[data-theme=\"slate\"]` palettes are unchanged, and the user-editable `custom` palette is also unaffected (its generator in `stores/themeStore.ts` derives its own variable set and doesn't read from `:root`).

### 2. Overview wordmark doubled
`frontend/src/routes/Overview.tsx` — `<AkagiWordmark className="h-14" />` → `h-28`. Twice the height; the wordmark already sits in a centered `flex justify-center` row, so layout absorbs the change without further tweaks.

## Verification
- `npm run build` (tsc -b && vite build) — clean; no TS / CSS errors.
- Smoke-checked the diff visually against the tweakcn source values.