### PR TITLE
style: fix doc_overindented_list_items warnings in inspector.rs

### DIFF
--- a/src/schema/inspector.rs
+++ b/src/schema/inspector.rs
@@ -3,12 +3,12 @@
 //!
 //! One canonical struct per pipeline stage:
 //!
-//! - `WsFrame`     — raw bytes the proxy or chromium capture saw,
-//!                   with the bridge's first-pass parsed view alongside.
-//! - `MjaiEvent`   — translated game event from `mjai_bus`.
+//! - `WsFrame` — raw bytes the proxy or chromium capture saw, with the
+//!   bridge's first-pass parsed view alongside.
+//! - `MjaiEvent` — translated game event from `mjai_bus`.
 //! - `BotReaction` — bot's response with the triggering mjai event and
-//!                   reaction latency, so "why did the bot do that?" is
-//!                   answerable from a single record.
+//!   reaction latency, so "why did the bot do that?" is answerable from a
+//!   single record.
 //!
 //! Same shape on the wire (live tail over `tauri::ipc::Channel`) and on
 //! disk (`<session>/inspector.jsonl`). The on-disk file is the source of


### PR DESCRIPTION
Closes #131.

## What

`cargo clippy --lib` emitted 3 `clippy::doc_overindented_list_items` warnings, all in the module doc comment of `src/schema/inspector.rs` (lines 7, 10, 11 — the wrapped continuation lines of the `WsFrame` and `BotReaction` bullets).

## Cause

The bullet list aligned its em-dashes into a column:

```
- `WsFrame`     — ...
- `MjaiEvent`   — ...
- `BotReaction` — ...
```

so the continuation lines were indented ~18 spaces to sit under the description text. The lint wants list-item continuations indented 2 spaces from the marker.

## Fix

Reflow the bullets to standard markdown — single-space dashes, 2-space continuation indent. Pure formatting; rustdoc renders identically and there is no code change.

## Verification

`cargo clippy --lib` from the branch is now **warning-free** (was 3 warnings).