### PR TITLE
fix(test): update example_bot spawn_with_command call for notify_tx arg

### DIFF
--- a/tests/example_bot.rs
+++ b/tests/example_bot.rs
@@ -57,9 +57,15 @@ async fn spawn_example(actor_id: u8) -> Option<SubprocessBot> {
         RuntimeMode::System,
     );
     Some(
-        SubprocessBot::spawn_with_command(cmd, runtime, &bot_dir, actor_id)
-            .await
-            .expect("spawn example bot"),
+        SubprocessBot::spawn_with_command(
+            cmd,
+            runtime,
+            &bot_dir,
+            actor_id,
+            akagi::event_bus::notify_bus(),
+        )
+        .await
+        .expect("spawn example bot"),
     )
 }
 


### PR DESCRIPTION
Closes #133.

## Problem

`cargo test` fails to compile the tracked integration test `tests/example_bot.rs` on `v3`:

```
error[E0061]: this function takes 5 arguments but 4 arguments were supplied
  --> tests/example_bot.rs:60:9
```

PR #130 added a `notify_tx: NotifyBus` parameter to `SubprocessBot::spawn_with_command` (forwarding a bot's stderr notifications to the frontend). The `src/bot/manager.rs` call site and the `runner.rs` unit test were updated, but `tests/example_bot.rs` — which also calls `spawn_with_command` — was missed. `cargo test --lib` builds the lib only, so the break didn't show up until the integration-test target was compiled.

## Fix

Pass `akagi::event_bus::notify_bus()` into the test's `spawn_example` helper, matching the new signature. Pure test-code change.

## Verification

`cargo test` now builds all targets and passes:

- lib unit tests: 466 passed
- `tests/example_bot.rs`: 4 passed
- other integration targets: green

## Follow-up

To stop this recurring, it's worth wiring `cargo test --no-run` (or full `cargo test`) into CI so integration-test compile breaks are caught pre-merge — `cargo test --lib` alone misses them.