### PR TITLE
ci: add PR gate (Rust fmt/clippy/test + frontend lint/build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+# Fast PR gate: lint + test on Linux only. The full cross-platform build
+# and packaging lives in release.yml (tag-triggered). The goal here is to
+# catch fmt / clippy / compile / test / frontend breakage before merge —
+# `cargo test --lib` alone misses integration-test compile breaks, so we
+# also compile every test target.
+
+on:
+  pull_request:
+    branches: [v2, v3]
+  push:
+    branches: [v2, v3]
+
+# A newer push to the same ref cancels the in-flight run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: Rust (fmt + clippy + test)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # build.rs runs prost-build on liqi.proto and needs protoc on PATH.
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The crate links tauri, so even `cargo test --lib` needs the GTK /
+      # WebKit dev libs to compile. Mirrors release.yml's Linux deps
+      # (minus the bundling-only patchelf / libfuse2).
+      - name: Linux system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libssl-dev
+
+      - name: rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: test (lib)
+        run: cargo test --lib
+
+      # Compile every test target (integration tests, benches) without
+      # running them. This is the check that would have caught the
+      # spawn_with_command arity break in tests/example_bot.rs.
+      - name: build all test targets
+        run: cargo test --no-run --all-targets
+
+  frontend:
+    name: Frontend (lint + build)
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # `npm run build` is `tsc -b && vite build` — type-checks too.
+      - name: Build
+        run: npm run build

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,4 +19,14 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    // shadcn/ui primitives intentionally export a variants helper (e.g.
+    // `buttonVariants`) or a small utility (`toast`) alongside the
+    // component. react-refresh's only-export-components rule guards HMR
+    // fast-refresh, not correctness, so it's safe to relax here.
+    files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/frontend/src/routes/Bots.tsx
+++ b/frontend/src/routes/Bots.tsx
@@ -62,6 +62,8 @@ export function Bots() {
   }
 
   useEffect(() => {
+    // Mount-time load; refresh() flips loading/list state internally.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (list.length === 0) void refresh()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -61,6 +61,8 @@ export function Settings() {
   const [err, setErr] = useState<string | null>(null)
 
   useEffect(() => {
+    // Sync the editable draft from the store when it (re)loads.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (stored) setDraft(stored)
   }, [stored])
 
@@ -770,6 +772,8 @@ function CaptureCard({
 
   useEffect(() => {
     if (mode === 'chromium' && detected === null) {
+      // probe() sets detecting/detected state; intentional on mode switch.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       probe()
     }
   }, [mode]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -961,6 +965,8 @@ function CftPanel({
   }
 
   useEffect(() => {
+    // Mount-time load of the installed-bots list; refresh() sets state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh()
   }, [])
 

--- a/frontend/src/routes/Setup.tsx
+++ b/frontend/src/routes/Setup.tsx
@@ -63,6 +63,8 @@ export function Setup() {
   const isRerun = params.get('rerun') === '1' || stored?.general.first_run_completed === true
 
   useEffect(() => {
+    // Sync the editable draft from the store when it (re)loads.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (stored) setDraft(stored)
   }, [stored])
 
@@ -87,7 +89,7 @@ export function Setup() {
       } catch (e) {
         // Surface the first failure to the wizard's error strip; let
         // the user retry. Don't proceed to Finish with stale settings.
-        throw new Error(`Save failed for ${name}: ${e}`)
+        throw new Error(`Save failed for ${name}: ${e}`, { cause: e })
       }
     }
   }
@@ -481,6 +483,8 @@ function ChromiumConfigStep({
   }
 
   useEffect(() => {
+    // Mount-time load; refresh() sets state internally.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh()
   }, [])
 
@@ -604,7 +608,8 @@ function BotsStep() {
   const install = async (mode: '4p' | '3p') => {
     setInstalling(mode)
     setErrors((e) => {
-      const { [mode]: _, ...rest } = e
+      const rest = { ...e }
+      delete rest[mode]
       return rest
     })
     try {

--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -264,7 +264,7 @@ function parseTheme(raw: unknown): CustomTheme {
         const trimmed = v.trim()
         // Legacy shadcn HSL triplet — no function wrapper, e.g. "240 5% 10%".
         const looksLikeHslTriplet =
-          /^[\d.\-]+\s+[\d.]+%\s+[\d.]+%(\s*\/\s*[\d.%]+)?$/.test(trimmed)
+          /^[\d.-]+\s+[\d.]+%\s+[\d.]+%(\s*\/\s*[\d.%]+)?$/.test(trimmed)
         out[key] = looksLikeHslTriplet ? `hsl(${trimmed})` : trimmed
       }
     }

--- a/src/autoplay/context.rs
+++ b/src/autoplay/context.rs
@@ -56,10 +56,7 @@ impl CanvasRect {
     /// Sanity check for a normalised point — clamps off-canvas requests
     /// before we hand them to CDP.
     pub fn contains(&self, x: f64, y: f64) -> bool {
-        x >= self.x
-            && x <= self.x + self.width
-            && y >= self.y
-            && y <= self.y + self.height
+        x >= self.x && x <= self.x + self.width && y >= self.y && y <= self.y + self.height
     }
 }
 
@@ -69,13 +66,23 @@ mod tests {
 
     #[test]
     fn pixel_translation_centre() {
-        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        let rect = CanvasRect {
+            x: 0.0,
+            y: 0.0,
+            width: 1600.0,
+            height: 900.0,
+        };
         assert_eq!(rect.pixel(8.0, 4.5), (800.0, 450.0));
     }
 
     #[test]
     fn pixel_translation_with_offset() {
-        let rect = CanvasRect { x: 100.0, y: 50.0, width: 1280.0, height: 720.0 };
+        let rect = CanvasRect {
+            x: 100.0,
+            y: 50.0,
+            width: 1280.0,
+            height: 720.0,
+        };
         let (px, py) = rect.pixel(8.0, 4.5);
         assert!((px - (100.0 + 640.0)).abs() < 1e-9);
         assert!((py - (50.0 + 360.0)).abs() < 1e-9);
@@ -83,13 +90,23 @@ mod tests {
 
     #[test]
     fn contains_inside() {
-        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        let rect = CanvasRect {
+            x: 0.0,
+            y: 0.0,
+            width: 1600.0,
+            height: 900.0,
+        };
         assert!(rect.contains(800.0, 450.0));
     }
 
     #[test]
     fn contains_outside() {
-        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        let rect = CanvasRect {
+            x: 0.0,
+            y: 0.0,
+            width: 1600.0,
+            height: 900.0,
+        };
         assert!(!rect.contains(-1.0, 0.0));
         assert!(!rect.contains(0.0, 1000.0));
     }

--- a/src/autoplay/majsoul/coords.rs
+++ b/src/autoplay/majsoul/coords.rs
@@ -82,18 +82,18 @@ pub const CANDIDATES_KAN: [(f64, f64); 7] = [
 /// first (rightmost / bottom-rightmost). Source:
 /// `autoplay_majsoul.py:67-81`. Indices align with `MajsoulOpType`.
 pub const ACTION_PRIORITY: [u32; 12] = [
-    0, // None       — pass / cancel button (always rightmost)
+    0,  // None       — pass / cancel button (always rightmost)
     99, // Discard   — no button
-    4, // Chi
-    3, // Pon
-    3, // Ankan
-    2, // Daiminkan
-    3, // Kakan
-    2, // Reach
-    1, // Zimo (tsumo agari)
-    1, // Ron
-    5, // Ryukyoku
-    4, // Nukidora
+    4,  // Chi
+    3,  // Pon
+    3,  // Ankan
+    2,  // Daiminkan
+    3,  // Kakan
+    2,  // Reach
+    1,  // Zimo (tsumo agari)
+    1,  // Ron
+    5,  // Ryukyoku
+    4,  // Nukidora
 ];
 
 /// Numeric type codes used by the priority table above. These match the
@@ -332,10 +332,25 @@ mod tests {
 
     #[test]
     fn op_type_from_engine_action_types() {
-        assert_eq!(MajsoulOpType::from_engine(ActionType::Riichi), Some(MajsoulOpType::Reach));
-        assert_eq!(MajsoulOpType::from_engine(ActionType::Tsumo), Some(MajsoulOpType::Zimo));
-        assert_eq!(MajsoulOpType::from_engine(ActionType::Ron), Some(MajsoulOpType::Ron));
-        assert_eq!(MajsoulOpType::from_engine(ActionType::KyushuKyuhai), Some(MajsoulOpType::Ryukyoku));
-        assert_eq!(MajsoulOpType::from_engine(ActionType::Pass), Some(MajsoulOpType::None));
+        assert_eq!(
+            MajsoulOpType::from_engine(ActionType::Riichi),
+            Some(MajsoulOpType::Reach)
+        );
+        assert_eq!(
+            MajsoulOpType::from_engine(ActionType::Tsumo),
+            Some(MajsoulOpType::Zimo)
+        );
+        assert_eq!(
+            MajsoulOpType::from_engine(ActionType::Ron),
+            Some(MajsoulOpType::Ron)
+        );
+        assert_eq!(
+            MajsoulOpType::from_engine(ActionType::KyushuKyuhai),
+            Some(MajsoulOpType::Ryukyoku)
+        );
+        assert_eq!(
+            MajsoulOpType::from_engine(ActionType::Pass),
+            Some(MajsoulOpType::None)
+        );
     }
 }

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -15,12 +15,12 @@ pub mod coords;
 use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};
 use crate::bridge::majsoul::tile::compare_pai;
 use crate::schema::MjaiEvent;
+#[cfg(test)]
+use coords::TSUMO_SPACE;
 use coords::{
     action_button_pos, candidate_pos, get_pai_coord, kan_candidate_pos, MajsoulOpType,
     ACTION_PRIORITY, TILES,
 };
-#[cfg(test)]
-use coords::TSUMO_SPACE;
 use rand::Rng;
 use riichienv_core::action::{Action, ActionType};
 use riichienv_core::parser::tid_to_mjai;
@@ -104,7 +104,12 @@ impl PlatformAutoplay for MajsoulAutoplay {
             }
             MjaiEvent::Daiminkan { actor, .. } if *actor == ctx.our_seat => {
                 push_random_pre_delay(&mut result.steps, ctx);
-                plan_meld(MajsoulOpType::Daiminkan, ActionType::Daiminkan, &mut result, ctx);
+                plan_meld(
+                    MajsoulOpType::Daiminkan,
+                    ActionType::Daiminkan,
+                    &mut result,
+                    ctx,
+                );
             }
             MjaiEvent::Ankan { actor, .. } if *actor == ctx.our_seat => {
                 push_random_pre_delay(&mut result.steps, ctx);
@@ -189,11 +194,12 @@ impl PlatformAutoplay for MajsoulAutoplay {
                 // windows have no claimable actions — Majsoul shows no buttons at all
                 // and a ghost click would land on the wrong UI element.
                 let has_claim = ctx.legal_actions.iter().any(|a| {
-                    matches!(a.action_type,
+                    matches!(
+                        a.action_type,
                         riichienv_core::action::ActionType::Pon
-                        | riichienv_core::action::ActionType::Daiminkan
-                        | riichienv_core::action::ActionType::Ron
-                        | riichienv_core::action::ActionType::Chi
+                            | riichienv_core::action::ActionType::Daiminkan
+                            | riichienv_core::action::ActionType::Ron
+                            | riichienv_core::action::ActionType::Chi
                     )
                 });
                 if !has_claim {
@@ -256,7 +262,10 @@ fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
         sorted.sort_by(|a, b| compare_pai(a, b));
         let idx = sorted.iter().position(|x| x == pai)?;
         let (x, y) = TILES.get(idx).copied()?;
-        return Some(Step::Click { x_norm: x, y_norm: y });
+        return Some(Step::Click {
+            x_norm: x,
+            y_norm: y,
+        });
     }
 
     let tehai: Vec<String> = ctx.snapshot.players[our_seat].tehai.clone();
@@ -264,7 +273,10 @@ fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
     // (None after pon/chi/kita since no Tsumo event fires for those draws).
     // In 3p: if snapshot_drawn is "N" but last_self_tsumo is set to something
     // else, the snapshot predates the Kita; use last_self_tsumo (rinshan).
-    let snapshot_drawn = ctx.snapshot.players.get(our_seat)
+    let snapshot_drawn = ctx
+        .snapshot
+        .players
+        .get(our_seat)
         .and_then(|p| p.drawn_tile.as_deref());
     let tsumohai = match (snapshot_drawn, ctx.last_self_tsumo) {
         (Some("N"), Some(rinshan)) => Some(rinshan),
@@ -285,13 +297,18 @@ fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
         if pai == t {
             // Discarding the tsumohai: click the far-right tsumohai slot.
             let (x, y) = get_pai_coord(13, tehai.len() - 1);
-            return Some(Step::Click { x_norm: x, y_norm: y });
+            return Some(Step::Click {
+                x_norm: x,
+                y_norm: y,
+            });
         }
         // Discarding a closed-hand tile. The tsumohai sits on the far right
         // visually. Exclude the last occurrence of the tsumohai tile from
         // sorted_tehai, then find pai index in the remaining tiles.
         let tsumo_excl = sorted_tehai.iter().rposition(|x| x.as_str() == t);
-        let idx = sorted_tehai.iter().enumerate()
+        let idx = sorted_tehai
+            .iter()
+            .enumerate()
             .filter(|(i, _)| Some(*i) != tsumo_excl)
             .enumerate()
             .find(|(_, (_, x))| x.as_str() == pai)
@@ -300,7 +317,10 @@ fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
             return None;
         }
         let (x, y) = get_pai_coord(idx, tehai.len() - 1);
-        return Some(Step::Click { x_norm: x, y_norm: y });
+        return Some(Step::Click {
+            x_norm: x,
+            y_norm: y,
+        });
     }
 
     // No tsumohai: all tiles closed, click by sorted index directly.
@@ -309,7 +329,10 @@ fn plan_dahai_click(pai: &str, ctx: &ActionContext) -> Option<Step> {
         return None;
     }
     let (x, y) = get_pai_coord(idx, tehai.len());
-    Some(Step::Click { x_norm: x, y_norm: y })
+    Some(Step::Click {
+        x_norm: x,
+        y_norm: y,
+    })
 }
 /// True for the dealer's very first discard of a kyoku — the moment
 /// when Mahjong Soul has dealt 14 tiles, played the hand-sort animation,
@@ -329,12 +352,7 @@ fn is_dealer_first_discard(ctx: &ActionContext) -> bool {
 
 /// Plan a chi/pon/daiminkan: action button click + optional candidate
 /// disambiguation when multiple consume-tile combinations are legal.
-fn plan_meld(
-    op: MajsoulOpType,
-    at: ActionType,
-    result: &mut PlanResult,
-    ctx: &ActionContext,
-) {
+fn plan_meld(op: MajsoulOpType, at: ActionType, result: &mut PlanResult, ctx: &ActionContext) {
     let Some(button) = action_button_for(op, ctx) else {
         return;
     };
@@ -378,12 +396,7 @@ fn plan_meld(
 /// Majsoul shows ONE kan button whose candidate row contains the union
 /// of both, ordered `[kakan…, ankan…]`. The candidate index for the
 /// bot's chosen tile is computed against the unified list.
-fn plan_kan(
-    op: MajsoulOpType,
-    at: ActionType,
-    result: &mut PlanResult,
-    ctx: &ActionContext,
-) {
+fn plan_kan(op: MajsoulOpType, at: ActionType, result: &mut PlanResult, ctx: &ActionContext) {
     let Some(button) = action_button_for(op, ctx) else {
         return;
     };
@@ -426,7 +439,13 @@ fn plan_kan(
     let idx = unified.iter().position(|c| {
         let any = c
             .iter()
-            .map(|t| if t.ends_with('r') { &t[..t.len() - 1] } else { t.as_str() })
+            .map(|t| {
+                if t.ends_with('r') {
+                    &t[..t.len() - 1]
+                } else {
+                    t.as_str()
+                }
+            })
             .next();
         any.map(|t| t == base).unwrap_or(false)
     });
@@ -650,8 +669,11 @@ mod tests {
         // discard layout doesn't apply — this test exercises the normal
         // tsumohai-offset path.
         let snap = snapshot_with_oya(
-            0, 1,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+            0,
+            1,
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Dahai {
             actor: 0,
@@ -660,7 +682,14 @@ mod tests {
         };
         let cfg_ref = cfg();
         let ctx = ctx_for(
-            &act, &snap, &[], Some("1m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            Some("1m"),
+            Some("5p"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         // sleep + click
@@ -682,7 +711,9 @@ mod tests {
     fn dahai_suppressed_under_riichi() {
         let snap = snapshot_with_hand(
             0,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Dahai {
             actor: 0,
@@ -731,14 +762,19 @@ mod tests {
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
-        assert!(!result.steps.is_empty(), "Path B follow-up dahai must click");
+        assert!(
+            !result.steps.is_empty(),
+            "Path B follow-up dahai must click"
+        );
     }
 
     #[test]
     fn reach_path_a_two_clicks() {
         let snap = snapshot_with_hand(
             0,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p"],
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Reach {
             actor: 0,
@@ -748,7 +784,14 @@ mod tests {
         // Reach must be in legal_actions for the button position to resolve.
         let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
         let ctx = ctx_for(
-            &act, &snap, &legal, Some("1m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &legal,
+            Some("1m"),
+            Some("5p"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         // sleep + reach btn + sleep + tile click
@@ -761,11 +804,21 @@ mod tests {
     #[test]
     fn reach_path_b_signals_inject() {
         let snap = snapshot_with_hand(0, vec!["1m"]);
-        let act = MjaiEvent::Reach { actor: 0, pai: None };
+        let act = MjaiEvent::Reach {
+            actor: 0,
+            pai: None,
+        };
         let cfg_ref = cfg();
         let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
         let ctx = ctx_for(
-            &act, &snap, &legal, Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &legal,
+            Some("1m"),
+            None,
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         // sleep + reach btn click only
@@ -787,7 +840,14 @@ mod tests {
             Action::new(ActionType::Pon, None, vec![], Some(0)),
         ];
         let ctx = ctx_for(
-            &act, &snap, &legal, Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &legal,
+            Some("1m"),
+            None,
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2);
@@ -810,7 +870,14 @@ mod tests {
         let act = MjaiEvent::None;
         let cfg_ref = cfg();
         let ctx = ctx_for(
-            &act, &snap, &[], Some("1m"), None, false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            Some("1m"),
+            None,
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
@@ -831,7 +898,14 @@ mod tests {
             Action::new(ActionType::Discard, Some(4), vec![], Some(0)),
         ];
         let ctx = ctx_for(
-            &act, &snap, &legal, Some("1m"), Some("1m"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &legal,
+            Some("1m"),
+            Some("1m"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
@@ -847,9 +921,11 @@ mod tests {
         // sorted-last tile (5p) must click TILES[13] directly, NOT
         // TILES[13] + TSUMO_SPACE.
         let snap = snapshot_with_oya(
-            0, 0,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
-                 "1p", "2p", "3p", "4p", "5p"],
+            0,
+            0,
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Dahai {
             actor: 0,
@@ -860,7 +936,14 @@ mod tests {
         // Even with last_self_tsumo set, dealer-first-discard layout
         // must override the tsumohai-offset path.
         let ctx = ctx_for(
-            &act, &snap, &[], None, Some("5p"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            None,
+            Some("5p"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2);
@@ -878,9 +961,11 @@ mod tests {
     #[test]
     fn dealer_first_discard_pads_extra_delay() {
         let snap = snapshot_with_oya(
-            0, 0,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
-                 "1p", "2p", "3p", "4p", "5p"],
+            0,
+            0,
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Dahai {
             actor: 0,
@@ -889,7 +974,14 @@ mod tests {
         };
         let cfg_ref = cfg_with_dealer_delay(2000);
         let ctx = ctx_for(
-            &act, &snap, &[], None, None, false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            None,
+            None,
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         // [pre-delay sleep, dealer-pad sleep, click]
@@ -905,16 +997,20 @@ mod tests {
         // After dealer's first discard, future turns are 13 closed + 1
         // tsumohai with the standard offset — same as non-dealer.
         let mut snap = snapshot_with_oya(
-            0, 0,
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
-                 "1p", "2p", "3p", "4p", "5p"],
+            0,
+            0,
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         // Mark a prior discard so river is non-empty (not first discard).
-        snap.players[0].river.push(crate::game_state::snapshot::DiscardEntry {
-            tile: "9m".into(),
-            tedashi: true,
-            is_riichi: false,
-        });
+        snap.players[0]
+            .river
+            .push(crate::game_state::snapshot::DiscardEntry {
+                tile: "9m".into(),
+                tedashi: true,
+                is_riichi: false,
+            });
         let act = MjaiEvent::Dahai {
             actor: 0,
             pai: "5p".into(),
@@ -922,7 +1018,14 @@ mod tests {
         };
         let cfg_ref = cfg();
         let ctx = ctx_for(
-            &act, &snap, &[], Some("9m"), Some("5p"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            Some("9m"),
+            Some("5p"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         match &result.steps.last().unwrap() {
@@ -941,9 +1044,11 @@ mod tests {
         // 13 closed + 1 tsumohai with TSUMO_SPACE — Majsoul does not
         // run the dealer-only sort animation.
         let snap = snapshot_with_oya(
-            1, 0, // we're seat 1, dealer is seat 0
-            vec!["1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m",
-                 "1p", "2p", "3p", "4p", "5p"],
+            1,
+            0, // we're seat 1, dealer is seat 0
+            vec![
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
+            ],
         );
         let act = MjaiEvent::Dahai {
             actor: 1,
@@ -952,7 +1057,14 @@ mod tests {
         };
         let cfg_ref = cfg_with_dealer_delay(2000);
         let ctx = ctx_for(
-            &act, &snap, &[], None, Some("5p"), false, ReachState::Idle, &cfg_ref,
+            &act,
+            &snap,
+            &[],
+            None,
+            Some("5p"),
+            false,
+            ReachState::Idle,
+            &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
         // No dealer pad: just [pre-delay, click].
@@ -961,7 +1073,12 @@ mod tests {
 
     #[test]
     fn pixel_translation_in_canvas_rect() {
-        let rect = CanvasRect { x: 0.0, y: 0.0, width: 1600.0, height: 900.0 };
+        let rect = CanvasRect {
+            x: 0.0,
+            y: 0.0,
+            width: 1600.0,
+            height: 900.0,
+        };
         // Centre of the canvas at (8.0, 4.5) norm.
         assert_eq!(rect.pixel(8.0, 4.5), (800.0, 450.0));
     }

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -639,6 +639,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn ctx_for<'a>(
         action: &'a MjaiEvent,
         snapshot: &'a GameStateSnapshot,

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -57,12 +57,6 @@ struct ManagerState {
     cached_our_seat: Option<u8>,
 }
 
-impl Default for ReachState {
-    fn default() -> Self {
-        Self::Idle
-    }
-}
-
 impl AutoplayManager {
     pub fn new(
         cfg: Arc<RwLock<AppConfig>>,

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -181,7 +181,10 @@ impl AutoplayManager {
         let rect = match self.canvas_rect_resolve().await {
             Some(r) => r,
             None => {
-                warn!("autoplay: no canvas rect — skipping click for {:?}", resp.action);
+                warn!(
+                    "autoplay: no canvas rect — skipping click for {:?}",
+                    resp.action
+                );
                 return;
             }
         };
@@ -223,7 +226,10 @@ impl AutoplayManager {
         // emit the riichi-declaring dahai we need to click next.
         if plan.inject_reach_for_followup {
             self.state.reach_state = ReachState::AwaitingDahai;
-            let synthetic = MjaiEvent::Reach { actor: our_seat, pai: None };
+            let synthetic = MjaiEvent::Reach {
+                actor: our_seat,
+                pai: None,
+            };
             if let Err(e) = self.mjai_bus.send(synthetic) {
                 // No subscribers (e.g. bot disabled) — nothing to do, but
                 // log for visibility because Path B without a downstream
@@ -309,7 +315,8 @@ impl AutoplayManager {
     /// Best-effort seat lookup. Uses the cached seat from `StartGame` first,
     /// falling back to try_lock on the tracker.
     fn our_seat_cached(&self) -> Option<u8> {
-        self.state.cached_our_seat
+        self.state
+            .cached_our_seat
             .or_else(|| self.tracker.try_lock().ok().and_then(|t| t.our_seat()))
     }
 
@@ -349,7 +356,9 @@ pub async fn run_autoplay_manager(
     mjai_bus: MjaiBus,
     response_bus: BotResponseBus,
 ) -> anyhow::Result<()> {
-    AutoplayManager::new(cfg, ctx, tracker, mjai_bus).run(response_bus).await
+    AutoplayManager::new(cfg, ctx, tracker, mjai_bus)
+        .run(response_bus)
+        .await
 }
 
 #[cfg(test)]
@@ -393,7 +402,11 @@ mod tests {
             id: Some(1),
             num_players: 4,
         });
-        assert_eq!(m.state.cached_our_seat, Some(1), "seat must be cached from StartGame");
+        assert_eq!(
+            m.state.cached_our_seat,
+            Some(1),
+            "seat must be cached from StartGame"
+        );
 
         // A Tsumo by our seat (1) before any bot response should be recorded.
         m.handle_mjai_event(&MjaiEvent::Tsumo {
@@ -433,10 +446,18 @@ mod tests {
             tehais: vec![vec!["1m".into(); 13]; 4],
             num_players: 4,
         });
-        assert_eq!(m.state.cached_our_seat, Some(2), "seat must survive StartKyoku reset");
+        assert_eq!(
+            m.state.cached_our_seat,
+            Some(2),
+            "seat must survive StartKyoku reset"
+        );
 
         m.handle_mjai_event(&MjaiEvent::EndKyoku);
-        assert_eq!(m.state.cached_our_seat, Some(2), "seat must survive EndKyoku reset");
+        assert_eq!(
+            m.state.cached_our_seat,
+            Some(2),
+            "seat must survive EndKyoku reset"
+        );
     }
 
     /// Observer/replay mode: `StartGame` with `id: None` must not cache a
@@ -462,6 +483,9 @@ mod tests {
             id: None,
             num_players: 4,
         });
-        assert!(m.state.cached_our_seat.is_none(), "stale seat must be cleared");
+        assert!(
+            m.state.cached_our_seat.is_none(),
+            "stale seat must be cleared"
+        );
     }
 }

--- a/src/autoplay/platform.rs
+++ b/src/autoplay/platform.rs
@@ -28,8 +28,9 @@ pub enum Step {
 /// emits one reach action that combines the declaration and the discard,
 /// so we click reach first, await the bot's follow-up `Dahai`, then click
 /// the discard tile.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ReachState {
+    #[default]
     Idle,
     /// Path B: we clicked the reach button and injected a synthetic
     /// `Reach` event into MjaiBus. The next `Dahai` from the bot is the

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -32,9 +32,7 @@ use crate::bot::runtime::PythonRuntime;
 use crate::bot::sync_guard::SyncGuard;
 use crate::event_bus::{BotResponseBus, BotStatusBus, NotifyBus};
 use crate::inspector::InspectorWriter;
-use crate::schema::{
-    BotReaction, BotStatus, InspectorEntry, LoadStage, MjaiEvent, Notification,
-};
+use crate::schema::{BotReaction, BotStatus, InspectorEntry, LoadStage, MjaiEvent, Notification};
 use anyhow::{bail, Context, Result};
 use chrono::Local;
 use std::collections::HashSet;

--- a/src/bot/runner.rs
+++ b/src/bot/runner.rs
@@ -133,18 +133,10 @@ impl SubprocessBot {
         let mut child = cmd
             .spawn()
             .with_context(|| format!("spawn bot {bot_name}"))?;
-            
-        let stdin = child
-            .stdin
-            .take()
-            .context("child stdin missing")?;
-            
-        let stdout = BufReader::new(
-            child
-                .stdout
-                .take()
-                .context("child stdout missing")?,
-        );
+
+        let stdin = child.stdin.take().context("child stdin missing")?;
+
+        let stdout = BufReader::new(child.stdout.take().context("child stdout missing")?);
 
         if let Some(stderr) = child.stderr.take() {
             spawn_stderr_pump(stderr, bot_name.clone(), notify_tx.clone());
@@ -238,7 +230,7 @@ impl BotRunner for SubprocessBot {
             react_timeout,
             ..
         } = new;
-        
+
         self.child = child;
         self.stdin = stdin;
         self.stdout = stdout;
@@ -331,7 +323,9 @@ for line in sys.stdin:
 
     #[tokio::test]
     async fn echo_bot_returns_none() {
-        if system_python().is_none() { return; }
+        if system_python().is_none() {
+            return;
+        }
         let tmp = TempDir::new().unwrap();
         write_echo_bot(tmp.path());
 
@@ -364,9 +358,13 @@ for line in sys.stdin:
 
     #[test]
     fn parse_notify_line_ignores_plain_lines() {
-        assert!(parse_notify_line("just a normal log line").unwrap().is_none());
+        assert!(parse_notify_line("just a normal log line")
+            .unwrap()
+            .is_none());
         // A near-miss without the trailing space is NOT the sentinel.
-        assert!(parse_notify_line("@@AKAGI_NOTIFY@@no-space").unwrap().is_none());
+        assert!(parse_notify_line("@@AKAGI_NOTIFY@@no-space")
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -53,7 +53,10 @@ impl ParseResult {
         Self::default()
     }
     pub fn just_events(events: Vec<MjaiEvent>) -> Self {
-        Self { events, parsed: None }
+        Self {
+            events,
+            parsed: None,
+        }
     }
 }
 

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -221,9 +221,7 @@ impl TenhouBridge {
         let mut events = Vec::with_capacity(2);
         if self.state.pending_start_game {
             self.state.pending_start_game = false;
-            let names: Vec<String> = (0..self.state.num_players)
-                .map(|i| i.to_string())
-                .collect();
+            let names: Vec<String> = (0..self.state.num_players).map(|i| i.to_string()).collect();
             events.push(MjaiEvent::StartGame {
                 names,
                 kyoku_first: None,
@@ -275,12 +273,7 @@ impl TenhouBridge {
     /// `<D7/>`, `<E/>`, `<f12/>` — dahai.
     /// `tsumogiri_uppercase` is true when the tag's leading letter is uppercase
     /// (Tenhou's signal that the discard is just-drawn).
-    fn on_dahai(
-        &mut self,
-        actor_rel: u8,
-        tag: &str,
-        tsumogiri_uppercase: bool,
-    ) -> Vec<MjaiEvent> {
+    fn on_dahai(&mut self, actor_rel: u8, tag: &str, tsumogiri_uppercase: bool) -> Vec<MjaiEvent> {
         if actor_rel >= 4 {
             return Vec::new();
         }
@@ -391,14 +384,22 @@ impl TenhouBridge {
                 actor,
                 target,
                 pai,
-                consumed: [consumed[0].clone(), consumed[1].clone(), consumed[2].clone()],
+                consumed: [
+                    consumed[0].clone(),
+                    consumed[1].clone(),
+                    consumed[2].clone(),
+                ],
             },
             MeldKind::Kakan => {
                 self.state.last_revealed_tile_actor = Some(actor); // chankan target
                 MjaiEvent::Kakan {
                     actor,
                     pai,
-                    consumed: [consumed[0].clone(), consumed[1].clone(), consumed[2].clone()],
+                    consumed: [
+                        consumed[0].clone(),
+                        consumed[1].clone(),
+                        consumed[2].clone(),
+                    ],
                 }
             }
             MeldKind::Ankan => MjaiEvent::Ankan {
@@ -440,9 +441,11 @@ impl TenhouBridge {
             return Vec::new();
         }
         // step arrives as a string in the Python reference (`message['step'] == '1'`).
-        let step = msg
-            .get("step")
-            .and_then(|v| v.as_str().and_then(|s| s.parse::<u8>().ok()).or(v.as_u64().map(|n| n as u8)));
+        let step = msg.get("step").and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse::<u8>().ok())
+                .or(v.as_u64().map(|n| n as u8))
+        });
         let events = match step {
             Some(1) => vec![MjaiEvent::Reach { actor, pai: None }],
             Some(2) => {
@@ -756,9 +759,18 @@ mod tests {
         parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#);
         let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"1","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
         let events = parse_one(&mut b, init);
-        assert_eq!(events.len(), 2, "yonma first INIT emits start_game + start_kyoku");
+        assert_eq!(
+            events.len(),
+            2,
+            "yonma first INIT emits start_game + start_kyoku"
+        );
         match &events[0] {
-            MjaiEvent::StartGame { id, num_players, names, .. } => {
+            MjaiEvent::StartGame {
+                id,
+                num_players,
+                names,
+                ..
+            } => {
                 assert_eq!(*id, Some(3));
                 assert_eq!(*num_players, 4);
                 assert_eq!(names.len(), 4);
@@ -861,7 +873,10 @@ mod tests {
                 _ => None,
             })
             .expect("start_game emitted alongside first INIT");
-        assert_eq!(sg_num_players, 3, "start_game.num_players must reflect sanma");
+        assert_eq!(
+            sg_num_players, 3,
+            "start_game.num_players must reflect sanma"
+        );
         let sk = events
             .iter()
             .find_map(|e| match e {
@@ -899,7 +914,11 @@ mod tests {
         let init = r#"{"tag":"INIT","seed":"1,0,0,1,2,4","ten":"400,0,300,0","oya":"0","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
         let events = parse_one(&mut b, init);
         match &events[0] {
-            MjaiEvent::StartKyoku { scores, num_players, .. } => {
+            MjaiEvent::StartKyoku {
+                scores,
+                num_players,
+                ..
+            } => {
                 assert_eq!(*num_players, 3);
                 assert_eq!(
                     scores,
@@ -1064,19 +1083,27 @@ mod tests {
         let hora = events
             .iter()
             .find_map(|e| match e {
-                MjaiEvent::Hora { actor, target, deltas, ura_markers } => {
-                    Some((*actor, *target, deltas.clone(), ura_markers.clone()))
-                }
+                MjaiEvent::Hora {
+                    actor,
+                    target,
+                    deltas,
+                    ura_markers,
+                } => Some((*actor, *target, deltas.clone(), ura_markers.clone())),
                 _ => None,
             })
             .expect("hora event emitted");
         assert_eq!(hora.0, 0, "winner is seat 0");
-        assert_eq!(hora.1, 2, "ron target is seat 2 — fromWho must parse case-sensitively");
+        assert_eq!(
+            hora.1, 2,
+            "ron target is seat 2 — fromWho must parse case-sensitively"
+        );
         // Ura dora indicator field is also camelCase; verify it survives the
         // same casing fix. Tile id 45 / 4 = 11 → 3p in 34-space; mjai's
         // string for `id % 4` variants of 3p is "3p".
         assert_eq!(
-            hora.3.as_deref().map(|v| v.iter().map(String::as_str).collect::<Vec<_>>()),
+            hora.3
+                .as_deref()
+                .map(|v| v.iter().map(String::as_str).collect::<Vec<_>>()),
             Some(vec!["3p"]),
             "doraHaiUra must parse a single-marker CSV",
         );
@@ -1096,7 +1123,10 @@ mod tests {
         );
         let e1 = parse_one(&mut b, r#"{"tag":"REACH","who":"0","step":"1"}"#);
         assert!(matches!(e1[0], MjaiEvent::Reach { actor: 0, .. }));
-        let e2 = parse_one(&mut b, r#"{"tag":"REACH","who":"0","step":"2","ten":"240,250,250,260"}"#);
+        let e2 = parse_one(
+            &mut b,
+            r#"{"tag":"REACH","who":"0","step":"2","ten":"240,250,250,260"}"#,
+        );
         assert!(matches!(e2[0], MjaiEvent::ReachAccepted { actor: 0 }));
     }
 
@@ -1174,12 +1204,19 @@ mod tests {
         // start_game (deferred from TAIKYOKU) + start_kyoku.
         assert_eq!(init.len(), 2);
         let sg = match &init[0] {
-            MjaiEvent::StartGame { id, num_players, names, .. } => {
-                (*id, *num_players, names.len())
-            }
+            MjaiEvent::StartGame {
+                id,
+                num_players,
+                names,
+                ..
+            } => (*id, *num_players, names.len()),
             other => panic!("expected StartGame first, got {other:?}"),
         };
-        assert_eq!(sg, (Some(1), 3, 3), "sanma start_game with id=1 (wire-abs of South seat) and num_players=3");
+        assert_eq!(
+            sg,
+            (Some(1), 3, 3),
+            "sanma start_game with id=1 (wire-abs of South seat) and num_players=3"
+        );
 
         let sk = match &init[1] {
             MjaiEvent::StartKyoku {
@@ -1203,7 +1240,10 @@ mod tests {
         };
         assert_eq!(sk.0, "E");
         assert_eq!(sk.1, 1);
-        assert_eq!(sk.2, 0, "E1 dealer at wire-abs 0 (East), not collapsed onto our seat");
+        assert_eq!(
+            sk.2, 0,
+            "E1 dealer at wire-abs 0 (East), not collapsed onto our seat"
+        );
         assert_eq!(
             sk.3,
             vec![35_000, 35_000, 35_000],
@@ -1229,7 +1269,11 @@ mod tests {
         // Dealer's dahai of tile 56 (6p), tsumogiri.
         let g56 = parse_one(&mut b, r#"{"tag":"g56"}"#);
         match &g56[0] {
-            MjaiEvent::Dahai { actor, pai, tsumogiri } => {
+            MjaiEvent::Dahai {
+                actor,
+                pai,
+                tsumogiri,
+            } => {
                 assert_eq!(*actor, 0);
                 assert_eq!(pai, "6p");
                 assert!(!*tsumogiri, "lowercase g → tedashi");
@@ -1251,7 +1295,11 @@ mod tests {
         // so tsumogiri must resolve to false.
         let d116 = parse_one(&mut b, r#"{"tag":"D116"}"#);
         match &d116[0] {
-            MjaiEvent::Dahai { actor, pai, tsumogiri } => {
+            MjaiEvent::Dahai {
+                actor,
+                pai,
+                tsumogiri,
+            } => {
                 assert_eq!(*actor, 1);
                 assert_eq!(pai, "W");
                 assert!(!*tsumogiri, "drew 2p but discarded W → not tsumogiri");

--- a/src/bridge/tenhou/state.rs
+++ b/src/bridge/tenhou/state.rs
@@ -104,8 +104,10 @@ mod tests {
 
     #[test]
     fn yonma_seat_round_trip() {
-        let mut s = State::default();
-        s.seat = 2;
+        let s = State {
+            seat: 2,
+            ..Default::default()
+        };
         for abs in 0..4u8 {
             let rel = s.abs_to_rel(abs);
             assert_eq!(s.rel_to_abs(rel), abs);
@@ -116,10 +118,12 @@ mod tests {
     /// wire positions including the ghost. Our seat is always real.
     #[test]
     fn sanma_seat_round_trip() {
-        let mut s = State::default();
-        s.num_players = 3;
-        s.is_3p = true;
-        s.seat = 1;
+        let s = State {
+            num_players: 3,
+            is_3p: true,
+            seat: 1,
+            ..Default::default()
+        };
         for abs in 0..4u8 {
             let rel = s.abs_to_rel(abs);
             assert_eq!(s.rel_to_abs(rel), abs);

--- a/src/capture/chromium/cdp.rs
+++ b/src/capture/chromium/cdp.rs
@@ -28,7 +28,6 @@ use crate::inspector::InspectorWriter;
 use crate::schema::{FrameDirection, FrameRaw, InspectorEntry};
 use anyhow::{anyhow, Context, Result};
 use base64::Engine;
-use chrono::Local;
 use chromiumoxide::page::Page;
 use chromiumoxide::{
     cdp::browser_protocol::network::{
@@ -37,6 +36,7 @@ use chromiumoxide::{
     },
     Browser,
 };
+use chrono::Local;
 use futures_util::StreamExt;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -501,7 +501,10 @@ mod tests {
     fn binary_frame_base64_decodes() {
         let raw = b"\x00\x01\x02hello";
         let b64 = base64::engine::general_purpose::STANDARD.encode(raw);
-        assert_eq!(decode_frame_payload(2, &b64), FrameDecode::Bytes(raw.to_vec()));
+        assert_eq!(
+            decode_frame_payload(2, &b64),
+            FrameDecode::Bytes(raw.to_vec())
+        );
     }
 
     #[test]
@@ -509,7 +512,10 @@ mod tests {
         // Distinguished from `Skip` so the inline branch can WARN —
         // legit malformed CDP from Chrome shouldn't be confused with
         // an intentionally-ignored control frame.
-        assert_eq!(decode_frame_payload(2, "not base64!@#"), FrameDecode::BadBase64);
+        assert_eq!(
+            decode_frame_payload(2, "not base64!@#"),
+            FrameDecode::BadBase64
+        );
     }
 
     #[test]

--- a/src/capture/chromium/cft.rs
+++ b/src/capture/chromium/cft.rs
@@ -83,9 +83,7 @@ pub fn cft_platform() -> Option<&'static str> {
 /// AppImage / read-only mounts the resolver falls back to
 /// `<user_config_root>/chrome-for-testing/`.
 pub fn install_root() -> Result<PathBuf> {
-    Ok(crate::util::resolve_dir(Path::new(
-        "./chrome-for-testing",
-    )))
+    Ok(crate::util::resolve_dir(Path::new("./chrome-for-testing")))
 }
 
 /// Per-version install dir: `<install_root>/<version>/`.

--- a/src/capture/chromium/detect.rs
+++ b/src/capture/chromium/detect.rs
@@ -41,7 +41,21 @@ pub struct DetectedBrowser {
 pub fn detect_system_browsers() -> Vec<DetectedBrowser> {
     let mut found = Vec::new();
     detect_into(&mut found);
-    found.dedup_by(|a, b| a.path == b.path);
+    dedup_by_path(found)
+}
+
+/// Drop duplicate paths, keeping the first (highest-priority) occurrence.
+///
+/// `detect_into` emits in priority order (Chrome → … → CfT), not path
+/// order, and several probes can resolve to the same binary — e.g.
+/// `google-chrome` and `google-chrome-stable`, or `chromium` and
+/// `chromium-browser`, are commonly symlinks to one executable. Those
+/// duplicates aren't necessarily adjacent, so `Vec::dedup_by` (which only
+/// collapses *consecutive* runs) would let them through; a seen-set retain
+/// dedups regardless of position while preserving priority order.
+fn dedup_by_path(mut found: Vec<DetectedBrowser>) -> Vec<DetectedBrowser> {
+    let mut seen = std::collections::HashSet::new();
+    found.retain(|b| seen.insert(b.path.clone()));
     found
 }
 
@@ -214,5 +228,49 @@ mod tests {
         let mut u = unique;
         u.dedup();
         assert_eq!(paths.len(), u.len(), "detect_system_browsers must dedup");
+    }
+
+    /// Hermetic regression for the dedup bug surfaced by CI: probes emit in
+    /// priority order, so a duplicate path can be non-adjacent — the case
+    /// `Vec::dedup_by` misses. `dedup_by_path` must drop it and keep the
+    /// first (higher-priority) occurrence. Fake paths per CLAUDE.md #8.
+    #[test]
+    fn dedup_by_path_keeps_first_nonadjacent_occurrence() {
+        use BrowserKind::*;
+        let input = vec![
+            DetectedBrowser {
+                kind: Chrome,
+                path: "/usr/bin/x".into(),
+            },
+            DetectedBrowser {
+                kind: Edge,
+                path: "/usr/bin/edge".into(),
+            },
+            // Same path as index 0 but non-adjacent — dedup_by would miss it.
+            DetectedBrowser {
+                kind: Chromium,
+                path: "/usr/bin/x".into(),
+            },
+            DetectedBrowser {
+                kind: Brave,
+                path: "/usr/bin/brave".into(),
+            },
+            DetectedBrowser {
+                kind: Chrome,
+                path: "/usr/bin/edge".into(),
+            },
+        ];
+        let out = dedup_by_path(input);
+        let paths: Vec<_> = out.iter().map(|b| b.path.clone()).collect();
+        assert_eq!(
+            paths,
+            [
+                PathBuf::from("/usr/bin/x"),
+                PathBuf::from("/usr/bin/edge"),
+                PathBuf::from("/usr/bin/brave"),
+            ]
+        );
+        // First occurrence wins: /usr/bin/x keeps Chrome, not Chromium.
+        assert_eq!(out[0].kind, Chrome);
     }
 }

--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -509,10 +509,12 @@ mod tests {
             oya: 0,
             scores: vec![36_000, 28_000, 28_000, 28_000],
             tehais: vec![
-                ["C", "6p", "4m", "3p", "8s", "3m", "2p", "1m", "N", "P", "9p", "W", "7p"]
-                    .iter()
-                    .map(|s| (*s).into())
-                    .collect(),
+                [
+                    "C", "6p", "4m", "3p", "8s", "3m", "2p", "1m", "N", "P", "9p", "W", "7p",
+                ]
+                .iter()
+                .map(|s| (*s).into())
+                .collect(),
                 vec!["?".into(); 13],
                 vec!["?".into(); 13],
                 vec!["?".into(); 13],
@@ -525,19 +527,53 @@ mod tests {
         // equality; non-actor draws use "?" since the bridge feeds the
         // observer perspective.
         let turns: &[(u8, &str, &str)] = &[
-            (0, "C", "W"),     (1, "?", "6s"),  (2, "?", "2s"),  (3, "?", "7m"),
-            (0, "E", "N"),     (1, "?", "8p"),  (2, "?", "P"),   (3, "?", "6s"),
-            (0, "3p", "1m"),   (1, "?", "3s"),  (2, "?", "3m"),  (3, "?", "6s"),
-            (0, "8s", "9p"),   (1, "?", "3m"),  (2, "?", "S"),   (3, "?", "2p"),
-            (0, "5sr", "P"),   (1, "?", "E"),   (2, "?", "4s"),  (3, "?", "W"),
-            (0, "1s", "1s"),   (1, "?", "4p"),  (2, "?", "2s"),  (3, "?", "7m"),
-            (0, "7m", "7m"),   (1, "?", "8s"),  (2, "?", "2m"),  (3, "?", "3p"),
-            (0, "1p", "3p"),   (1, "?", "9m"),  (2, "?", "4s"),  (3, "?", "3s"),
-            (0, "5p", "E"),    (1, "?", "1m"),  (2, "?", "S"),   (3, "?", "F"),
-            (0, "7s", "5sr"),  (1, "?", "9p"),  (2, "?", "8m"),  (3, "?", "5m"),
+            (0, "C", "W"),
+            (1, "?", "6s"),
+            (2, "?", "2s"),
+            (3, "?", "7m"),
+            (0, "E", "N"),
+            (1, "?", "8p"),
+            (2, "?", "P"),
+            (3, "?", "6s"),
+            (0, "3p", "1m"),
+            (1, "?", "3s"),
+            (2, "?", "3m"),
+            (3, "?", "6s"),
+            (0, "8s", "9p"),
+            (1, "?", "3m"),
+            (2, "?", "S"),
+            (3, "?", "2p"),
+            (0, "5sr", "P"),
+            (1, "?", "E"),
+            (2, "?", "4s"),
+            (3, "?", "W"),
+            (0, "1s", "1s"),
+            (1, "?", "4p"),
+            (2, "?", "2s"),
+            (3, "?", "7m"),
+            (0, "7m", "7m"),
+            (1, "?", "8s"),
+            (2, "?", "2m"),
+            (3, "?", "3p"),
+            (0, "1p", "3p"),
+            (1, "?", "9m"),
+            (2, "?", "4s"),
+            (3, "?", "3s"),
+            (0, "5p", "E"),
+            (1, "?", "1m"),
+            (2, "?", "S"),
+            (3, "?", "F"),
+            (0, "7s", "5sr"),
+            (1, "?", "9p"),
+            (2, "?", "8m"),
+            (3, "?", "5m"),
         ];
         for &(actor, draw, dahai) in turns {
-            t.handle(&E::Tsumo { actor, pai: draw.into() }).unwrap();
+            t.handle(&E::Tsumo {
+                actor,
+                pai: draw.into(),
+            })
+            .unwrap();
             t.handle(&E::Dahai {
                 actor,
                 pai: dahai.into(),
@@ -547,8 +583,16 @@ mod tests {
         }
 
         // Reach + reach-discard 7s + reach_accepted for actor 0.
-        t.handle(&E::Tsumo { actor: 0, pai: "8s".into() }).unwrap();
-        t.handle(&E::Reach { actor: 0, pai: None }).unwrap();
+        t.handle(&E::Tsumo {
+            actor: 0,
+            pai: "8s".into(),
+        })
+        .unwrap();
+        t.handle(&E::Reach {
+            actor: 0,
+            pai: None,
+        })
+        .unwrap();
         t.handle(&E::Dahai {
             actor: 0,
             pai: "7s".into(),
@@ -559,14 +603,22 @@ mod tests {
 
         // One full go-around inside the ippatsu window: actor 1 then actor 2
         // discards 5mr (the ron tile).
-        t.handle(&E::Tsumo { actor: 1, pai: "?".into() }).unwrap();
+        t.handle(&E::Tsumo {
+            actor: 1,
+            pai: "?".into(),
+        })
+        .unwrap();
         t.handle(&E::Dahai {
             actor: 1,
             pai: "S".into(),
             tsumogiri: false,
         })
         .unwrap();
-        t.handle(&E::Tsumo { actor: 2, pai: "?".into() }).unwrap();
+        t.handle(&E::Tsumo {
+            actor: 2,
+            pai: "?".into(),
+        })
+        .unwrap();
         t.handle(&E::Dahai {
             actor: 2,
             pai: "5mr".into(),
@@ -627,7 +679,7 @@ mod tests {
             48, 49, // 4p 4p
             72, 73, // 1s 1s
             112, 113, // S S (28*4=112)
-            64, // 8p (lone — chiitoitsu wait)
+            64,  // 8p (lone — chiitoitsu wait)
         ];
         s.players[actor as usize].hand = hand;
 

--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -303,7 +303,7 @@ mod tests {
         let info = evaluate_hora_4p(&s, 0, true).expect("winning shape");
         assert!(info.han >= 1, "han = {}", info.han);
         assert!(info.points > 0, "points = {}", info.points);
-        assert!(info.points % 100 == 0, "points = {}", info.points);
+        assert!(info.points.is_multiple_of(100), "points = {}", info.points);
     }
 
     #[test]

--- a/src/game_state/snapshot.rs
+++ b/src/game_state/snapshot.rs
@@ -177,7 +177,11 @@ impl GameStateSnapshot {
                     double_riichi: p.double_riichi_declared,
                     riichi_declaration_index: p.riichi_declaration_index,
                     kita_tiles: Vec::new(),
-                    drawn_tile: if i as u8 == s.current_player { s.drawn_tile.map(tid_to_mjai) } else { None },
+                    drawn_tile: if i as u8 == s.current_player {
+                        s.drawn_tile.map(tid_to_mjai)
+                    } else {
+                        None
+                    },
                 }
             })
             .collect();
@@ -236,7 +240,11 @@ impl GameStateSnapshot {
                     double_riichi: p.double_riichi_declared,
                     riichi_declaration_index: p.riichi_declaration_index,
                     kita_tiles: p.kita_tiles.iter().copied().map(tid_to_mjai).collect(),
-                    drawn_tile: if i as u8 == s.current_player { s.drawn_tile.map(tid_to_mjai) } else { None },
+                    drawn_tile: if i as u8 == s.current_player {
+                        s.drawn_tile.map(tid_to_mjai)
+                    } else {
+                        None
+                    },
                 }
             })
             .collect();

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -540,7 +540,11 @@ mod tests {
             pai: "3m".into(),
         })
         .unwrap();
-        t.handle(&AkagiEvent::Reach { actor: 0, pai: None }).unwrap();
+        t.handle(&AkagiEvent::Reach {
+            actor: 0,
+            pai: None,
+        })
+        .unwrap();
         t.handle(&AkagiEvent::Dahai {
             actor: 0,
             pai: "1m".into(),

--- a/src/history/aggregator.rs
+++ b/src/history/aggregator.rs
@@ -19,9 +19,7 @@
 use chrono::{DateTime, Utc};
 use tracing::warn;
 
-use crate::schema::{
-    GameRecord, GameStats, HistoryEventLog, KyokuMode, MjaiEvent, Platform,
-};
+use crate::schema::{GameRecord, GameStats, HistoryEventLog, KyokuMode, MjaiEvent, Platform};
 
 /// 4p starting score / kyotaku-normalisation target / sanma equivalents.
 const STARTING_SCORE_4P: i32 = 25_000;
@@ -295,9 +293,7 @@ pub fn aggregate(input: AggregateInput<'_>) -> Option<GameRecord> {
         // Top up rank-1 (highest-score, then lowest-seat tiebreak).
         let top_seat = (0..n)
             .max_by(|&a, &b| {
-                cur_scores[a]
-                    .cmp(&cur_scores[b])
-                    .then_with(|| b.cmp(&a)) // lower seat wins tie
+                cur_scores[a].cmp(&cur_scores[b]).then_with(|| b.cmp(&a)) // lower seat wins tie
             })
             .unwrap_or(0);
         cur_scores[top_seat] += total - sum;
@@ -443,7 +439,10 @@ mod tests {
         let events = vec![
             start_game_4p(2),
             start_kyoku("E", 0, vec![25000, 25000, 25000, 25000]),
-            MjaiEvent::Reach { actor: 2, pai: None },
+            MjaiEvent::Reach {
+                actor: 2,
+                pai: None,
+            },
             MjaiEvent::ReachAccepted { actor: 2 },
             MjaiEvent::Dahai {
                 actor: 2,
@@ -593,7 +592,10 @@ mod tests {
         let events = vec![
             start_game_4p(0),
             start_kyoku("E", 0, vec![25000, 25000, 25000, 25000]),
-            MjaiEvent::Reach { actor: 0, pai: None },
+            MjaiEvent::Reach {
+                actor: 0,
+                pai: None,
+            },
             MjaiEvent::ReachAccepted { actor: 0 }, // -1000 to seat 0
             MjaiEvent::Ryukyoku {
                 deltas: Some(vec![1500, -1500, 0, 0]),

--- a/src/history/recorder.rs
+++ b/src/history/recorder.rs
@@ -12,12 +12,12 @@
 use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, Utc};
-use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tokio::sync::broadcast::{error::RecvError, Receiver};
 use tracing::{info, warn};
 use ulid::Ulid;
 
 use crate::event_bus::HistoryBus;
-use crate::history::aggregator::{AggregateInput, aggregate};
+use crate::history::aggregator::{aggregate, AggregateInput};
 use crate::history::store::HistoryStore;
 use crate::schema::{HistoryEvent, MjaiEvent, Platform};
 
@@ -192,7 +192,7 @@ impl RecorderState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event_bus::{DEFAULT_CAPACITY, HistoryBus};
+    use crate::event_bus::{HistoryBus, DEFAULT_CAPACITY};
     use crate::schema::{HistoryFilter, MjaiEvent};
     use tempfile::TempDir;
     use tokio::sync::broadcast;
@@ -231,7 +231,13 @@ mod tests {
         let store_clone = store.clone();
         let bus_clone = history_tx.clone();
         let handle = tokio::spawn(async move {
-            drive_loop(store_clone, bus_clone, shared_platform(Platform::Majsoul), rx).await
+            drive_loop(
+                store_clone,
+                bus_clone,
+                shared_platform(Platform::Majsoul),
+                rx,
+            )
+            .await
         });
 
         tx.send(start_game()).unwrap();
@@ -249,9 +255,7 @@ mod tests {
         // Give the loop a tick to drain.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        let records = store
-            .list(&HistoryFilter::default(), 100, 0)
-            .unwrap();
+        let records = store.list(&HistoryFilter::default(), 100, 0).unwrap();
         assert_eq!(records.len(), 1, "exactly one record after end_game");
         assert_eq!(records[0].our_rank, Some(1));
         assert_eq!(records[0].our_delta, Some(8000));
@@ -270,7 +274,13 @@ mod tests {
         let store_clone = store.clone();
         let bus_clone = history_tx.clone();
         let handle = tokio::spawn(async move {
-            drive_loop(store_clone, bus_clone, shared_platform(Platform::Majsoul), rx).await
+            drive_loop(
+                store_clone,
+                bus_clone,
+                shared_platform(Platform::Majsoul),
+                rx,
+            )
+            .await
         });
 
         tx.send(start_game()).unwrap();
@@ -286,9 +296,7 @@ mod tests {
         drop(tx);
         let _ = handle.await;
 
-        let records = store
-            .list(&HistoryFilter::default(), 100, 0)
-            .unwrap();
+        let records = store.list(&HistoryFilter::default(), 100, 0).unwrap();
         assert!(records.is_empty(), "no record without end_game");
     }
 
@@ -302,7 +310,13 @@ mod tests {
         let store_clone = store.clone();
         let bus_clone = history_tx.clone();
         let handle = tokio::spawn(async move {
-            drive_loop(store_clone, bus_clone, shared_platform(Platform::Majsoul), rx).await
+            drive_loop(
+                store_clone,
+                bus_clone,
+                shared_platform(Platform::Majsoul),
+                rx,
+            )
+            .await
         });
 
         // First game starts but never ends.
@@ -325,9 +339,7 @@ mod tests {
         drop(tx);
         let _ = handle.await;
 
-        let records = store
-            .list(&HistoryFilter::default(), 100, 0)
-            .unwrap();
+        let records = store.list(&HistoryFilter::default(), 100, 0).unwrap();
         assert_eq!(records.len(), 1, "only the cleanly-ended second game");
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -65,7 +65,9 @@ impl HistoryStore {
     }
 
     fn game_log_path(&self, id: &str) -> PathBuf {
-        self.root.join(GAMES_SUBDIR).join(format!("{id}.mjai.jsonl"))
+        self.root
+            .join(GAMES_SUBDIR)
+            .join(format!("{id}.mjai.jsonl"))
     }
 
     /// Persist a finalised game: write the full event stream as
@@ -75,9 +77,8 @@ impl HistoryStore {
         let _g = self.write_lock.lock().expect("history write lock poisoned");
 
         let game_path = self.game_log_path(&record.id);
-        write_jsonl_events(&game_path, events).with_context(|| {
-            format!("failed to write game log {}", game_path.display())
-        })?;
+        write_jsonl_events(&game_path, events)
+            .with_context(|| format!("failed to write game log {}", game_path.display()))?;
 
         if let Err(e) = self.append_index_locked(record) {
             // Roll back the orphan game log so re-running the same id
@@ -110,8 +111,7 @@ impl HistoryStore {
         if !path.exists() {
             return Ok(Vec::new());
         }
-        let f = File::open(&path)
-            .with_context(|| format!("failed to open {}", path.display()))?;
+        let f = File::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
         let mut out = Vec::new();
         for (lineno, line) in BufReader::new(f).lines().enumerate() {
             let line = line.with_context(|| format!("read error in {}", path.display()))?;
@@ -133,12 +133,7 @@ impl HistoryStore {
     /// Filtered + paginated listing, newest-first by `started_at`.
     /// `limit == NO_LIMIT` (0) returns every match; otherwise caps the
     /// result to that many records after `offset`.
-    pub fn list(
-        &self,
-        filter: &HistoryFilter,
-        limit: u32,
-        offset: u32,
-    ) -> Result<Vec<GameRecord>> {
+    pub fn list(&self, filter: &HistoryFilter, limit: u32, offset: u32) -> Result<Vec<GameRecord>> {
         let mut all = self.read_all()?;
         // Newest first.
         all.sort_by(|a, b| b.started_at.cmp(&a.started_at));
@@ -162,8 +157,7 @@ impl HistoryStore {
         if !path.exists() {
             return Ok(None);
         }
-        let f = File::open(&path)
-            .with_context(|| format!("failed to open {}", path.display()))?;
+        let f = File::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
         let mut out = Vec::new();
         for (lineno, line) in BufReader::new(f).lines().enumerate() {
             let line = line.with_context(|| format!("read error in {}", path.display()))?;
@@ -215,9 +209,8 @@ impl HistoryStore {
             }
             f.sync_data().ok();
         }
-        fs::rename(&tmp, &path).with_context(|| {
-            format!("failed to rename {} -> {}", tmp.display(), path.display())
-        })
+        fs::rename(&tmp, &path)
+            .with_context(|| format!("failed to rename {} -> {}", tmp.display(), path.display()))
     }
 }
 
@@ -284,9 +277,7 @@ mod tests {
         store.append(&r1, &sample_events()).unwrap();
         store.append(&r2, &sample_events()).unwrap();
 
-        let all = store
-            .list(&HistoryFilter::default(), NO_LIMIT, 0)
-            .unwrap();
+        let all = store.list(&HistoryFilter::default(), NO_LIMIT, 0).unwrap();
         assert_eq!(all.len(), 2);
         // Newest first.
         assert_eq!(all[0].id, "BBB");
@@ -347,7 +338,9 @@ mod tests {
     fn delete_unknown_id_no_op() {
         let tmp = TempDir::new().unwrap();
         let store = HistoryStore::new(tmp.path().to_path_buf()).unwrap();
-        store.append(&mk_record("KEEP", 0), &sample_events()).unwrap();
+        store
+            .append(&mk_record("KEEP", 0), &sample_events())
+            .unwrap();
         let removed = store.delete("NOPE").unwrap();
         assert!(!removed);
         assert_eq!(store.read_all().unwrap().len(), 1);

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -136,7 +136,7 @@ impl HistoryStore {
     pub fn list(&self, filter: &HistoryFilter, limit: u32, offset: u32) -> Result<Vec<GameRecord>> {
         let mut all = self.read_all()?;
         // Newest first.
-        all.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        all.sort_by_key(|b| std::cmp::Reverse(b.started_at));
         let off = offset as usize;
         let it = all.into_iter().filter(|r| filter.matches(r)).skip(off);
         Ok(if limit == NO_LIMIT {

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -108,8 +108,7 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
         *state
             .history_platform
             .write()
-            .expect("history platform lock poisoned") =
-            crate::schema::Platform::from(new_platform);
+            .expect("history platform lock poisoned") = crate::schema::Platform::from(new_platform);
     }
 
     if capture_changed || proxy_changed || platform_changed {
@@ -574,10 +573,7 @@ pub async fn get_log_dir(state: State<'_, AppState>) -> CmdResult<PathBuf> {
 /// child, so a missing tool surfaces only if `spawn` itself fails. The
 /// frontend already wraps this in try/catch.
 #[tauri::command]
-pub async fn open_log_folder(
-    session: Option<String>,
-    state: State<'_, AppState>,
-) -> CmdResult<()> {
+pub async fn open_log_folder(session: Option<String>, state: State<'_, AppState>) -> CmdResult<()> {
     let target = match session {
         Some(name) if !name.is_empty() => {
             // Defense-in-depth: only allow the canonical session name
@@ -641,10 +637,13 @@ fn is_session_name(name: &str) -> bool {
         return false;
     }
     let bytes = name.as_bytes();
-    bytes
-        .iter()
-        .enumerate()
-        .all(|(i, &b)| if i == 8 { b == b'-' } else { b.is_ascii_digit() })
+    bytes.iter().enumerate().all(|(i, &b)| {
+        if i == 8 {
+            b == b'-'
+        } else {
+            b.is_ascii_digit()
+        }
+    })
 }
 
 /// List every session directory under the active log root. Newest first.
@@ -755,7 +754,11 @@ pub async fn read_log_session(
         let target_filters: Vec<String> = req.targets.unwrap_or_default();
         let search_lc = req.search.as_deref().map(|s| s.to_lowercase());
         // 0 → use a sane default (1000); otherwise hard-cap at 2000.
-        let limit = if req.limit == 0 { 1000 } else { req.limit.min(2000) };
+        let limit = if req.limit == 0 {
+            1000
+        } else {
+            req.limit.min(2000)
+        };
 
         let mut skipped_malformed: u32 = 0;
         let mut total_match: usize = 0;
@@ -844,7 +847,11 @@ pub async fn read_inspector(
             req.kinds.as_ref().map(|v| v.iter().cloned().collect());
         let actor = req.actor;
         let search_lc = req.search.as_deref().map(|s| s.to_lowercase());
-        let limit = if req.limit == 0 { 1000 } else { req.limit.min(2000) };
+        let limit = if req.limit == 0 {
+            1000
+        } else {
+            req.limit.min(2000)
+        };
 
         let mut skipped_malformed: u32 = 0;
         let mut total_match: usize = 0;
@@ -1194,10 +1201,7 @@ pub async fn get_game_history_events(
 /// `HistoryEvent::Deleted` on the history bus so the frontend can drop
 /// the row from its cache without a refetch.
 #[tauri::command]
-pub async fn delete_game_history_entry(
-    id: String,
-    state: State<'_, AppState>,
-) -> CmdResult<bool> {
+pub async fn delete_game_history_entry(id: String, state: State<'_, AppState>) -> CmdResult<bool> {
     let store = state.history_store.clone();
     let id_for_blocking = id.clone();
     let removed = tokio::task::spawn_blocking(move || store.delete(&id_for_blocking))

--- a/src/ipc/state.rs
+++ b/src/ipc/state.rs
@@ -23,8 +23,8 @@ use crate::event_bus::{
     AnalysisBus, BotResponseBus, BotStatusBus, CaptureStatusBus, HistoryBus, MjaiBus, NotifyBus,
 };
 use crate::game_state::GameTracker;
-use crate::history::HistoryStore;
 use crate::history::recorder::SharedPlatform;
+use crate::history::HistoryStore;
 use crate::logger::Session;
 use crate::schema::{BotStatus, CaptureStatus};
 use std::collections::HashSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,4 +316,3 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-

--- a/src/logger/session.rs
+++ b/src/logger/session.rs
@@ -1,5 +1,9 @@
 use crate::inspector::{InspectorBus, InspectorWriter};
-use crate::logger::{binary::BinaryLogger, flow::FlowLogger, stream::{LogStreamHandle, LogStreamLayer}};
+use crate::logger::{
+    binary::BinaryLogger,
+    flow::FlowLogger,
+    stream::{LogStreamHandle, LogStreamLayer},
+};
 use crate::schema::{InspectorEntry, LogEntry};
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -156,12 +160,9 @@ impl Session {
         // viewer can live-tail without polling. Keep `all.log` in parallel
         // for humans tailing from a terminal.
         let jsonl_path = dir.join("all.jsonl");
-        let (stream_layer, stream_handle) =
-            LogStreamLayer::open(&jsonl_path, 1024).with_context(|| {
-                format!("Failed to open {}", jsonl_path.display())
-            })?;
-        let jsonl_filter =
-            EnvFilter::try_new(all_level).unwrap_or_else(|_| EnvFilter::new("info"));
+        let (stream_layer, stream_handle) = LogStreamLayer::open(&jsonl_path, 1024)
+            .with_context(|| format!("Failed to open {}", jsonl_path.display()))?;
+        let jsonl_filter = EnvFilter::try_new(all_level).unwrap_or_else(|_| EnvFilter::new("info"));
         layers.push(stream_layer.with_filter(jsonl_filter).boxed());
 
         // Inspector pipeline timeline. Separate file from `all.jsonl`
@@ -170,10 +171,8 @@ impl Session {
         // and conflating them would multiply file size and complicate
         // filtering on either side.
         let inspector_path = dir.join("inspector.jsonl");
-        let (inspector_writer, inspector_bus) =
-            InspectorWriter::open(&inspector_path, 1024).with_context(|| {
-                format!("Failed to open {}", inspector_path.display())
-            })?;
+        let (inspector_writer, inspector_bus) = InspectorWriter::open(&inspector_path, 1024)
+            .with_context(|| format!("Failed to open {}", inspector_path.display()))?;
 
         // Per-target files.
         for t in targets {

--- a/src/logger/stream.rs
+++ b/src/logger/stream.rs
@@ -92,8 +92,10 @@ impl Visit for FieldVisitor {
         if field.name() == "message" {
             self.message = Some(value.to_string());
         } else {
-            self.fields
-                .insert(field.name().to_string(), serde_json::Value::String(value.to_string()));
+            self.fields.insert(
+                field.name().to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
         }
     }
 
@@ -103,13 +105,17 @@ impl Visit for FieldVisitor {
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.fields
-            .insert(field.name().to_string(), serde_json::Value::Number(value.into()));
+        self.fields.insert(
+            field.name().to_string(),
+            serde_json::Value::Number(value.into()),
+        );
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.fields
-            .insert(field.name().to_string(), serde_json::Value::Number(value.into()));
+        self.fields.insert(
+            field.name().to_string(),
+            serde_json::Value::Number(value.into()),
+        );
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {

--- a/src/proxy/handler.rs
+++ b/src/proxy/handler.rs
@@ -145,11 +145,7 @@ impl ProxyHandler {
 }
 
 impl HttpHandler for ProxyHandler {
-    async fn handle_request(
-        &mut self,
-        ctx: &HttpContext,
-        req: Request<Body>,
-    ) -> RequestOrResponse {
+    async fn handle_request(&mut self, ctx: &HttpContext, req: Request<Body>) -> RequestOrResponse {
         if req.uri().path() == "/ping" {
             return Response::builder()
                 .status(StatusCode::OK)
@@ -200,11 +196,7 @@ impl HttpHandler for ProxyHandler {
     ///
     /// Hostnames are always MITM'd; the maj-soul hostname endpoints
     /// (`mjusgs.mahjongsoul.com`, etc.) don't hit this code path.
-    async fn should_intercept(
-        &mut self,
-        _ctx: &HttpContext,
-        req: &Request<Body>,
-    ) -> bool {
+    async fn should_intercept(&mut self, _ctx: &HttpContext, req: &Request<Body>) -> bool {
         let Some(host) = req.uri().host() else {
             return true;
         };
@@ -365,7 +357,13 @@ impl ProxyHandler {
                     let mut b = bridge.lock().expect("bridge mutex poisoned");
                     b.parse(dir, buf)
                 };
-                self.record_frame(client, dir, FrameRaw::Text(t.to_string()), buf.len(), &result);
+                self.record_frame(
+                    client,
+                    dir,
+                    FrameRaw::Text(t.to_string()),
+                    buf.len(),
+                    &result,
+                );
                 self.dispatch_events(dir_arrow, &uri, result.events);
             }
             Message::Close(_) => debug!("{dir_arrow} {uri} close"),

--- a/src/updater/apply.rs
+++ b/src/updater/apply.rs
@@ -73,8 +73,7 @@ pub async fn download_and_apply(app: &AppHandle, info: &UpdateInfo) -> Result<()
         .ok_or_else(|| anyhow!("current_exe has no file name"))
         .map_err(UpdateError::from)?
         .to_owned();
-    let new_binary = find_binary(&extract_dir, &binary_name)
-        .ok_or(UpdateError::NoMatchingAsset)?;
+    let new_binary = find_binary(&extract_dir, &binary_name).ok_or(UpdateError::NoMatchingAsset)?;
 
     #[cfg(unix)]
     {
@@ -231,11 +230,7 @@ mod tests {
     fn find_binary_returns_none_when_absent() {
         let tmp = TempDir::new().unwrap();
         std::fs::create_dir_all(tmp.path().join("akagi-3.0.12-linux-x64")).unwrap();
-        std::fs::write(
-            tmp.path().join("akagi-3.0.12-linux-x64/README.txt"),
-            b"hi",
-        )
-        .unwrap();
+        std::fs::write(tmp.path().join("akagi-3.0.12-linux-x64/README.txt"), b"hi").unwrap();
         assert!(find_binary(tmp.path(), std::ffi::OsStr::new("akagi")).is_none());
     }
 

--- a/src/updater/check.rs
+++ b/src/updater/check.rs
@@ -133,10 +133,7 @@ pub fn build_update_info(
     };
 
     let latest_version = tag.trim_start_matches('v').to_owned();
-    let digest = asset
-        .digest
-        .as_deref()
-        .and_then(parse_sha256_digest);
+    let digest = asset.digest.as_deref().and_then(parse_sha256_digest);
 
     Ok(Some(UpdateInfo {
         current: current.to_owned(),
@@ -256,7 +253,10 @@ mod tests {
     #[test]
     fn parse_sha256_digest_normalises_case() {
         let raw = "SHA256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
-        assert_eq!(parse_sha256_digest(raw).unwrap(), raw[7..].to_ascii_lowercase());
+        assert_eq!(
+            parse_sha256_digest(raw).unwrap(),
+            raw[7..].to_ascii_lowercase()
+        );
     }
 
     #[test]
@@ -299,9 +299,7 @@ mod tests {
             vec![
                 asset(
                     "akagi-3.0.12-linux-x64.zip",
-                    Some(
-                        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-                    ),
+                    Some("sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"),
                     Some(12345),
                 ),
                 asset("akagi-3.0.12-windows-x64.zip", None, None),


### PR DESCRIPTION
Closes #135.

## What

Adds the first PR-stage CI. `release.yml` only runs on `v3.*` tags, so nothing checked fmt/clippy/test/build before a merge — which is how a tracked integration test reached `v3` broken (#133). New `.github/workflows/ci.yml` runs on `pull_request` / `push` to `v2`/`v3`, **Linux-only**, two parallel jobs:

| Job | Steps |
|-----|-------|
| **Rust** | `cargo fmt --all -- --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test --lib` · `cargo test --no-run --all-targets` |
| **Frontend** | `npm ci` · `npm run lint` · `npm run build` (tsc typecheck + vite) |

`cargo test --no-run --all-targets` is the key addition — it compiles every integration-test target, the exact gap that let the #133 arity break through (`cargo test --lib` builds the lib only).

Mirrors `release.yml`'s Linux deps (webkit2gtk / appindicator / rsvg / soup / ssl) + `protoc`; caches via `Swatinem/rust-cache` and npm; `concurrency` cancels superseded runs. Cross-platform builds stay in `release.yml`. No branch-protection / required-checks change (out of scope by request).

## Pre-existing debt cleared so CI is green on arrival

Four isolated commits:

1. **`style: cargo fmt --all`** — mechanical reformat of 24 files (the crate had drifted from rustfmt). No logic change.
2. **`fix(clippy)`** — 3 test-code lints for `--all-targets -D warnings`: `#[allow(clippy::too_many_arguments)]` on a test fixture builder; struct-initializer form in two seat round-trip tests.
3. **`fix(frontend)`** — 13 eslint errors: a config override relaxing `react-refresh/only-export-components` for the shadcn `components/ui/**` primitives; justified `react-hooks/set-state-in-effect` disables on 6 intentional mount / store-sync effects; `{ cause: e }` on a rethrow + a copy-delete instead of an unused `_` destructure; a needless regex escape removed.
4. **`ci: add PR gate`** — the workflow.

## Verified locally

All six gate commands pass on the branch: fmt clean · clippy `--all-targets -D warnings` clean · `cargo test --lib` 466 passed · `cargo test --no-run --all-targets` builds all targets · `npm run lint` 0 errors · `npm run build` ok.

## Note

This PR's own CI run won't appear until `ci.yml` exists on the base — GitHub evaluates the workflow from the PR branch for `pull_request`, so it should run on this PR itself. If anything's red I'll fix forward.