### PR TITLE
feat(frontend): add 2D mahjong table board tile to the game dashboard

### DIFF
--- a/frontend/src/components/AddTileMenu.tsx
+++ b/frontend/src/components/AddTileMenu.tsx
@@ -25,6 +25,7 @@ const TILE_TITLE_KEYS: Record<TileId, string> = {
   'player-2':        'tile.player_2',
   'player-3':        'tile.player_3',
   'self-hand':       'tile.self_hand',
+  'board':           'tile.board',
   'recommendations': 'tile.recommendations',
   'risk-chart':      'tile.risk_chart',
   'opponents':       'tile.opponents',

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -170,6 +170,8 @@
     "player_n_self": "Player {{n}} (Self)",
     "self_hand": "Self Hand",
     "self_hand_empty": "No hand yet — connect a game.",
+    "board": "Board",
+    "board_empty": "No game yet — connect a game.",
     "recommendations": "Algorithmic Top 3 Discards",
     "recommendations_empty": "Awaiting analysis.",
     "risk_chart": "Mixed Deal-in Risk",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -170,6 +170,8 @@
     "player_n_self": "プレイヤー {{n}}（自分）",
     "self_hand": "手牌",
     "self_hand_empty": "手牌がまだありません — ゲームに接続してください。",
+    "board": "卓",
+    "board_empty": "対局がまだありません — ゲームに接続してください。",
     "recommendations": "アルゴリズム推奨打牌 トップ3",
     "recommendations_empty": "解析待ちです。",
     "risk_chart": "総合放銃リスク",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -170,6 +170,8 @@
     "player_n_self": "玩家 {{n}}（自家）",
     "self_hand": "自家手牌",
     "self_hand_empty": "尚无手牌 — 请先连接到游戏。",
+    "board": "牌桌",
+    "board_empty": "尚无对局 — 请先连接到游戏。",
     "recommendations": "纯算法前三推荐切牌",
     "recommendations_empty": "等待分析中。",
     "risk_chart": "综合放铳风险",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -170,6 +170,8 @@
     "player_n_self": "玩家 {{n}}（自家）",
     "self_hand": "自家手牌",
     "self_hand_empty": "尚無手牌 — 請先連線至遊戲。",
+    "board": "牌桌",
+    "board_empty": "尚無對局 — 請先連線至遊戲。",
     "recommendations": "純算法前三建議切牌",
     "recommendations_empty": "等待分析中。",
     "risk_chart": "綜合放銃風險",

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -50,3 +50,11 @@ export const BAKAZE_LABEL: Record<string, string> = {
 export function kyokuLabel(bakaze: string, kyoku: number): string {
   return `${BAKAZE_LABEL[bakaze] ?? bakaze} ${kyoku}局`
 }
+
+/** Seat wind (自風) label for `seat`. East = oya seat; each subsequent seat
+ * rotates S → W → N (4p) or S → W (3p — sanma has no N self-wind, only E/S/W). */
+export function bakazeFor(seat: number, oya: number, numPlayers: number): string {
+  const order = ['E', 'S', 'W', 'N']
+  const n = Math.max(1, numPlayers)
+  return BAKAZE_LABEL[order[(seat - oya + n) % n]]
+}

--- a/frontend/src/lib/mahgenRegistry.ts
+++ b/frontend/src/lib/mahgenRegistry.ts
@@ -33,9 +33,13 @@ const SIZE_CTX: Record<MahgenKind, SizeCtx> = {
   // when the tile is small. `board-hand` uses linear (constant-ish tile size,
   // width grows with tile count) rather than `hand`'s 'fit' min:44 which would
   // overflow a small seat. Values are tunable — refine visually in the webview.
-  'board-hand':  { mode: 'linear', base: 26, ref: 300, min: 14, max: 34 },
-  'board-river': { mode: 'river',  maxScale: 0.3, minScale: 0.10 },
-  'board-meld':  { mode: 'linear', base: 18, ref: 220, min: 10, max: 30 },
+  // 'fit' makes the hand fill its container width (which is a fraction of the
+  // square board) so it scales with the board and never overflows. River uses
+  // 'river' scaling with a high cap so it grows with the board too; its smaller
+  // container width keeps river tiles smaller than hand tiles.
+  'board-hand':  { mode: 'fit', min: 16, max: 100 },
+  'board-river': { mode: 'river',  maxScale: 1.0, minScale: 0.14 },
+  'board-meld':  { mode: 'linear', base: 34, ref: 240, min: 16, max: 80 },
 }
 
 const RIVER_FULL_ROW_W = 420

--- a/frontend/src/lib/mahgenRegistry.ts
+++ b/frontend/src/lib/mahgenRegistry.ts
@@ -4,7 +4,9 @@
 // root; setting host + inner <img> dimensions in pixels is the only path
 // that survives the WebKitGTK + circular-containing-block constraints.
 
-export type MahgenKind = 'river' | 'hand' | 'melds' | 'dora' | 'rec' | 'bot-action' | 'bot-show'
+export type MahgenKind =
+  | 'river' | 'hand' | 'melds' | 'dora' | 'rec' | 'bot-action' | 'bot-show'
+  | 'board-hand' | 'board-river' | 'board-meld'
 
 type SizeCtx =
   | { mode: 'river'; maxScale?: number; minScale?: number }
@@ -26,6 +28,14 @@ const SIZE_CTX: Record<MahgenKind, SizeCtx> = {
   // bot-action so the label/value columns stay readable; cap higher than
   // 'rec' for chi/pon melds.
   'bot-show': { mode: 'linear', base: 30, ref: 260, min: 22, max: 64 },
+  // board-*: compact tiles for the 2D table tile (BoardTile). Each seat's
+  // mahgen container is a fraction of the square board, so these scale down
+  // when the tile is small. `board-hand` uses linear (constant-ish tile size,
+  // width grows with tile count) rather than `hand`'s 'fit' min:44 which would
+  // overflow a small seat. Values are tunable — refine visually in the webview.
+  'board-hand':  { mode: 'linear', base: 30, ref: 320, min: 14, max: 40 },
+  'board-river': { mode: 'river',  maxScale: 0.5, minScale: 0.12 },
+  'board-meld':  { mode: 'linear', base: 22, ref: 200, min: 12, max: 38 },
 }
 
 const RIVER_FULL_ROW_W = 420

--- a/frontend/src/lib/mahgenRegistry.ts
+++ b/frontend/src/lib/mahgenRegistry.ts
@@ -33,9 +33,9 @@ const SIZE_CTX: Record<MahgenKind, SizeCtx> = {
   // when the tile is small. `board-hand` uses linear (constant-ish tile size,
   // width grows with tile count) rather than `hand`'s 'fit' min:44 which would
   // overflow a small seat. Values are tunable — refine visually in the webview.
-  'board-hand':  { mode: 'linear', base: 30, ref: 320, min: 14, max: 40 },
-  'board-river': { mode: 'river',  maxScale: 0.5, minScale: 0.12 },
-  'board-meld':  { mode: 'linear', base: 22, ref: 200, min: 12, max: 38 },
+  'board-hand':  { mode: 'linear', base: 26, ref: 300, min: 14, max: 34 },
+  'board-river': { mode: 'river',  maxScale: 0.3, minScale: 0.10 },
+  'board-meld':  { mode: 'linear', base: 18, ref: 220, min: 10, max: 30 },
 }
 
 const RIVER_FULL_ROW_W = 420

--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -1,0 +1,151 @@
+/* BoardTile — 2D top-down mahjong table.
+ *
+ * Layout strategy (see claude_plan / issue): the hero sits at the bottom; the
+ * other seats are drawn into a full-square layer that is rotated 90/180/270°
+ * about the board center. CSS `transform: rotate()` is paint-only, so each
+ * seat's mahgen container reports its pre-rotation (axis-aligned) clientWidth —
+ * which is what mahgen's sizing reads — so all four seats size identically.
+ * Nameplates are rendered in a SEPARATE, non-rotated layer so their text stays
+ * upright regardless of seat.
+ *
+ * The square pixel size is set inline by BoardTile (ResizeObserver), so every
+ * percentage below resolves against a known square. Positions/sizes are
+ * deliberately simple and tunable — refine visually in the Tauri webview. */
+
+.board-root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.board-empty {
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+}
+
+.board-square {
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 50% 45%, rgba(21, 128, 97, 0.30), rgba(6, 38, 30, 0.55) 70%),
+    var(--card);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+/* ---- center info ---- */
+.board-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 56%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+  pointer-events: none;
+  color: var(--foreground);
+}
+.board-center-round {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+.board-center-sticks {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.board-stick {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.board-stick img {
+  height: 18px;
+}
+.board-center-dora {
+  display: flex;
+  justify-content: center;
+  margin-top: 2px;
+}
+
+/* ---- rotated per-seat tile layer ---- */
+.board-seat {
+  position: absolute;
+  inset: 0;
+  transform-origin: center center;
+  pointer-events: none;
+}
+.board-seat-stack {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 2%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1.5%;
+}
+.board-seat-river {
+  width: 42%;
+  display: flex;
+  justify-content: center;
+}
+.board-seat-melds {
+  width: 86%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+.board-seat-hand {
+  width: 66%;
+  display: flex;
+  justify-content: center;
+}
+
+/* ---- upright nameplates (NOT rotated) ---- */
+.board-label {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.5);
+  color: var(--foreground);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.board-label--bottom { bottom: 2%; left: 3%; }
+.board-label--top    { top: 2%; right: 3%; }
+.board-label--left   { left: 2%; bottom: 3%; }
+.board-label--right  { right: 2%; top: 3%; }
+.board-label--active {
+  outline: 2px solid rgba(251, 191, 36, 0.95);
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.55);
+}
+.board-label-wind { font-weight: 700; }
+.board-label-score { font-variant-numeric: tabular-nums; }
+.board-badge {
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.board-badge--riichi { background: rgba(245, 158, 11, 0.18); color: #fbbf24; }
+.board-badge--kita { background: rgba(14, 165, 233, 0.18); color: #38bdf8; }

--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -5,12 +5,15 @@
  * about the board center. CSS `transform: rotate()` is paint-only, so each
  * seat's mahgen container reports its pre-rotation (axis-aligned) clientWidth —
  * which is what mahgen's sizing reads — so all four seats size identically.
- * Nameplates are rendered in a SEPARATE, non-rotated layer so their text stays
- * upright regardless of seat.
  *
- * The square pixel size is set inline by BoardTile (ResizeObserver), so every
- * percentage below resolves against a known square. Positions/sizes are
- * deliberately simple and tunable — refine visually in the Tauri webview. */
+ * Each seat's hand / river / melds are absolutely positioned within the layer:
+ * the hand hugs the outer edge, the river is TOP-anchored just inside it so new
+ * rows fill DOWNWARD (the first row never shifts), and melds sit beside the hand.
+ *
+ * Scores live in a central panel (one per seat, placed on that seat's side, à la
+ * Majsoul) so they never collide. Dora sits in a top-left panel. The square
+ * pixel size is set inline by BoardTile (ResizeObserver) so every percentage
+ * below resolves against a known square. Positions/sizes are tunable. */
 
 .board-root {
   width: 100%;
@@ -36,45 +39,25 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
-/* ---- center info ---- */
-.board-center {
+/* ---- dora panel (top-left) ---- */
+.board-dora {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 56%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  text-align: center;
-  pointer-events: none;
-  color: var(--foreground);
-}
-.board-center-round {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-.board-center-sticks {
+  top: 2.5%;
+  left: 2.5%;
+  z-index: 3;
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
+  gap: 5px;
+  padding: 3px 7px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border);
+  border-radius: 8px;
 }
-.board-stick {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-}
-.board-stick img {
-  height: 18px;
-}
-.board-center-dora {
-  display: flex;
-  justify-content: center;
-  margin-top: 2px;
+.board-dora-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
 }
 
 /* ---- rotated per-seat tile layer ---- */
@@ -84,68 +67,119 @@
   transform-origin: center center;
   pointer-events: none;
 }
-.board-seat-stack {
+.board-seat-hand {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 2%;
+  bottom: 1.5%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 52%;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 1.5%;
+  justify-content: center;
 }
 .board-seat-river {
-  width: 42%;
+  /* TOP-anchored so the river grows downward; the first row stays put. */
+  position: absolute;
+  top: 67%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 34%;
   display: flex;
   justify-content: center;
 }
 .board-seat-melds {
-  width: 86%;
+  position: absolute;
+  bottom: 1.5%;
+  right: 0.5%;
+  max-width: 46%;
   display: flex;
   flex-wrap: wrap;
   gap: 3px;
   justify-content: flex-end;
   align-items: flex-end;
 }
-.board-seat-hand {
-  width: 66%;
-  display: flex;
-  justify-content: center;
-}
 
-/* ---- upright nameplates (NOT rotated) ---- */
-.board-label {
+/* ---- central panel: round info + each seat's score on its side ---- */
+.board-center {
   position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 31%;
+  aspect-ratio: 1;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 1fr 1.25fr 1fr;
+  grid-template-rows: 1fr 1.25fr 1fr;
+  color: var(--foreground);
+  background: rgba(6, 26, 22, 0.86);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+.board-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.board-score--top    { grid-column: 2; grid-row: 1; }
+.board-score--right  { grid-column: 3; grid-row: 2; }
+.board-score--bottom { grid-column: 2; grid-row: 3; }
+.board-score--left   { grid-column: 1; grid-row: 2; }
+.board-score--active {
+  background: rgba(251, 191, 36, 0.16);
+  border-radius: 6px;
+  outline: 1px solid rgba(251, 191, 36, 0.8);
+}
+.board-score-wind {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 2px 7px;
-  border-radius: 9999px;
-  background: rgba(0, 0, 0, 0.5);
-  color: var(--foreground);
-  font-size: 11px;
-  line-height: 1.5;
-  white-space: nowrap;
-  pointer-events: none;
-}
-.board-label--bottom { bottom: 2%; left: 3%; }
-.board-label--top    { top: 2%; right: 3%; }
-.board-label--left   { left: 2%; bottom: 3%; }
-.board-label--right  { right: 2%; top: 3%; }
-.board-label--active {
-  outline: 2px solid rgba(251, 191, 36, 0.95);
-  box-shadow: 0 0 12px rgba(251, 191, 36, 0.55);
-}
-.board-label-wind { font-weight: 700; }
-.board-label-score { font-variant-numeric: tabular-nums; }
-.board-badge {
-  padding: 0 5px;
-  border-radius: 4px;
-  font-size: 9px;
+  gap: 2px;
+  font-size: 10px;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  opacity: 0.85;
 }
-.board-badge--riichi { background: rgba(245, 158, 11, 0.18); color: #fbbf24; }
-.board-badge--kita { background: rgba(14, 165, 233, 0.18); color: #38bdf8; }
+.board-score-riichi {
+  color: #fbbf24;
+  font-size: 8px;
+}
+.board-score-pts {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.board-center-mid {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  text-align: center;
+}
+.board-center-round {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+.board-center-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+.board-stick {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.board-stick img {
+  height: 12px;
+}

--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -33,9 +33,8 @@
   position: relative;
   overflow: hidden;
   border-radius: 10px;
-  background:
-    radial-gradient(circle at 50% 45%, rgba(21, 128, 97, 0.30), rgba(6, 38, 30, 0.55) 70%),
-    var(--card);
+  /* fixed solid dark grey, matching the Akagi default (neutral) dark theme */
+  background: oklch(0.17 0 0);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
@@ -52,6 +51,9 @@
   background: rgba(0, 0, 0, 0.5);
   border: 1px solid var(--border);
   border-radius: 8px;
+  /* scale with the board so the dora doesn't look tiny on a large tile */
+  transform: scale(var(--board-scale, 1));
+  transform-origin: top left;
 }
 .board-dora-label {
   font-size: 10px;
@@ -72,7 +74,7 @@
   bottom: 1.5%;
   left: 50%;
   transform: translateX(-50%);
-  width: 52%;
+  width: 56%;
   display: flex;
   justify-content: center;
 }
@@ -82,7 +84,7 @@
   top: 67%;
   left: 50%;
   transform: translateX(-50%);
-  width: 34%;
+  width: 26%;
   display: flex;
   justify-content: center;
 }
@@ -130,11 +132,6 @@
 .board-score--right  { grid-column: 3; grid-row: 2; }
 .board-score--bottom { grid-column: 2; grid-row: 3; }
 .board-score--left   { grid-column: 1; grid-row: 2; }
-.board-score--active {
-  background: rgba(251, 191, 36, 0.16);
-  border-radius: 6px;
-  outline: 1px solid rgba(251, 191, 36, 0.8);
-}
 .board-score-wind {
   display: inline-flex;
   align-items: center;
@@ -182,4 +179,23 @@
 }
 .board-stick img {
   height: 12px;
+}
+
+/* ---- current-turn indicator: slow-blinking yellow bar on the active side ---- */
+.board-turn-bar {
+  position: absolute;
+  background: #fbbf24;
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(251, 191, 36, 0.7);
+  animation: board-turn-pulse 1.6s ease-in-out infinite;
+  pointer-events: none;
+}
+.board-turn-bar--bottom { left: 20%; right: 20%; bottom: 3.5%; height: 3px; }
+.board-turn-bar--top    { left: 20%; right: 20%; top: 3.5%; height: 3px; }
+.board-turn-bar--left   { top: 20%; bottom: 20%; left: 3.5%; width: 3px; }
+.board-turn-bar--right  { top: 20%; bottom: 20%; right: 3.5%; width: 3px; }
+
+@keyframes board-turn-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.2; }
 }

--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -113,11 +113,16 @@
   grid-template-columns: 1fr 1.25fr 1fr;
   grid-template-rows: 1fr 1.25fr 1fr;
   color: var(--foreground);
-  background: rgba(6, 26, 22, 0.86);
+  /* lighter translucent grey over the dark board, with a border */
+  background: oklch(0.30 0 0 / 0.55);
   border: 1px solid var(--border);
   border-radius: 12px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
   overflow: hidden;
+  /* panel text scales with the board (see --board-scale on .board-square) */
+  font-size: calc(11px * var(--board-scale, 1));
 }
 .board-score {
   display: flex;
@@ -128,24 +133,25 @@
   line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-.board-score--top    { grid-column: 2; grid-row: 1; }
-.board-score--right  { grid-column: 3; grid-row: 2; }
+/* Each seat's info rotates to face that player (Majsoul-style). */
+.board-score--top    { grid-column: 2; grid-row: 1; transform: rotate(180deg); }
+.board-score--right  { grid-column: 3; grid-row: 2; transform: rotate(270deg); }
 .board-score--bottom { grid-column: 2; grid-row: 3; }
-.board-score--left   { grid-column: 1; grid-row: 2; }
+.board-score--left   { grid-column: 1; grid-row: 2; transform: rotate(90deg); }
 .board-score-wind {
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  font-size: 10px;
+  font-size: 0.85em;
   font-weight: 700;
   opacity: 0.85;
 }
 .board-score-riichi {
   color: #fbbf24;
-  font-size: 8px;
+  font-size: 0.7em;
 }
 .board-score-pts {
-  font-size: 12px;
+  font-size: 1.05em;
   font-weight: 600;
 }
 
@@ -160,7 +166,7 @@
   text-align: center;
 }
 .board-center-round {
-  font-size: 12px;
+  font-size: 1.15em;
   font-weight: 600;
   letter-spacing: 0.03em;
   white-space: nowrap;
@@ -169,7 +175,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 9px;
+  font-size: 0.8em;
   font-variant-numeric: tabular-nums;
 }
 .board-stick {
@@ -178,7 +184,7 @@
   gap: 2px;
 }
 .board-stick img {
-  height: 12px;
+  height: 1.2em;
 }
 
 /* ---- current-turn indicator: slow-blinking yellow bar on the active side ---- */

--- a/frontend/src/tiles/BoardTile.tsx
+++ b/frontend/src/tiles/BoardTile.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import { TileFrame } from '@/components/TileFrame'
+import { Mahgen } from '@/components/Mahgen'
+import { useGameStore } from '@/stores/gameStore'
+import { fmtScore, bakazeFor, kyokuLabel, relativeKind, type RelativeKind } from '@/lib/format'
+import type { Breakpoint } from '@/tiles/defaults'
+import './BoardTile.css'
+
+// Screen edge each seat is drawn on, and the rotation applied to its tile
+// layer (paint-only — see BoardTile.css for why sizing survives rotation).
+type Edge = 'bottom' | 'right' | 'top' | 'left'
+const EDGE_ROT: Record<Edge, number> = { bottom: 0, right: 270, top: 180, left: 90 }
+const KIND_EDGE: Record<RelativeKind, Edge> = {
+  self: 'bottom',
+  shimocha: 'right',
+  toimen: 'top',
+  kamicha: 'left',
+}
+// Spectator fallback: with no hero seat, relativeKind() collapses everyone to
+// 'self', so place seats by absolute index instead.
+const IDENTITY_EDGE: Edge[] = ['bottom', 'right', 'top', 'left']
+
+function seatEdge(seat: number, ourSeat: number | null, numPlayers: number): Edge {
+  if (ourSeat == null) return IDENTITY_EDGE[seat] ?? 'bottom'
+  return KIND_EDGE[relativeKind(seat, ourSeat, numPlayers)]
+}
+
+// Largest square that fits the (possibly non-square) content box. The pixel
+// size is set on `.board-square` so every CSS percentage inside resolves
+// against a known square and mahgen containers report stable widths.
+function useSquareSize(ref: RefObject<HTMLElement | null>): number {
+  const [size, setSize] = useState(0)
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => {
+      const r = el.getBoundingClientRect()
+      setSize(Math.max(0, Math.floor(Math.min(r.width, r.height))))
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [ref])
+  return size
+}
+
+export function BoardTile({ bp }: { bp: Breakpoint }) {
+  const { t } = useTranslation()
+  const game = useGameStore((s) => s.game)
+  const view = useGameStore((s) => s.view)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const size = useSquareSize(rootRef)
+
+  const numPlayers = game?.num_players ?? view?.num_players ?? 4
+  const ourSeat = game?.our_seat ?? null
+
+  return (
+    <TileFrame id="board" title={t('tile.board')} bp={bp} contentClassName="p-0">
+      <div ref={rootRef} className="board-root">
+        {game && view && size > 0 ? (
+          <div className="board-square" style={{ width: size, height: size }}>
+            {/* center: round / sticks / dora */}
+            <div className="board-center">
+              <div className="board-center-round">{kyokuLabel(game.bakaze, game.kyoku)}</div>
+              <div className="board-center-sticks">
+                <span className="board-stick">
+                  <img src="/1000_mini.svg" alt="" />×{game.kyotaku}
+                </span>
+                <span className="board-stick">
+                  <img src="/100_mini.svg" alt="" />×{game.honba}
+                </span>
+              </div>
+              {view.dora_indicators && (
+                <div className="board-center-dora">
+                  <Mahgen seq={view.dora_indicators} kind="dora" />
+                </div>
+              )}
+            </div>
+
+            {/* rotated tile layer per seat */}
+            {Array.from({ length: numPlayers }, (_, seat) => {
+              const pview = view.players[seat]
+              if (!pview) return null
+              const edge = seatEdge(seat, ourSeat, numPlayers)
+              return (
+                <div
+                  key={seat}
+                  className="board-seat"
+                  style={{ transform: `rotate(${EDGE_ROT[edge]}deg)` }}
+                >
+                  <div className="board-seat-stack">
+                    {pview.river && (
+                      <div className="board-seat-river">
+                        <Mahgen seq={pview.river} kind="board-river" riverMode />
+                      </div>
+                    )}
+                    {pview.melds.length > 0 && (
+                      <div className="board-seat-melds">
+                        {pview.melds.map((m, i) => (
+                          <Mahgen key={i} seq={m} kind="board-meld" />
+                        ))}
+                      </div>
+                    )}
+                    {pview.hand && (
+                      <div className="board-seat-hand">
+                        <Mahgen seq={pview.hand} kind="board-hand" />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+
+            {/* upright nameplates per seat (current turn highlighted) */}
+            {Array.from({ length: numPlayers }, (_, seat) => {
+              const player = game.players[seat]
+              if (!player) return null
+              const edge = seatEdge(seat, ourSeat, numPlayers)
+              const active = game.current_player === seat
+              const kita = player.kita_tiles?.length ?? 0
+              return (
+                <div
+                  key={seat}
+                  className={`board-label board-label--${edge}${active ? ' board-label--active' : ''}`}
+                >
+                  <span className="board-label-wind">{bakazeFor(seat, game.oya, numPlayers)}</span>
+                  <span className="board-label-score">{fmtScore(player.score)}</span>
+                  {player.riichi_declared && (
+                    <span className="board-badge board-badge--riichi">{t('mahjong.riichi')}</span>
+                  )}
+                  {kita > 0 && <span className="board-badge board-badge--kita">北×{kita}</span>}
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <span className="board-empty">{t('tile.board_empty')}</span>
+        )}
+      </div>
+    </TileFrame>
+  )
+}

--- a/frontend/src/tiles/BoardTile.tsx
+++ b/frontend/src/tiles/BoardTile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type RefObject } from 'react'
+import { useEffect, useRef, useState, type CSSProperties, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TileFrame } from '@/components/TileFrame'
 import { Mahgen } from '@/components/Mahgen'
@@ -53,12 +53,19 @@ export function BoardTile({ bp }: { bp: Breakpoint }) {
 
   const numPlayers = game?.num_players ?? view?.num_players ?? 4
   const ourSeat = game?.our_seat ?? null
+  // Scales board chrome (dora panel, etc.) with the board so it doesn't look
+  // empty when the tile is enlarged. The tiles themselves scale via their
+  // container widths (fractions of the square); this covers the fixed-size bits.
+  const boardScale = Math.min(2.4, Math.max(0.8, size / 460))
 
   return (
     <TileFrame id="board" title={t('tile.board')} bp={bp} contentClassName="p-0">
       <div ref={rootRef} className="board-root">
         {game && view && size > 0 ? (
-          <div className="board-square" style={{ width: size, height: size }}>
+          <div
+            className="board-square"
+            style={{ width: size, height: size, '--board-scale': boardScale } as CSSProperties}
+          >
             {/* dora indicators, top-left */}
             {view.dora_indicators && (
               <div className="board-dora">
@@ -105,12 +112,8 @@ export function BoardTile({ bp }: { bp: Breakpoint }) {
                 const player = game.players[seat]
                 if (!player) return null
                 const edge = seatEdge(seat, ourSeat, numPlayers)
-                const active = game.current_player === seat
                 return (
-                  <div
-                    key={seat}
-                    className={`board-score board-score--${edge}${active ? ' board-score--active' : ''}`}
-                  >
+                  <div key={seat} className={`board-score board-score--${edge}`}>
                     <span className="board-score-wind">
                       {bakazeFor(seat, game.oya, numPlayers)}
                       {player.riichi_declared && <span className="board-score-riichi">●</span>}
@@ -119,6 +122,12 @@ export function BoardTile({ bp }: { bp: Breakpoint }) {
                   </div>
                 )
               })}
+              {/* current-turn indicator: a slow-blinking bar on the active seat's side */}
+              {game.players[game.current_player] && (
+                <div
+                  className={`board-turn-bar board-turn-bar--${seatEdge(game.current_player, ourSeat, numPlayers)}`}
+                />
+              )}
               <div className="board-center-mid">
                 <div className="board-center-round">{kyokuLabel(game.bakaze, game.kyoku)}</div>
                 <div className="board-center-sub">

--- a/frontend/src/tiles/BoardTile.tsx
+++ b/frontend/src/tiles/BoardTile.tsx
@@ -59,25 +59,15 @@ export function BoardTile({ bp }: { bp: Breakpoint }) {
       <div ref={rootRef} className="board-root">
         {game && view && size > 0 ? (
           <div className="board-square" style={{ width: size, height: size }}>
-            {/* center: round / sticks / dora */}
-            <div className="board-center">
-              <div className="board-center-round">{kyokuLabel(game.bakaze, game.kyoku)}</div>
-              <div className="board-center-sticks">
-                <span className="board-stick">
-                  <img src="/1000_mini.svg" alt="" />×{game.kyotaku}
-                </span>
-                <span className="board-stick">
-                  <img src="/100_mini.svg" alt="" />×{game.honba}
-                </span>
+            {/* dora indicators, top-left */}
+            {view.dora_indicators && (
+              <div className="board-dora">
+                <span className="board-dora-label">{t('tile.dora')}</span>
+                <Mahgen seq={view.dora_indicators} kind="dora" />
               </div>
-              {view.dora_indicators && (
-                <div className="board-center-dora">
-                  <Mahgen seq={view.dora_indicators} kind="dora" />
-                </div>
-              )}
-            </div>
+            )}
 
-            {/* rotated tile layer per seat */}
+            {/* rotated tile layer per seat (hand / river / melds) */}
             {Array.from({ length: numPlayers }, (_, seat) => {
               const pview = view.players[seat]
               if (!pview) return null
@@ -88,50 +78,59 @@ export function BoardTile({ bp }: { bp: Breakpoint }) {
                   className="board-seat"
                   style={{ transform: `rotate(${EDGE_ROT[edge]}deg)` }}
                 >
-                  <div className="board-seat-stack">
-                    {pview.river && (
-                      <div className="board-seat-river">
-                        <Mahgen seq={pview.river} kind="board-river" riverMode />
-                      </div>
-                    )}
-                    {pview.melds.length > 0 && (
-                      <div className="board-seat-melds">
-                        {pview.melds.map((m, i) => (
-                          <Mahgen key={i} seq={m} kind="board-meld" />
-                        ))}
-                      </div>
-                    )}
-                    {pview.hand && (
-                      <div className="board-seat-hand">
-                        <Mahgen seq={pview.hand} kind="board-hand" />
-                      </div>
-                    )}
-                  </div>
+                  {pview.river && (
+                    <div className="board-seat-river">
+                      <Mahgen seq={pview.river} kind="board-river" riverMode />
+                    </div>
+                  )}
+                  {pview.melds.length > 0 && (
+                    <div className="board-seat-melds">
+                      {pview.melds.map((m, i) => (
+                        <Mahgen key={i} seq={m} kind="board-meld" />
+                      ))}
+                    </div>
+                  )}
+                  {pview.hand && (
+                    <div className="board-seat-hand">
+                      <Mahgen seq={pview.hand} kind="board-hand" />
+                    </div>
+                  )}
                 </div>
               )
             })}
 
-            {/* upright nameplates per seat (current turn highlighted) */}
-            {Array.from({ length: numPlayers }, (_, seat) => {
-              const player = game.players[seat]
-              if (!player) return null
-              const edge = seatEdge(seat, ourSeat, numPlayers)
-              const active = game.current_player === seat
-              const kita = player.kita_tiles?.length ?? 0
-              return (
-                <div
-                  key={seat}
-                  className={`board-label board-label--${edge}${active ? ' board-label--active' : ''}`}
-                >
-                  <span className="board-label-wind">{bakazeFor(seat, game.oya, numPlayers)}</span>
-                  <span className="board-label-score">{fmtScore(player.score)}</span>
-                  {player.riichi_declared && (
-                    <span className="board-badge board-badge--riichi">{t('mahjong.riichi')}</span>
-                  )}
-                  {kita > 0 && <span className="board-badge board-badge--kita">北×{kita}</span>}
+            {/* central panel: each seat's score around it + round info */}
+            <div className="board-center">
+              {Array.from({ length: numPlayers }, (_, seat) => {
+                const player = game.players[seat]
+                if (!player) return null
+                const edge = seatEdge(seat, ourSeat, numPlayers)
+                const active = game.current_player === seat
+                return (
+                  <div
+                    key={seat}
+                    className={`board-score board-score--${edge}${active ? ' board-score--active' : ''}`}
+                  >
+                    <span className="board-score-wind">
+                      {bakazeFor(seat, game.oya, numPlayers)}
+                      {player.riichi_declared && <span className="board-score-riichi">●</span>}
+                    </span>
+                    <span className="board-score-pts">{fmtScore(player.score)}</span>
+                  </div>
+                )
+              })}
+              <div className="board-center-mid">
+                <div className="board-center-round">{kyokuLabel(game.bakaze, game.kyoku)}</div>
+                <div className="board-center-sub">
+                  <span className="board-stick">
+                    <img src="/100_mini.svg" alt="honba" />×{game.honba}
+                  </span>
+                  <span className="board-stick">
+                    <img src="/1000_mini.svg" alt="kyotaku" />×{game.kyotaku}
+                  </span>
                 </div>
-              )
-            })}
+              </div>
+            </div>
           </div>
         ) : (
           <span className="board-empty">{t('tile.board_empty')}</span>

--- a/frontend/src/tiles/PlayerTile.tsx
+++ b/frontend/src/tiles/PlayerTile.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { TileFrame } from '@/components/TileFrame'
 import { Mahgen } from '@/components/Mahgen'
 import { useGameStore } from '@/stores/gameStore'
-import { fmtScore, relativeKind, BAKAZE_LABEL } from '@/lib/format'
+import { fmtScore, relativeKind, bakazeFor } from '@/lib/format'
 import type { Breakpoint, TileId } from '@/tiles/defaults'
 
 const SEAT_TO_TILE: Record<number, TileId> = {
@@ -89,12 +89,4 @@ export function PlayerTile({ seat, bp }: { seat: number; bp: Breakpoint }) {
       )}
     </TileFrame>
   )
-}
-
-// East = oya seat. Each subsequent seat rotates S → W → N (4p) or
-// S → W (3p — sanma has no N self-wind, only E/S/W).
-function bakazeFor(seat: number, oya: number, numPlayers: number): string {
-  const order = ['E', 'S', 'W', 'N']
-  const n = Math.max(1, numPlayers)
-  return BAKAZE_LABEL[order[(seat - oya + n) % n]]
 }

--- a/frontend/src/tiles/defaults.ts
+++ b/frontend/src/tiles/defaults.ts
@@ -7,6 +7,7 @@ export type TileId =
   | 'player-2'
   | 'player-3'
   | 'self-hand'
+  | 'board'
   | 'recommendations'
   | 'risk-chart'
   | 'opponents'
@@ -30,6 +31,7 @@ export const ALL_TILES: TileId[] = [
   'player-2',
   'player-3',
   'self-hand',
+  'board',
   'recommendations',
   'risk-chart',
   'opponents',
@@ -62,6 +64,7 @@ const LG_LAYOUT: LayoutItem[] = [
   { i: 'risk-chart',      x: 0, y: 19, w: 3,  h: 6, minW: 2, minH: 4 },
   { i: 'opponents',       x: 3, y: 19, w: 3,  h: 6, minW: 2, minH: 4 },
   { i: 'proxy-control',   x: 6, y: 19, w: 6,  h: 6, minW: 2, minH: 2, maxH: 6 },
+  { i: 'board',           x: 0, y: 25, w: 6,  h: 14, minW: 4, minH: 8 },
 ]
 
 const MD_LAYOUT: LayoutItem[] = [
@@ -80,6 +83,7 @@ const MD_LAYOUT: LayoutItem[] = [
   { i: 'player-2',        x: 6, y: 18, w: 2,  h: 8, minW: 2, minH: 6 },
   { i: 'player-3',        x: 8, y: 18, w: 2,  h: 8, minW: 2, minH: 6 },
   { i: 'proxy-control',   x: 0, y: 26, w: 10, h: 4, minW: 2, minH: 2, maxH: 6 },
+  { i: 'board',           x: 0, y: 30, w: 6,  h: 14, minW: 4, minH: 8 },
 ]
 
 const SM_LAYOUT: LayoutItem[] = [
@@ -98,6 +102,7 @@ const SM_LAYOUT: LayoutItem[] = [
   { i: 'bot-responses',   x: 3, y: 38, w: 3, h: 5, minW: 2, minH: 3 },
   { i: 'bot-action',      x: 0, y: 43, w: 6, h: 3, minW: 3, minH: 2 },
   { i: 'bot-show',        x: 0, y: 46, w: 6, h: 5, minW: 2, minH: 3 },
+  { i: 'board',           x: 0, y: 51, w: 6, h: 16, minW: 4, minH: 8 },
 ]
 
 const XS_LAYOUT: LayoutItem[] = ALL_TILES.map((id, i) => ({
@@ -139,6 +144,7 @@ const LG_LAYOUT_3P: LayoutItem[] = [
   { i: 'events',          x: 8, y: 20, w: 4,  h: 5, minW: 2, minH: 3 },
   { i: 'recommendations', x: 0, y: 25, w: 6,  h: 8, minW: 2, minH: 4 },
   { i: 'risk-chart',      x: 6, y: 25, w: 6,  h: 8, minW: 2, minH: 4 },
+  { i: 'board',           x: 0, y: 33, w: 6,  h: 14, minW: 4, minH: 8 },
 ]
 
 const MD_LAYOUT_3P: LayoutItem[] = [
@@ -156,6 +162,7 @@ const MD_LAYOUT_3P: LayoutItem[] = [
   { i: 'events',          x: 7, y: 20, w: 3,  h: 5, minW: 2, minH: 3 },
   { i: 'recommendations', x: 0, y: 25, w: 5,  h: 8, minW: 2, minH: 4 },
   { i: 'risk-chart',      x: 5, y: 25, w: 5,  h: 8, minW: 2, minH: 4 },
+  { i: 'board',           x: 0, y: 33, w: 6,  h: 14, minW: 4, minH: 8 },
 ]
 
 const SM_LAYOUT_3P: LayoutItem[] = [
@@ -173,6 +180,7 @@ const SM_LAYOUT_3P: LayoutItem[] = [
   { i: 'bot-action',      x: 0, y: 43, w: 6, h: 3, minW: 3, minH: 2 },
   { i: 'bot-show',        x: 0, y: 46, w: 6, h: 5, minW: 2, minH: 3 },
 //{ i: 'recommendations', x: 0, y: 10, w: 6, h: 8, minW: 2, minH: 4 },
+  { i: 'board',           x: 0, y: 51, w: 6, h: 16, minW: 4, minH: 8 },
 ]
 
 const ALL_TILES_3P: TileId[] = ALL_TILES.filter((id) => id !== 'player-3')
@@ -204,6 +212,7 @@ export const TILE_TITLES: Record<TileId, string> = {
   'player-2':        'Player 3 (Self)',
   'player-3':        'Player 4',
   'self-hand':       'Self Hand',
+  'board':           'Board',
   'recommendations': 'Recommendations',
   'risk-chart':      'Mixed Risk',
   'opponents':       'Opponents',

--- a/frontend/src/tiles/registry.tsx
+++ b/frontend/src/tiles/registry.tsx
@@ -1,6 +1,7 @@
 import { HeaderTile } from './HeaderTile'
 import { PlayerTile } from './PlayerTile'
 import { SelfHandTile } from './SelfHandTile'
+import { BoardTile } from './BoardTile'
 import { RecommendationsTile } from './RecommendationsTile'
 import { RiskChartTile } from './RiskChartTile'
 import { OpponentsTile } from './OpponentsTile'
@@ -20,6 +21,7 @@ export function renderTile(id: TileId, bp: Breakpoint) {
     case 'player-2':        return <PlayerTile seat={2} bp={bp} />
     case 'player-3':        return <PlayerTile seat={3} bp={bp} />
     case 'self-hand':       return <SelfHandTile bp={bp} />
+    case 'board':           return <BoardTile bp={bp} />
     case 'recommendations': return <RecommendationsTile bp={bp} />
     case 'risk-chart':      return <RiskChartTile bp={bp} />
     case 'opponents':       return <OpponentsTile bp={bp} />


### PR DESCRIPTION
Closes #141.

## What

Adds a new dashboard tile — a **2D top-down mahjong table** (`TileId: 'board'`).
The hero sits at the bottom; the other seats are drawn into full-square layers
rotated 90/180/270° about the board center. The center shows round / honba /
kyotaku / dora, and each seat has an upright nameplate (wind, score, riichi/kita).
The **current player's** nameplate is highlighted.

## How

- **Reuses existing primitives only** — `Mahgen` + the `MahgenView` data already
  on the frontend (per-player `hand` / `melds` / `river` mahgen DSL +
  `dora_indicators`). **No backend / store / type changes.**
- Seats are placed by `relativeKind(seat, ourSeat, numPlayers)`; rotation is
  applied to a per-seat tile layer. CSS `transform: rotate()` is paint-only, so
  each seat's mahgen container reports its pre-rotation `clientWidth` and all
  four seats size identically. A `ResizeObserver` sets `.board-square` to the
  largest fitting square so every percentage / container width resolves against a
  known square.
- Nameplates live in a separate, non-rotated layer so their text stays upright.
- Handles **4p and 3p** (no opposite seat in sanma); spectator mode
  (`our_seat == null`) falls back to identity seat→edge mapping.

## Files

- New: `frontend/src/tiles/BoardTile.tsx` (+ `BoardTile.css`).
- `lib/mahgenRegistry.ts`: add compact `board-hand` / `board-river` / `board-meld`
  sizing kinds (`board-hand` uses linear sizing — `hand`'s `min:44` 'fit' would
  overflow a small seat).
- `lib/format.ts`: lift & export `bakazeFor` (was private in `PlayerTile.tsx`).
- Register: `tiles/defaults.ts` (default-visible; appended at the bottom of each
  breakpoint + 3p so existing tuned positions aren't disturbed — `normaliseLayouts`
  appends it for existing saved layouts), `tiles/registry.tsx`,
  `components/AddTileMenu.tsx`, and `tile.board` / `tile.board_empty` in all four
  i18n files.

## Scope

- v1: core board + current-turn highlight. **Out of scope** (follow-ups):
  hora/ryukyoku result banner, per-tile last-discard highlight, replacing the
  per-seat Player/Self-hand tiles.

## Verification

- `tsc -b`, `eslint .`, and `vite build` all pass clean.
- No frontend test runner exists (no vitest/jest), so no unit test was added.
  **Visual verification in the running app is still pending** — in particular,
  rotated-mahgen tile sizing under the WebKitGTK webview, and fine-tuning the
  per-seat positions (deliberately simple and tunable in `BoardTile.css`).

Original, clean-room implementation using this project's own rendering primitives
and assets.