### PR TITLE
feat(bot): let mjai bots push toast notifications to the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,29 +304,13 @@ suggestion).
 
 ### Write your own
 
-```
-mjai_bot/<name>/
-├── bot.py            # JSONL stdin → JSONL stdout
-├── pyproject.toml    # requires-python = ">=3.12"
-├── manifest.toml     # optional — supported_modes, settings schema
-└── README.md
-```
-
-`bot.py` reads one JSON array of mjai events per line and writes one
-mjai action object per line (`{"type":"none"}` when no action is owed).
-Akagi pumps stderr into the application log under `bot=<name>`.
-
-A bot can also push a **toast notification** to the UI (it pops in the
-bottom-right corner) by writing a single stderr line prefixed with
-`@@AKAGI_NOTIFY@@ ` followed by a JSON object with a `level`
-(`info` / `success` / `warn` / `error`), a `title`, and an optional
-`body`. See [`mjai_bot/README.md`](./mjai_bot/README.md) for the full
-notification protocol and a copy-pasteable helper.
-
-See [`src/bot/README.md`](./src/bot/README.md) for the full contract,
-the manifest schema, and the secret-field handling.
-[`mjai_bot/example/`](./mjai_bot/example/) is a working rule-based
-reference that ships in tree.
+A bot is a standalone subprocess that talks JSONL over stdin/stdout — Akagi
+feeds it the game as mjai events and it replies with an action plus optional
+HUD data. The full developer guide lives in
+**[`mjai_bot/README.md`](./mjai_bot/README.md)**: the I/O protocol, the mjai
+event stream, the reaction and `meta` HUD format, toast notifications, and
+`manifest.toml` settings. [`mjai_bot/example/`](./mjai_bot/example/) is a
+working rule-based bot you can copy.
 
 ### AGPL boundary
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,13 @@ mjai_bot/<name>/
 mjai action object per line (`{"type":"none"}` when no action is owed).
 Akagi pumps stderr into the application log under `bot=<name>`.
 
+A bot can also push a **toast notification** to the UI (it pops in the
+bottom-right corner) by writing a single stderr line prefixed with
+`@@AKAGI_NOTIFY@@ ` followed by a JSON object with a `level`
+(`info` / `success` / `warn` / `error`), a `title`, and an optional
+`body`. See [`mjai_bot/README.md`](./mjai_bot/README.md) for the full
+notification protocol and a copy-pasteable helper.
+
 See [`src/bot/README.md`](./src/bot/README.md) for the full contract,
 the manifest schema, and the secret-field handling.
 [`mjai_bot/example/`](./mjai_bot/example/) is a working rule-based

--- a/mjai_bot/README.md
+++ b/mjai_bot/README.md
@@ -1,29 +1,223 @@
-# `mjai_bot/` — bot development
+# Writing an mjai bot for Akagi
 
-Each subdirectory here is one self-contained bot: a `bot.py` entry point, a
-`pyproject.toml` declaring its Python dependencies, and an optional
-`manifest.toml` describing user-configurable settings. Akagi spawns the bot as
-a subprocess and talks to it over a line-based protocol.
+This is the developer guide for building your own AI bot. A bot is a
+**standalone subprocess** that Akagi spawns and talks to over a simple
+line-based JSON protocol — Akagi feeds it the live game as mjai events and the
+bot replies with the action it wants to take, plus optional data for the HUD.
 
-## I/O protocol
+Everything a bot needs is in this document: the I/O protocol, the mjai event
+stream, the reaction format and the `meta` HUD payload, toast notifications,
+and user-configurable settings. The reference bot in
+[`example/`](example/) implements all of it in plain Python and is the best
+companion to read alongside this guide.
 
-- **stdin** — Akagi writes one JSON array of mjai events per line (a batch up
-  to the current decision point).
-- **stdout** — the bot writes **exactly one** JSON mjai reaction per input
-  line (`{"type":"dahai",...}`, or `{"type":"none"}` when not acting). An
-  optional `meta` object on the reaction is forwarded verbatim to the HUD.
+> **Internals?** This guide is for *bot authors*. If you're hacking on how
+> Akagi *runs* bots (the Rust runner, the lifecycle manager, the bundled
+> Python runtime, GitHub install), see [`../src/bot/README.md`](../src/bot/README.md).
 
-Because stdout is parsed strictly as one reaction per line, **never print
-anything else to stdout** — it desyncs the protocol.
+## Contents
 
