### PR TITLE
fix(bot): let developers build env + enable a locally-dropped bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ event stream, the reaction and `meta` HUD format, toast notifications, and
 `manifest.toml` settings. [`mjai_bot/example/`](./mjai_bot/example/) is a
 working rule-based bot you can copy.
 
+For local development, drop your bot folder under `mjai_bot/<name>/` and click
+**Install environment** on its row in the **Bots** tab to build its venv — no
+need to repackage and reinstall on every change. The activation toggle stays
+disabled until the environment is ready.
+
 ### AGPL boundary
 
 Bots run as a **separate OS subprocess** spawned by Akagi. Communication
@@ -429,6 +434,12 @@ Useful when debugging a bot or a bridge issue.
 - **Bot stuck in `Loading{SyncingDeps}`.** First-run `uv sync` is
   slow — watch the Diagnostic tab for `bot=<name>` lines. If it never
   finishes, delete `mjai_bot/<name>/.akagi/synced.stamp` and retry.
+- **Activation toggle greyed out / a dropped-in bot won't enable.** Its
+  Python environment isn't built yet. On the **Bots** tab, click the
+  **Install environment** button on that bot's row (it appears whenever the
+  env isn't ready) to run `uv sync`; the toggle enables once it finishes.
+  Editing the bot's `pyproject.toml` marks the env stale and brings the
+  button back.
 - **Bot crashed mid-game.** The Inspector tab shows the last frame the
   bot saw before dying; attach it to the bug report.
 - **Wrong bot picked for a 3-player game.** Check `bot.active_3p` in

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -307,6 +307,10 @@ stdout 每行写出一个 mjai 动作对象（无动作时输出
 [`mjai_bot/example/`](./mjai_bot/example/) 是一个 in-tree、
 可运行的规则型示例 bot。
 
+本地开发时，把 bot 文件夹放到 `mjai_bot/<name>/`，在 **Bots** 标签页该 bot
+行上点击 **安装环境** 即可构建其 venv —— 无需每次改动都重新打包安装。环境
+就绪前启用开关会保持禁用。
+
 ### AGPL 边界
 
 Bot 以 Akagi 启动的 **独立 OS 子进程** 运行。通信严格通
@@ -418,6 +422,10 @@ session；点击行可看到原始结构化字段与源位置。
   会很慢 — 在 Diagnostic 标签页观察 `bot=<name>` 的消息。
   若一直未完成，删除
   `mjai_bot/<name>/.akagi/synced.stamp` 后重试。
+- **启用开关变灰 / 手动放入的 bot 无法启用。** 它的 Python 环境还没构建。
+  在 **Bots** 标签页该 bot 行上点击 **安装环境** 按钮（环境未就绪时会出现）
+  以运行 `uv sync`；完成后开关即可启用。修改该 bot 的 `pyproject.toml` 会
+  使环境失效，按钮会再次出现。
 - **Bot 对局途中崩溃。** Inspector 标签页可显示 bot 死前
   看到的最后一帧；附在 bug 报告里。
 - **三麻挑了错的 bot。** 检查设置 → Bot 中的

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -299,6 +299,10 @@ stdout 每行寫出一個 mjai 動作物件（無動作時輸出
 [`mjai_bot/example/`](./mjai_bot/example/) 為一個 in-tree、
 可運作的規則型範例 bot。
 
+本機開發時，把 bot 資料夾放到 `mjai_bot/<name>/`，在 **Bots** 頁籤該 bot
+列上點擊 **安裝環境** 即可建立其 venv —— 不必每次改動都重新打包安裝。環境
+就緒前啟用開關會保持停用。
+
 ### AGPL 邊界
 
 Bot 以 Akagi 啟動的 **獨立 OS 子行程** 執行。通訊嚴格透
@@ -410,6 +414,10 @@ session；點選列可看到原始結構化欄位與來源位置。
   會慢 — 在 Diagnostic 頁籤觀察 `bot=<name>` 的訊息。
   若一直未完成，刪除
   `mjai_bot/<name>/.akagi/synced.stamp` 後重試。
+- **啟用開關變灰 / 手動放入的 bot 無法啟用。** 它的 Python 環境還沒建立。
+  在 **Bots** 頁籤該 bot 列上點擊 **安裝環境** 按鈕（環境未就緒時會出現）
+  以執行 `uv sync`；完成後開關即可啟用。修改該 bot 的 `pyproject.toml` 會
+  使環境失效，按鈕會再次出現。
 - **Bot 對局途中崩潰。** Inspector 頁籤可顯示 bot 死前
   看到的最後一個訊框；附在 bug 報告裡。
 - **三麻挑了錯的 bot。** 檢查設定 → Bot 中的

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -451,7 +451,11 @@
     "drawer_reinstall": "Reinstall environment",
     "drawer_reinstall_tooltip": "Wipe and recreate the Python virtualenv for this bot",
     "drawer_reinstalling": "Reinstalling…",
-    "env_not_ready_tooltip": "Environment not installed yet — install or sync it before activating."
+    "env_not_ready_tooltip": "Environment not installed yet — install or sync it before activating.",
+    "install_env": "Install environment",
+    "install_env_tooltip": "Build the Python environment (uv sync) so this bot can be activated",
+    "installing_env": "Installing…",
+    "activate_failed": "Couldn't change active bot"
   },
   "overview": {
     "title": "Overview",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -451,7 +451,11 @@
     "drawer_reinstall": "環境を再構築",
     "drawer_reinstall_tooltip": "この Bot の Python virtualenv を消去して再構築",
     "drawer_reinstalling": "再構築中…",
-    "env_not_ready_tooltip": "環境がまだインストールされていません。有効化する前にインストール／同期してください。"
+    "env_not_ready_tooltip": "環境がまだインストールされていません。有効化する前にインストール／同期してください。",
+    "install_env": "環境をインストール",
+    "install_env_tooltip": "このボットを有効化できるよう Python 環境を構築します（uv sync）",
+    "installing_env": "インストール中…",
+    "activate_failed": "有効なボットを切り替えられませんでした"
   },
   "overview": {
     "title": "概要",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -451,7 +451,11 @@
     "drawer_reinstall": "重建环境",
     "drawer_reinstall_tooltip": "清除并重建这个 Bot 的 Python 虚拟环境",
     "drawer_reinstalling": "重建中…",
-    "env_not_ready_tooltip": "环境尚未安装完成——启用前请先安装或同步环境。"
+    "env_not_ready_tooltip": "环境尚未安装完成——启用前请先安装或同步环境。",
+    "install_env": "安装环境",
+    "install_env_tooltip": "构建此 Bot 的 Python 环境（uv sync），之后才能启用",
+    "installing_env": "安装中…",
+    "activate_failed": "无法切换启用中的 Bot"
   },
   "overview": {
     "title": "总览",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -451,7 +451,11 @@
     "drawer_reinstall": "重建環境",
     "drawer_reinstall_tooltip": "清除並重建這個 Bot 的 Python 虛擬環境",
     "drawer_reinstalling": "重建中…",
-    "env_not_ready_tooltip": "環境尚未安裝完成——啟用前請先安裝或同步環境。"
+    "env_not_ready_tooltip": "環境尚未安裝完成——啟用前請先安裝或同步環境。",
+    "install_env": "安裝環境",
+    "install_env_tooltip": "建立此 Bot 的 Python 環境（uv sync），之後才能啟用",
+    "installing_env": "安裝中…",
+    "activate_failed": "無法切換啟用中的 Bot"
   },
   "overview": {
     "title": "總覽",

--- a/frontend/src/routes/Bots.tsx
+++ b/frontend/src/routes/Bots.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plus, Settings as SettingsIcon, RefreshCw, CheckCircle2, Trash2, FileArchive } from 'lucide-react'
+import { Plus, Settings as SettingsIcon, RefreshCw, CheckCircle2, Trash2, FileArchive, Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -31,6 +31,7 @@ import {
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
 import { invoke } from '@/lib/tauri'
 import { withInstallBlock } from '@/lib/install'
+import { toast } from '@/components/ui/sonner'
 import { useBotStore } from '@/stores/botStore'
 import { useConfigStore } from '@/stores/configStore'
 import type { AppConfig, BotInfo, BotSettings } from '@/types'
@@ -45,6 +46,7 @@ export function Bots() {
   const [loading, setLoading] = useState(false)
   const [editing, setEditing] = useState<string | null>(null)
   const [deleting, setDeleting] = useState<string | null>(null)
+  const [installingEnv, setInstallingEnv] = useState<string | null>(null)
 
   const refresh = async () => {
     setLoading(true)
@@ -80,10 +82,32 @@ export function Bots() {
     }
     try {
       await invoke('set_active_bot', { mode, name })
-    } catch {
-      /* noop */
+    } catch (e) {
+      // set_active_bot rejects (e.g. env not installed) without emitting a
+      // notify toast, so surface it here — otherwise the optimistic flip just
+      // reverts on refresh with no explanation.
+      toast.error(t('bots.activate_failed'), { description: String(e) })
     } finally {
       void refresh()
+    }
+  }
+
+  // Build a bot's Python environment (uv sync) on demand. This is the only
+  // path that works for a bot dropped straight into the bots directory with a
+  // pyproject.toml but no manifest.toml: activation is gated on env readiness,
+  // game-start sync needs activation first, and the drawer's "Reinstall
+  // environment" button is reachable only via Configure (manifest-gated).
+  // sync_bot_deps emits its own success/failure notify toasts, so we don't
+  // double-report here.
+  const installEnv = async (name: string) => {
+    setInstallingEnv(name)
+    try {
+      await withInstallBlock(() => invoke('sync_bot_deps', { name, force: false }))
+      await refresh()
+    } catch {
+      /* backend emits a `bot-sync-<name>` error toast */
+    } finally {
+      setInstallingEnv(null)
     }
   }
 
@@ -161,6 +185,19 @@ export function Bots() {
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-1">
+                    {bot.has_pyproject && !bot.env_ready && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void installEnv(bot.name)}
+                        disabled={installingEnv !== null}
+                        title={t('bots.install_env_tooltip')}
+                        className="gap-1.5"
+                      >
+                        <Download className={`h-4 w-4 ${installingEnv === bot.name ? 'animate-pulse' : ''}`} />
+                        {installingEnv === bot.name ? t('bots.installing_env') : t('bots.install_env')}
+                      </Button>
+                    )}
                     <Button
                       size="sm"
                       variant="ghost"

--- a/mjai_bot/README.md
+++ b/mjai_bot/README.md
@@ -40,10 +40,25 @@ mjai_bot/<name>/
 └── README.md         # bot-specific notes (model files, license, …)
 ```
 
-`pyproject.toml` declares the bot's Python dependencies. On the first launch
-Akagi runs `uv sync` into a per-bot virtual environment, so a bot can pull in
-whatever packages it needs without touching the rest of the system. (Akagi
-ships its own Python + `uv`, so bots run even with no system Python installed.)
+`pyproject.toml` declares the bot's Python dependencies. The first time the
+environment is built, Akagi runs `uv sync` into a per-bot virtual environment,
+so a bot can pull in whatever packages it needs without touching the rest of
+the system. (Akagi ships its own Python + `uv`, so bots run even with no system
+Python installed.) Two things it must contain:
+
+```toml
+[project]
+requires-python = ">=3.12"   # Akagi bundles Python 3.12
+
+[tool.uv]
+package = false              # the bot is a script, not an installable library
+```
+
+Without `[tool.uv] package = false`, `uv sync` tries to **build** your bot as a
+package and fails — set it on every bot. See
+[`example/pyproject.toml`](example/pyproject.toml) for a complete, known-good
+file. A bot with no `pyproject.toml` at all is treated as dependency-free and
+is activatable immediately (it must then rely only on the stdlib).
 
 ## The I/O protocol
 
@@ -328,16 +343,25 @@ panel — perfectly fine for a no-knobs bot.
 
 ## Registering the bot
 
-1. Drop the folder under `mjai_bot/<name>/`. Akagi rescans on each game start,
-   so a freshly added bot is picked up without a restart.
-2. In Akagi's settings, set it as the active bot for 4-player and/or 3-player
-   games (`bot.active_4p` / `bot.active_3p` — the two slots are independent;
-   leave one empty to run that mode analysis-only).
-3. On first launch Akagi runs `uv sync` for the bot (a one-time, possibly slow
-   step shown as a "Preparing bot" toast); later launches are instant.
+1. Drop the folder under `mjai_bot/<name>/`. Akagi rescans on each game start
+   and whenever you open or **Refresh** the Bots tab, so a freshly added bot is
+   picked up without a restart.
+2. **Build its Python environment.** If the bot has a `pyproject.toml`, its row
+   shows an **Install environment** button until the env is built — click it to
+   run `uv sync` once (a possibly slow, one-time step). The activation toggle
+   stays disabled until the environment is ready, so a game never picks a bot
+   that would need a slow `uv sync` mid-match. Editing `pyproject.toml` later
+   marks the env stale and the button returns — click it again to rebuild.
+   (A bot with no `pyproject.toml` skips this step entirely.)
+3. **Activate it.** Toggle the bot on for 4-player and/or 3-player games
+   (`bot.active_4p` / `bot.active_3p` — the two slots are independent; leave one
+   empty to run that mode analysis-only). You can rebuild the env any time later
+   via **Configure → Reinstall environment**.
 
-Bots can also be installed straight from a GitHub release via the **Bots** tab
-— see [`../src/bot/README.md`](../src/bot/README.md) for that flow.
+This local-folder flow is the fastest way to iterate while developing. Bots can
+also be installed straight from a GitHub release or a local `.zip` via the
+**Bots** tab — those paths build the environment automatically as part of the
+install. See [`../src/bot/README.md`](../src/bot/README.md) for that flow.
 
 ## AGPL boundary
 

--- a/mjai_bot/example/pyproject.toml
+++ b/mjai_bot/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "akagi-example-bot"
 version = "0.1.0"
 description = "Shanten-evaluating example bot for Akagi v3 (adapted from mjai.app evalbot)."
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }
 
 # `mahjong` is a pure-Python shanten / hand-value calculator (MIT).

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -667,4 +667,43 @@ mod tests {
         // No `.akagi/` dir at all — must not panic.
         reset_sync_state(tmp.path()).await;
     }
+
+    /// Regression (issue #143): a bot dropped straight into the bots dir with a
+    /// `pyproject.toml` but **no** `manifest.toml` must still go through the
+    /// normal env-readiness transition — readiness/sync never depends on a
+    /// manifest. This is the invariant the Bots-tab "Install environment"
+    /// button relies on: it runs the same sync path for manifest-less bots,
+    /// breaking the chicken-and-egg where activation needs a ready env but the
+    /// only manual sync trigger (the drawer's "Reinstall environment" button)
+    /// was reachable only via the manifest-gated Configure button.
+    #[test]
+    fn is_synced_is_manifest_independent() {
+        let tmp = TempDir::new().unwrap();
+        // A minimal locally-developed bot: entry point + deps, no manifest.
+        write(&tmp.path().join("bot.py"), "print()\n");
+        let py = tmp.path().join("pyproject.toml");
+        write(&py, "[project]\nname='a'\n\n[tool.uv]\npackage = false\n");
+        assert!(
+            !tmp.path().join("manifest.toml").exists(),
+            "this fixture deliberately has no manifest"
+        );
+
+        // Before sync: deps declared but no venv/stamp → not ready (toggle
+        // blocked, install button shown).
+        assert!(
+            !is_synced(tmp.path()),
+            "fresh dropped-in bot must read as not ready"
+        );
+
+        // After a sync seeds the venv + matching stamp → ready, with no
+        // manifest anywhere in the picture.
+        let sig = current_signature(&py, &tmp.path().join("uv.lock")).unwrap();
+        let akagi = tmp.path().join(AKAGI_DIR);
+        std::fs::create_dir_all(akagi.join(VENV_DIR)).unwrap();
+        std::fs::write(akagi.join(STAMP_FILE), &sig).unwrap();
+        assert!(
+            is_synced(tmp.path()),
+            "manifest-less bot must become ready after sync"
+        );
+    }
 }

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -159,7 +159,16 @@ impl PythonRuntime {
             bail!("uv sync failed in {} ({status})", bot_dir.display());
         }
 
-        write_stamp(&stamp_path, &current).await?;
+        // `uv sync` creates (or refreshes) `uv.lock`, so the `current`
+        // signature captured before the sync is stale the moment the bot
+        // shipped no lockfile — the common case for a hand-written bot. Writing
+        // that stale signature would make the very next `is_synced` check fail
+        // (it re-stats the now-present `uv.lock` and sees a mismatch), leaving a
+        // freshly-synced bot reading as not-ready and its activation toggle
+        // disabled. Re-snapshot the on-disk pyproject + lock so the stamp
+        // matches what `is_synced` computes next.
+        let synced = current_signature(&pyproject, &lock)?;
+        write_stamp(&stamp_path, &synced).await?;
         Ok(())
     }
 
@@ -704,6 +713,51 @@ mod tests {
         assert!(
             is_synced(tmp.path()),
             "manifest-less bot must become ready after sync"
+        );
+    }
+
+    /// Regression (issue #143): `uv sync` creates/refreshes `uv.lock`, so the
+    /// stamp must be written from the POST-sync on-disk signature, not the
+    /// pre-sync one. A bot that ships no lockfile (the common hand-written
+    /// case) otherwise reads as not-ready immediately after a successful sync —
+    /// its activation toggle stays disabled until a second sync. Uses a fake
+    /// `uv` that reproduces the real side effects: it seeds the venv and writes
+    /// a `uv.lock` into the project dir.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ensure_synced_marks_ready_when_uv_creates_lockfile() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let bot = tmp.path();
+        write(&bot.join("pyproject.toml"), "[project]\nname='a'\n");
+        // No uv.lock shipped — the (fake) uv will create it during sync.
+        assert!(!bot.join("uv.lock").exists());
+
+        let fake_uv = tmp.path().join("uv");
+        std::fs::write(
+            &fake_uv,
+            "#!/bin/sh\n\
+             mkdir -p \"$UV_PROJECT_ENVIRONMENT/bin\"\n\
+             : > \"$UV_PROJECT_ENVIRONMENT/bin/python\"\n\
+             proj=\"$(dirname \"$(dirname \"$UV_PROJECT_ENVIRONMENT\")\")\"\n\
+             printf 'version = 1\\n' > \"$proj/uv.lock\"\n\
+             exit 0\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_uv, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let fake_python = tmp.path().join("python");
+        std::fs::write(&fake_python, "").unwrap();
+
+        let rt = PythonRuntime::from_paths(fake_python, fake_uv, RuntimeMode::System);
+        rt.ensure_synced(bot).await.unwrap();
+
+        assert!(
+            bot.join("uv.lock").exists(),
+            "fake uv should have created the lockfile"
+        );
+        assert!(
+            is_synced(bot),
+            "a freshly-synced bot must read as ready even when uv created the lockfile"
         );
     }
 }


### PR DESCRIPTION
Fixes #143.

## Problem

Building an mjai_bot by dropping its folder straight into `mjai_bot/<name>/` and iterating in place — the most natural development workflow — hit a dead end. Such a bot is discovered (it has `bot.py`) but its Python environment is never built, so its activation toggle is disabled. The only UI paths that build the env (`uv sync`) are install-via-ZIP/GitHub, game start (which requires the bot to already be active), and the **Reinstall environment** button — which lives in the settings drawer, reachable only through **Configure**, which is disabled when the bot has no `manifest.toml`. Since `manifest.toml` is optional, a bot with a `pyproject.toml` but no manifest had **no UI path at all** to build its environment.

This produced the three reported symptoms:

1. **The env build can't be triggered.**
2. **A finished bot can't be enabled — the toggle is greyed out.**
3. **Once the toggle is turned off, it can never be turned back on** (editing `pyproject.toml` flips an active bot to not-ready; turning it off then leaves it permanently disabled).

Activation errors were also swallowed on the frontend, so the toggle silently reverted with no explanation.

## Fix

- **Per-row "Install environment" button** on the Bots tab, shown when a bot has a `pyproject.toml` but its env isn't ready. It calls the existing `sync_bot_deps` command (which does **not** require a manifest) through the install-blocking overlay, then refreshes — breaking the chicken-and-egg, and acting as the escape hatch for symptom #3.
- **Surface activation errors** instead of swallowing them (`set_active_bot` rejects without emitting a notify toast).
- **Docs**: document the required `[tool.uv] package = false` (otherwise `uv sync` tries to build the bot as a package and fails); rewrite "Registering the bot" to include building the env; bump the example bot's `requires-python` to `>=3.12` to match the bundled runtime; add a troubleshooting entry for the greyed-out toggle (English + both Chinese READMEs).
- **i18n**: new keys in all four locales.
- **Regression test**: `is_synced_is_manifest_independent` asserts env readiness/sync never depends on `manifest.toml`.

No backend behavior change — `sync_bot_deps` and `is_synced` were already manifest-agnostic; the entire bug surface was frontend gating.

## Verification

- `cargo test --lib bot::runtime` — 16 passed (incl. the new test).
- `tsc -b` and `eslint src/routes/Bots.tsx` — clean.
- Manual: drop a bot with `pyproject.toml` and no `manifest.toml` → **Install environment** appears → click → toggle enables. Editing `pyproject.toml` then toggling off brings the button back so it can be re-enabled.