-- **stderr** — free-form. Lines are pumped into Akagi's logs, *except*
-  notification lines (below).
+- [Directory layout](#directory-layout)
+- [The I/O protocol](#the-io-protocol)
+- [Knowing your seat](#knowing-your-seat)
+- [The mjai event stream](#the-mjai-event-stream)
+- [The reaction & the `meta` field](#the-reaction--the-meta-field)
+- [Frontend toast notifications](#frontend-toast-notifications)
+- [User-configurable settings (`manifest.toml`)](#user-configurable-settings-manifesttoml)
+- [Registering the bot](#registering-the-bot)
+- [AGPL boundary](#agpl-boundary)
 
-## Sending notifications to the frontend (`@@AKAGI_NOTIFY@@`)
+## Directory layout
 
-A bot can push a toast notification to the Akagi UI — it pops in the app's
-bottom-right corner. This rides on stderr so it never interferes with the
-stdout reaction protocol and can be sent at any time, not just on a reaction.
+Each bot lives in its own folder under `mjai_bot/`:
+
+```
+mjai_bot/<name>/
+├── bot.py            # entry point — speaks the I/O protocol below
+├── pyproject.toml    # dependencies; requires-python = ">=3.12"
+├── manifest.toml     # OPTIONAL — UI metadata + settings schema
+├── settings.toml     # OPTIONAL — current setting values (written by Akagi at runtime)
+└── README.md         # bot-specific notes (model files, license, …)
+```
+
+`pyproject.toml` declares the bot's Python dependencies. On the first launch
+Akagi runs `uv sync` into a per-bot virtual environment, so a bot can pull in
+whatever packages it needs without touching the rest of the system. (Akagi
+ships its own Python + `uv`, so bots run even with no system Python installed.)
+
+## The I/O protocol
+
+Akagi spawns `bot.py` once per game (working directory = the bot's folder) and
+communicates over **stdin / stdout**, one JSON value per line:
+
+- **stdin → bot**: a JSON **array** of mjai events, newline-terminated. Each
+  line is a *batch* — every event the game produced since the last time the bot
+  was asked to react.
+- **bot → stdout**: **exactly one** JSON reaction object, newline-terminated.
+  This is a single mjai action (see below), or `{"type":"none"}` when the bot
+  has nothing to do this turn.
+
+```
+ stdin  →  [{"type":"tsumo","actor":2,"pai":"5p"}]
+stdout  ←  {"type":"dahai","actor":2,"pai":"1m","tsumogiri":false}
+```
+
+Rules:
+
+- **Reply to every line with exactly one reaction.** Reading is strictly
+  one-reaction-per-batch; printing extra lines (or none) desyncs the protocol.
+- **stdout is for protocol JSON only.** Send logs and diagnostics to **stderr**
+  (Akagi pumps stderr into its application log under `bot=<name>`). stderr also
+  carries [toast notifications](#frontend-toast-notifications).
+- **`{"type":"none"}`** is the correct reply whenever it isn't the bot's turn or
+  no call is available. The bot still sees every event so its internal state
+  stays current; it just declines to act.
+- **Shut down on `end_game`.** When a batch contains `{"type":"end_game"}`,
+  reply once (`{"type":"none"}` is fine) and exit cleanly.
+- **React budget ≈ 5 s.** Akagi aborts the bot if a reaction takes longer than
+  the default timeout, so keep inference within a few seconds.
+
+A minimal loop:
+
+```python
+import json, sys
+
+def react(events: list[dict]) -> dict:
+    # ... inspect events, update state, decide ...
+    return {"type": "none"}
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    events = json.loads(line)
+    sys.stdout.write(json.dumps(react(events), separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+    if any(e.get("type") == "end_game" for e in events):
+        break
+```
+
+> **Note on batches.** Akagi only asks the bot to react at *decision points*
+> (your own draw, an opponent's discard that opens a call window, your own
+> call, round/game boundaries). The triggering event is the **last** element of
+> the batch; the earlier elements are the events that accumulated since the
+> previous reaction. The bot doesn't need to detect decision points itself —
+> just keep state current from the whole batch and act on the last event.
+
+## Knowing your seat
+
+The bot's seat (`actor_id`, 0–3) is delivered three ways. Use whichever is
+convenient; prefer the `start_game` value as authoritative:
+
+1. **argv** — `python bot.py <player_id>` (matches the mjai.app convention, so
+   unmodified mjai.app bots work as-is).
+2. **`AKAGI_PLAYER_ID`** — environment variable, always set to the same value.
+3. **`start_game.id`** — the `id` field on the first `start_game` event. This is
+   the source of truth (argv/env exist mainly for mjai.app compatibility).
+
+The reference bot resolves argv → env → default, then trusts `start_game.id`
+once the game begins.
+
+## The mjai event stream
+
+Akagi speaks the **mjai** protocol. The authoritative, always-current list of
+event types and their exact field shapes is the `MjaiEvent` enum in
+[`../src/schema/mjai/mod.rs`](../src/schema/mjai/mod.rs) — read it as the
+schema. The wire `type` strings:
+
+| `type`           | Fields (key ones)                                     | Notes |
+| ---------------- | ----------------------------------------------------- | ----- |
+| `start_game`     | `names`, `id` (your seat), `num_players`, `aka_flag`  | First event. |
+| `start_kyoku`    | `bakaze`, `kyoku`, `honba`, `oya`, `dora_marker`, `scores`, `tehais` | Hand start; `tehais[seat]` is the deal. |
+| `tsumo`          | `actor`, `pai`                                        | A draw. |
+| `dahai`          | `actor`, `pai`, `tsumogiri`                           | A discard. |
+| `chi`            | `actor`, `target`, `pai`, `consumed[2]`               | |
+| `pon`            | `actor`, `target`, `pai`, `consumed[2]`               | |
+| `daiminkan`      | `actor`, `target`, `pai`, `consumed[3]`               | open kan |
+| `kakan`          | `actor`, `pai`, `consumed[3]`                         | added kan |
+| `ankan`          | `actor`, `consumed[4]`                                | closed kan |
+| `dora`           | `dora_marker`                                         | new dora indicator |
+| `reach`          | `actor`, `pai?`                                       | riichi declaration |
+| `reach_accepted` | `actor`                                               | stick committed |
+| `hora`           | `actor`, `target`, `deltas?`, `ura_markers?`          | a win |
+| `ryukyoku`       | `deltas?`                                             | exhaustive draw |
+| `kita`           | `actor`, `pai?`                                       | 3-player only (North) |
+| `end_kyoku`      | —                                                     | hand over |
+| `end_game`       | —                                                     | game over → exit |
+
+**Tile strings** (`pai`, `consumed`, `tehais`, …) are mjai notation: `"1m"`…
+`"9m"` (man), `"…p"` (pin), `"…s"` (sou); honors `"E" "S" "W" "N"` (winds) and
+`"P" "F" "C"` (haku / hatsu / chun); a red five is suffixed `r`, e.g. `"5mr"`.
+A hidden/unknown tile is `"?"`.
+
+## The reaction & the `meta` field
+
+A reaction is one mjai action object — the same shape as the events above. The
+common replies:
+
+```jsonc
+{"type":"none"}                                              // not my turn / pass
+{"type":"dahai","actor":2,"pai":"1m","tsumogiri":false}      // discard
+{"type":"reach","actor":2}                                   // declare riichi (the dahai follows next turn)
+{"type":"pon","actor":2,"target":0,"pai":"1m","consumed":["1m","1m"]}
+{"type":"hora","actor":2,"target":0,"pai":"5p"}              // ron / tsumo
+```
+
+### `meta` — optional HUD payload
+
+A reaction may carry an extra **`meta`** object alongside the action. Akagi
+treats `meta` as **opaque** and forwards it verbatim to the frontend; the bot
+owns its contents. Use it to surface *why* the bot chose its action:
+
+```json
+{"type":"dahai","actor":0,"pai":"9m","tsumogiri":false,
+ "meta":{"q_values":[0.12,0.05,0.85],"confidence":0.87}}
+```
+
+Any keys you put in `meta` are visible in the HUD's bot-responses view as raw
+data, so even ad-hoc fields are useful for debugging.
+
+### `meta.show` — the structured HUD card
+
+For a clean, rendered display, populate **`meta.show`**. Akagi's *Bot Show* HUD
+tile renders the most recent reaction that carries it as a titled list of rows
+(top-N discards, opponent reads, yaku breakdowns — you decide the semantics):
+
+```json
+{"type":"dahai","actor":0,"pai":"1m","tsumogiri":false,
+ "meta":{"show":{
+   "title":"Discard candidates",
+   "items":[
+     {"label":"Discard 1m","pais":["1m"],"value":"85.42%","color":"#00ff80","note":"keeps tenpai"},
+     {"label":"Discard 9p","pais":["9p"],"value":"11.30%"},
+     {"label":"Riichi","value":"+12000","color":"#ffaa00"}
+   ]
+ }}}
+```
+
+`meta.show` shape:
+
+| Field    | Type       | Meaning                                                                 |
+| -------- | ---------- | ----------------------------------------------------------------------- |
+| `title`  | string?    | Card heading; falls back to a default title.                            |
+| `items`  | array      | One row each. Rows with no `label`/`tiles`/`pais` are skipped.          |
+
+Each item in `items`:
+
+| Field   | Type      | Meaning                                                                            |
+| ------- | --------- | ---------------------------------------------------------------------------------- |
+| `label` | string?   | Primary text on the row.                                                           |
+| `pais`  | string[]? | mjai tile strings, rendered as tile graphics.                                      |
+| `tiles` | string?   | Raw mahgen DSL string; takes precedence over `pais` if both are set.               |
+| `value` | string?   | Right-aligned text — any format, e.g. `"85.42%"`, `"+12000"`.                       |
+| `color` | string?   | Hex accent, e.g. `"#00ff80"` — drawn as a left bar + faint row tint.                |
+| `note`  | string?   | Small subtitle under `label`.                                                      |
+
+## Frontend toast notifications
+
+A bot can push a **toast notification** to the Akagi UI — it pops in the app's
+bottom-right corner. This rides on **stderr** so it never interferes with the
+stdout reaction protocol, and can be sent at any time, not just on a reaction.
 
 Write a single stderr line of the form:
 
@@ -31,8 +225,7 @@ Write a single stderr line of the form:
 @@AKAGI_NOTIFY@@ {"level":"warn","title":"...","body":"...","sticky":false,"id":"..."}
 ```
 
-The JSON object after the `@@AKAGI_NOTIFY@@ ` prefix (note the trailing space)
-is the notification:
+The JSON object after the `@@AKAGI_NOTIFY@@ ` prefix (note the trailing space):
 
 | Field    | Type   | Required | Meaning                                                            |
 | -------- | ------ | -------- | ------------------------------------------------------------------ |
@@ -42,14 +235,11 @@ is the notification:
 | `sticky` | bool   | no       | `true` keeps the toast until dismissed (default `false`).          |
 | `id`     | string | no       | Stable key; a later toast with the same `id` replaces the earlier. |
 
-Anything on stderr **without** this exact prefix is logged as an ordinary
+Any stderr line **without** this exact prefix is logged as an ordinary
 diagnostic line. A malformed payload after the prefix is logged as a warning
 and dropped — it never reaches the UI.
 
-### Helper
-
-The reference bot in [`example/bot.py`](example/bot.py) includes a small
-copy-pasteable helper:
+A copy-pasteable helper (also in [`example/bot.py`](example/bot.py)):
 
 ```python
 import json, sys
@@ -76,10 +266,83 @@ notify("error", "Model failed to load", "Falling back to rule-based play.")
 The protocol is just a stderr line, so any language can implement it — the
 helper is a convenience, not a requirement.
 
-## Adding a new bot
+## User-configurable settings (`manifest.toml`)
 
-1. Create `mjai_bot/<name>/` with a `bot.py` implementing the I/O protocol.
-2. Add a `pyproject.toml` listing dependencies (Akagi runs `uv sync` into a
-   per-bot venv on first launch).
-3. Optionally add a `manifest.toml` to expose settings as a form in the UI.
-4. Select the bot in Akagi's settings; it is picked up without a restart.
+A bot can expose settings that Akagi renders as a form in the **Bots** tab. Add
+a `manifest.toml`:
+
+```toml
+manifest_version = 1
+
+[bot]
+name        = "my-bot"                 # should match the folder name
+display     = "My Bot"                 # label in the bot picker
+description = "One-line description."
+version     = "0.1.0"
+supported_modes = ["4p", "3p"]         # defaults to ["4p"] if omitted
+
+[settings.temperature]
+type    = "float"                      # string | bool | int | float | enum
+label   = "Sampling temperature"
+default = 1.0
+help    = "Higher = more random."      # optional tooltip
+min     = 0.1                          # int/float only
+max     = 2.0
+step    = 0.1
+
+[settings.api_key]
+type   = "string"
+label  = "API key"
+default = ""
+secret = true                          # password input; redacted to *** in logs
+
+[settings.style]
+type    = "enum"
+label   = "Play style"
+default = "balanced"
+choices = ["aggressive", "balanced", "defensive"]   # required for enum
+```
+
+Field types (`type`): `string`, `bool`, `int`, `float`, `enum`. `int`/`float`
+accept `min`/`max`/`step`; `enum` requires `choices`. `secret = true` renders a
+password input and redacts the value to `***` in Akagi's logs (it is still
+stored in plaintext in `settings.toml`).
+
+The current values live in `settings.toml` (Akagi writes it when the user edits
+the form — it isn't something you commit). At spawn time Akagi merges manifest
+defaults with the saved values, writes the result to a JSON file, and points
+**`AKAGI_BOT_CONFIG`** at its absolute path. Read it on startup:
+
+```python
+import json, os
+
+cfg = {}
+path = os.environ.get("AKAGI_BOT_CONFIG")
+if path:
+    with open(path) as f:
+        cfg = json.load(f)          # {"temperature": 1.0, "style": "balanced", ...}
+```
+
+A bot with no `manifest.toml` simply gets no `AKAGI_BOT_CONFIG` and no settings
+panel — perfectly fine for a no-knobs bot.
+
+## Registering the bot
+
+1. Drop the folder under `mjai_bot/<name>/`. Akagi rescans on each game start,
+   so a freshly added bot is picked up without a restart.
+2. In Akagi's settings, set it as the active bot for 4-player and/or 3-player
+   games (`bot.active_4p` / `bot.active_3p` — the two slots are independent;
+   leave one empty to run that mode analysis-only).
+3. On first launch Akagi runs `uv sync` for the bot (a one-time, possibly slow
+   step shown as a "Preparing bot" toast); later launches are instant.
+
+Bots can also be installed straight from a GitHub release via the **Bots** tab
+— see [`../src/bot/README.md`](../src/bot/README.md) for that flow.
+
+## AGPL boundary
+
+Bots run as a **separate OS subprocess** and communicate strictly via JSONL
+over stdin/stdout — no in-process linking, no shared address space, no FFI.
+This is a deliberate license boundary: an AGPL-licensed bot stays inside its
+own process, so dropping it under `mjai_bot/<name>/` does **not** make Akagi a
+derived work of the bot.

--- a/mjai_bot/README.md
+++ b/mjai_bot/README.md
@@ -1,0 +1,85 @@
+# `mjai_bot/` — bot development
+
+Each subdirectory here is one self-contained bot: a `bot.py` entry point, a
+`pyproject.toml` declaring its Python dependencies, and an optional
+`manifest.toml` describing user-configurable settings. Akagi spawns the bot as
+a subprocess and talks to it over a line-based protocol.
+
+## I/O protocol
+
+- **stdin** — Akagi writes one JSON array of mjai events per line (a batch up
+  to the current decision point).
+- **stdout** — the bot writes **exactly one** JSON mjai reaction per input
+  line (`{"type":"dahai",...}`, or `{"type":"none"}` when not acting). An
+  optional `meta` object on the reaction is forwarded verbatim to the HUD.
+
+Because stdout is parsed strictly as one reaction per line, **never print
+anything else to stdout** — it desyncs the protocol.
+
+- **stderr** — free-form. Lines are pumped into Akagi's logs, *except*
+  notification lines (below).
+
+## Sending notifications to the frontend (`@@AKAGI_NOTIFY@@`)
+
+A bot can push a toast notification to the Akagi UI — it pops in the app's
+bottom-right corner. This rides on stderr so it never interferes with the
+stdout reaction protocol and can be sent at any time, not just on a reaction.
+
+Write a single stderr line of the form:
+
+```
+@@AKAGI_NOTIFY@@ {"level":"warn","title":"...","body":"...","sticky":false,"id":"..."}
+```
+
+The JSON object after the `@@AKAGI_NOTIFY@@ ` prefix (note the trailing space)
+is the notification:
+
+| Field    | Type   | Required | Meaning                                                            |
+| -------- | ------ | -------- | ------------------------------------------------------------------ |
+| `level`  | string | yes      | Severity: `"info"`, `"success"`, `"warn"`, or `"error"`.           |
+| `title`  | string | yes      | Short headline, shown in bold.                                     |
+| `body`   | string | no       | Longer description.                                                |
+| `sticky` | bool   | no       | `true` keeps the toast until dismissed (default `false`).          |
+| `id`     | string | no       | Stable key; a later toast with the same `id` replaces the earlier. |
+
+Anything on stderr **without** this exact prefix is logged as an ordinary
+diagnostic line. A malformed payload after the prefix is logged as a warning
+and dropped — it never reaches the UI.
+
+### Helper
+
+The reference bot in [`example/bot.py`](example/bot.py) includes a small
+copy-pasteable helper:
+
+```python
+import json, sys
+
+NOTIFY_PREFIX = "@@AKAGI_NOTIFY@@ "
+
+def notify(level, title, body=None, *, sticky=False, id=None):
+    payload = {"level": level, "title": title}
+    if body is not None:
+        payload["body"] = body
+    if sticky:
+        payload["sticky"] = True
+    if id is not None:
+        payload["id"] = id
+    sys.stderr.write(NOTIFY_PREFIX + json.dumps(payload, separators=(",", ":")) + "\n")
+    sys.stderr.flush()
+
+# Examples:
+notify("info", "Bot ready")
+notify("warn", "Low wall", "Fewer than 8 tiles left — playing defensively.")
+notify("error", "Model failed to load", "Falling back to rule-based play.")
+```
+
+The protocol is just a stderr line, so any language can implement it — the
+helper is a convenience, not a requirement.
+
+## Adding a new bot
+
+1. Create `mjai_bot/<name>/` with a `bot.py` implementing the I/O protocol.
+2. Add a `pyproject.toml` listing dependencies (Akagi runs `uv sync` into a
+   per-bot venv on first launch).
+3. Optionally add a `manifest.toml` to expose settings as a form in the UI.
+4. Select the bot in Akagi's settings; it is picked up without a restart.

--- a/mjai_bot/example/bot.py
+++ b/mjai_bot/example/bot.py
@@ -28,6 +28,49 @@ from mahjong.hand_calculating.hand_config import HandConfig
 from mahjong.meld import Meld
 from mahjong.shanten import Shanten
 
+# ---------- Akagi frontend notifications ----------
+#
+# Akagi reads the bot's stdout strictly as one mjai reaction per line, so a
+# bot must NOT print anything else there. stderr, however, is a free-form
+# side-channel: any line prefixed with NOTIFY_PREFIX followed by a JSON
+# object is parsed by Akagi and surfaced as a toast in the app's bottom-right
+# corner. Every other stderr line is treated as a normal diagnostic log line.
+#
+# Severity levels: "info", "success", "warn", "error".
+
+NOTIFY_PREFIX = "@@AKAGI_NOTIFY@@ "
+
+
+def notify(
+    level: str,
+    title: str,
+    body: str | None = None,
+    *,
+    sticky: bool = False,
+    id: str | None = None,
+) -> None:
+    """Send a toast notification to the Akagi frontend.
+
+    Args:
+        level: one of "info", "success", "warn", "error".
+        title: short headline shown in bold.
+        body: optional longer description.
+        sticky: if True the toast stays until dismissed (use for long-running
+            states); otherwise it auto-dismisses.
+        id: stable key — a later notification with the same id replaces the
+            earlier toast instead of stacking a new one (use for progress).
+    """
+    payload: dict[str, object] = {"level": level, "title": title}
+    if body is not None:
+        payload["body"] = body
+    if sticky:
+        payload["sticky"] = True
+    if id is not None:
+        payload["id"] = id
+    sys.stderr.write(NOTIFY_PREFIX + json.dumps(payload, separators=(",", ":")) + "\n")
+    sys.stderr.flush()
+
+
 # ---------- mjai tile string ↔ 34-array index ----------
 
 # 0-8 m, 9-17 p, 18-26 s, 27 E, 28 S, 29 W, 30 N, 31 P, 32 F, 33 C
@@ -142,6 +185,13 @@ class State:
         if t == "start_game":
             if "id" in e:
                 self.actor_id = int(e["id"])
+            # Demonstrates the frontend notification channel — a toast pops in
+            # the app's bottom-right corner. Remove or repurpose at will.
+            notify(
+                "info",
+                "Example bot ready",
+                f"Seated at player {self.actor_id}.",
+            )
         elif t == "start_kyoku":
             self.oya = e["oya"]
             self.bakaze = e["bakaze"]

--- a/src/bot/README.md
+++ b/src/bot/README.md
@@ -32,7 +32,12 @@ bridge to them.
   over stdin/stdout, pumps stderr into `tracing` (`bot=<name>` field),
   enforces a 5 s default react timeout, and `kill_on_drop(true)` so a
   dropped runner can't leak children. `reset()` writes `[{"end_game"}]`,
-  waits 500 ms, then SIGKILL's and respawns.
+  waits 500 ms, then SIGKILL's and respawns. The stderr pump doubles as a
+  bot→frontend notification channel: a line prefixed with `NOTIFY_PREFIX`
+  (`@@AKAGI_NOTIFY@@ `) followed by a JSON `Notification` is parsed and
+  forwarded onto the `NotifyBus` (→ `notify` Tauri event → bottom-right
+  toast); every other line is logged as before, and a malformed payload
+  after the prefix is dropped with a `warn!`.
 - `manager` — `BotManager`: subscribes to the `MjaiBus`, accumulates
   events between decision points (own tsumo / others' dahai-or-kakan /
   reach_accepted / hora / ryukyoku / end_kyoku / end_game), flushes the
@@ -63,6 +68,10 @@ mjai_bot/<name>/
   `{"type":"none"}` when no action is owed)
 - print **only** protocol JSON to stdout; logs go to stderr
 - exit cleanly when it sees `{"type":"end_game"}` in a batch
+
+A bot MAY also surface a toast in the UI by writing an
+`@@AKAGI_NOTIFY@@ {…}` line to stderr (level / title / body — see
+[`mjai_bot/README.md`](../../mjai_bot/README.md)).
 
 The bot's seat is delivered three ways (pick whichever fits):
 

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -382,6 +382,7 @@ impl BotManager {
             self.runtime.clone(),
             &entry.dir,
             actor_id,
+            self.notify_tx.clone(),
         )
         .await
         {

--- a/src/bot/runner.rs
+++ b/src/bot/runner.rs
@@ -4,10 +4,21 @@
 //! venv, talks JSONL over stdin/stdout, and pumps stderr into `tracing`
 //! with a `bot=<name>` field so logs are searchable. One long-lived child
 //! per game; `reset()` ends the current game and respawns for the next.
+//!
+//! ## Bot → frontend notifications
+//!
+//! stdout is a strict one-line-per-`react()` request/response channel, so a
+//! bot can't print extra lines there without desyncing the protocol. stderr
+//! is free-form, so it doubles as an out-of-band notification channel: a bot
+//! emits a single line prefixed with [`NOTIFY_PREFIX`] followed by a
+//! [`Notification`] JSON object, and [`spawn_stderr_pump`] parses it and
+//! forwards it onto the `NotifyBus`. Any other stderr line is logged as
+//! before, so older bots (and plain diagnostics) degrade gracefully.
 
 use crate::bot::runtime::PythonRuntime;
 use crate::bot::types::BotResponse;
-use crate::schema::MjaiEvent;
+use crate::event_bus::NotifyBus;
+use crate::schema::{MjaiEvent, Notification};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -18,6 +29,26 @@ use tracing::{info, warn};
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
+
+/// Sentinel that marks a bot stderr line as a frontend notification rather
+/// than a diagnostic log line. The remainder of the line (after this exact
+/// prefix) must be a JSON [`Notification`] object. Kept deliberately
+/// distinctive so it never collides with ordinary log output.
+pub const NOTIFY_PREFIX: &str = "@@AKAGI_NOTIFY@@ ";
+
+/// Parse one bot stderr line into a [`Notification`].
+///
+/// - `Ok(None)` — the line is not a notification (no sentinel prefix); the
+///   caller should log it as a normal diagnostic line.
+/// - `Ok(Some(n))` — a well-formed notification to forward to the frontend.
+/// - `Err(e)` — the line carried the sentinel but the payload didn't parse;
+///   the caller should warn (a bot bug worth surfacing in the logs).
+fn parse_notify_line(line: &str) -> Result<Option<Notification>, serde_json::Error> {
+    match line.strip_prefix(NOTIFY_PREFIX) {
+        Some(payload) => serde_json::from_str::<Notification>(payload.trim()).map(Some),
+        None => Ok(None),
+    }
+}
 
 /// Default per-call timeout. Mahjong turn budget is several seconds; 5 s
 /// is well above legitimate NN inference cost (Mortal ≈ 100 ms) and below
@@ -56,16 +87,24 @@ pub struct SubprocessBot {
     runtime: PythonRuntime,
     actor_id: u8,
     react_timeout: std::time::Duration,
+    /// Forwards bot-emitted stderr notifications to the frontend. Cloned
+    /// into each stderr pump, including the one spawned on `reset()`.
+    notify_tx: NotifyBus,
 }
 
 impl SubprocessBot {
     /// Production spawn: `uv sync` if needed, then launch under the venv
     /// interpreter.
-    pub async fn spawn(runtime: &PythonRuntime, bot_dir: &Path, actor_id: u8) -> Result<Self> {
+    pub async fn spawn(
+        runtime: &PythonRuntime,
+        bot_dir: &Path,
+        actor_id: u8,
+        notify_tx: NotifyBus,
+    ) -> Result<Self> {
         runtime.ensure_synced(bot_dir).await?;
         let mut cmd = runtime.command_for(bot_dir, &["bot.py"]);
         cmd.arg(actor_id.to_string());
-        Self::spawn_with_command(cmd, runtime.clone(), bot_dir, actor_id).await
+        Self::spawn_with_command(cmd, runtime.clone(), bot_dir, actor_id, notify_tx).await
     }
 
     /// Test / advanced spawn: caller supplies a fully-built `Command`.
@@ -74,6 +113,7 @@ impl SubprocessBot {
         runtime: PythonRuntime,
         bot_dir: &Path,
         actor_id: u8,
+        notify_tx: NotifyBus,
     ) -> Result<Self> {
         let bot_name = bot_dir
             .file_name()
@@ -107,7 +147,7 @@ impl SubprocessBot {
         );
 
         if let Some(stderr) = child.stderr.take() {
-            spawn_stderr_pump(stderr, bot_name.clone());
+            spawn_stderr_pump(stderr, bot_name.clone(), notify_tx.clone());
         }
 
         info!(bot = %bot_name, actor_id, "bot subprocess spawned");
@@ -121,6 +161,7 @@ impl SubprocessBot {
             runtime,
             actor_id,
             react_timeout: std::time::Duration::from_millis(DEFAULT_REACT_TIMEOUT_MS),
+            notify_tx,
         })
     }
 
@@ -183,7 +224,13 @@ impl BotRunner for SubprocessBot {
             let _ = self.child.wait().await;
         }
 
-        let new = SubprocessBot::spawn(&self.runtime, &self.bot_dir, self.actor_id).await?;
+        let new = SubprocessBot::spawn(
+            &self.runtime,
+            &self.bot_dir,
+            self.actor_id,
+            self.notify_tx.clone(),
+        )
+        .await?;
         let SubprocessBot {
             child,
             stdin,
@@ -200,12 +247,24 @@ impl BotRunner for SubprocessBot {
     }
 }
 
-fn spawn_stderr_pump(stderr: ChildStderr, bot_name: String) {
+fn spawn_stderr_pump(stderr: ChildStderr, bot_name: String, notify_tx: NotifyBus) {
     tokio::spawn(async move {
         let mut lines = BufReader::new(stderr).lines();
         loop {
             match lines.next_line().await {
-                Ok(Some(line)) => info!(bot = %bot_name, "{line}"),
+                Ok(Some(line)) => match parse_notify_line(&line) {
+                    Ok(Some(n)) => {
+                        // Best-effort: a closed bus (no IPC subscribers yet)
+                        // is fine — same fire-and-forget contract as every
+                        // other NotifyBus producer.
+                        let _ = notify_tx.send(n);
+                    }
+                    Ok(None) => info!(bot = %bot_name, "{line}"),
+                    Err(e) => warn!(
+                        bot = %bot_name,
+                        "malformed {NOTIFY_PREFIX} line ({e}); raw: {line}"
+                    ),
+                },
                 Ok(None) => break,
                 Err(e) => {
                     warn!(bot = %bot_name, "stderr pump error: {e}");
@@ -260,7 +319,14 @@ for line in sys.stdin:
         let py = system_python().expect("test requires python on PATH");
         let mut cmd = Command::new(&py);
         cmd.current_dir(bot_dir).arg("bot.py");
-        SubprocessBot::spawn_with_command(cmd, dummy_runtime(&py), bot_dir, 0).await
+        SubprocessBot::spawn_with_command(
+            cmd,
+            dummy_runtime(&py),
+            bot_dir,
+            0,
+            crate::event_bus::notify_bus(),
+        )
+        .await
     }
 
     #[tokio::test]
@@ -281,6 +347,99 @@ for line in sys.stdin:
             .await
             .unwrap();
         assert!(matches!(resp.action, MjaiEvent::None));
+
+        let _ = bot.react(&[MjaiEvent::EndGame]).await.unwrap();
+    }
+
+    #[test]
+    fn parse_notify_line_recognizes_sentinel() {
+        let line = format!(
+            "{NOTIFY_PREFIX}{{\"level\":\"warn\",\"title\":\"Heads up\",\"body\":\"low wall\"}}"
+        );
+        let n = parse_notify_line(&line).unwrap().expect("a notification");
+        assert_eq!(n.level, crate::schema::NotifyLevel::Warn);
+        assert_eq!(n.title, "Heads up");
+        assert_eq!(n.body.as_deref(), Some("low wall"));
+    }
+
+    #[test]
+    fn parse_notify_line_ignores_plain_lines() {
+        assert!(parse_notify_line("just a normal log line").unwrap().is_none());
+        // A near-miss without the trailing space is NOT the sentinel.
+        assert!(parse_notify_line("@@AKAGI_NOTIFY@@no-space").unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_notify_line_errors_on_bad_payload() {
+        let line = format!("{NOTIFY_PREFIX}{{not json}}");
+        assert!(parse_notify_line(&line).is_err());
+    }
+
+    /// Bot that emits a notification on stderr on its first react, then
+    /// replies `none`. Exercises the full stderr → NotifyBus path.
+    fn write_notify_bot(dir: &Path) {
+        std::fs::write(
+            dir.join("bot.py"),
+            r#"import json, sys
+notified = False
+for line in sys.stdin:
+    if not notified:
+        n = {"level": "info", "title": "Bot says hi", "body": "from stderr"}
+        sys.stderr.write("@@AKAGI_NOTIFY@@ " + json.dumps(n) + "\n")
+        sys.stderr.flush()
+        notified = True
+    print('{"type":"none"}', flush=True)
+    try:
+        events = json.loads(line)
+    except Exception:
+        continue
+    if any(e.get("type") == "end_game" for e in events):
+        break
+"#,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn bot_stderr_notification_reaches_notify_bus() {
+        if system_python().is_none() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        write_notify_bot(tmp.path());
+
+        let py = system_python().unwrap();
+        let mut cmd = Command::new(&py);
+        cmd.current_dir(tmp.path()).arg("bot.py");
+        let notify = crate::event_bus::notify_bus();
+        let mut notify_rx = notify.subscribe();
+        let mut bot =
+            SubprocessBot::spawn_with_command(cmd, dummy_runtime(&py), tmp.path(), 0, notify)
+                .await
+                .unwrap();
+
+        // Trigger react so the bot runs its first iteration and emits the
+        // stderr notification.
+        let resp = bot
+            .react(&[MjaiEvent::StartGame {
+                names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+                kyoku_first: None,
+                aka_flag: None,
+                id: Some(0),
+                num_players: 4,
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(resp.action, MjaiEvent::None));
+
+        // stderr is pumped on a separate task; give it a bounded window.
+        let n = tokio::time::timeout(std::time::Duration::from_secs(5), notify_rx.recv())
+            .await
+            .expect("notification arrived before timeout")
+            .expect("notify bus open");
+        assert_eq!(n.level, crate::schema::NotifyLevel::Info);
+        assert_eq!(n.title, "Bot says hi");
+        assert_eq!(n.body.as_deref(), Some("from stderr"));
 
         let _ = bot.react(&[MjaiEvent::EndGame]).await.unwrap();
     }


### PR DESCRIPTION
Closes #129.

## What

Gives a running mjai bot a way to push a **toast notification** to the Akagi UI — it pops in the **bottom-right corner** — with a **title**, optional **body**, and a **severity level** (`info` / `success` / `warn` / `error`).

## Why this is small

The notification pipeline already existed end-to-end:

- a backend `Notification` type with severity levels + an internal notification bus,
- the IPC forwarder that emits the `notify` event,
- the frontend `notify` listener that feeds the store + toaster,
- the bottom-right sonner `Toaster` with per-level left-border colours.

The **only** missing link was a path from the Python bot subprocess into that bus. No new types and **no frontend changes** were needed.

## How

A **structured stderr side-channel**. The bot's stdout is parsed strictly as one mjai reaction per line, so it can't carry anything else without desyncing the protocol. stderr is free-form, so the bot writes a single line:

```
@@AKAGI_NOTIFY@@ {"level":"warn","title":"Low wall","body":"Playing defensively."}
```

The runner's stderr pump recognises the sentinel prefix, parses the rest as a `Notification`, and forwards it onto the notification bus. This:

- keeps stdout's one-line-per-reaction contract intact,
- lets a bot notify at **any** time (not just on a reaction turn),
- degrades gracefully — a malformed payload is logged and dropped, and any non-sentinel stderr line is logged exactly as before.

## Changes

- **`src/bot/runner.rs`** — `NOTIFY_PREFIX` + `parse_notify_line()`; thread the notification-bus sender into `SubprocessBot` (kept on the struct so `reset()`'s respawn keeps forwarding) and the stderr pump; sentinel → forward, bad payload → `warn!` + drop, else → log.
- **`src/bot/manager.rs`** — pass the sender into the spawn.
- **`mjai_bot/example/bot.py`** — a copy-pasteable `notify(level, title, body=None, *, sticky=False, id=None)` helper + one demonstrative call on `start_game`.
- **Docs** — new `mjai_bot/README.md` (I/O protocol + full notification spec + helper), plus `src/bot/README.md` and `README.md`.

## Tests

- `parse_notify_line_*` — sentinel recognised, plain/near-miss lines ignored, malformed payload errors.
- `bot_stderr_notification_reaches_notify_bus` — spawns a **real Python bot** that emits an `@@AKAGI_NOTIFY@@` line on stderr and asserts the `Notification` lands on a subscribed bus.

All 73 `bot::` tests pass; `cargo clippy --lib` introduces no new warnings.