### PR TITLE
fix(capture): relaunch a still-running Chromium instead of duplicating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,14 @@ Useful when debugging a bot or a bridge issue.
   `config.toml`. If the launched browser starts but no frames flow,
   check that `--remote-debugging-port` was not blocked by another
   extension.
+- **Reopening Akagi with the Chromium window still open.** Akagi closes
+  the still-running browser and relaunches a single fresh window (it
+  cannot attach a second instance to the same profile). Login is
+  preserved, so Mahjong Soul reconnects to an in-progress match on
+  reload. If a leftover browser refuses to close — capture stops with
+  "couldn't terminate the browser already using profile …" — close it
+  manually and click Restart. Running two Akagi instances against the
+  same profile is unsupported.
 - **Bot stuck in `Loading{SyncingDeps}`.** First-run `uv sync` is
   slow — watch the Diagnostic tab for `bot=<name>` lines. If it never
   finishes, delete `mjai_bot/<name>/.akagi/synced.stamp` and retry.

--- a/src/capture/chromium/mod.rs
+++ b/src/capture/chromium/mod.rs
@@ -80,11 +80,22 @@ impl CaptureBackend for ChromiumBackend {
         let profile_dir = profile::resolve_profile_dir(&self.cfg.user_data_dir)?;
         std::fs::create_dir_all(&profile_dir)
             .with_context(|| format!("creating chromium profile dir {}", profile_dir.display()))?;
-        if let Err(e) = profile::clear_stale_singleton(&profile_dir) {
-            warn!(
-                "singleton-lock cleanup at {} failed: {e:#}",
-                profile_dir.display()
-            );
+        // If a browser we previously launched is still running with this
+        // profile (e.g. the user closed Akagi but left Chrome open), terminate
+        // it before relaunching. Spawning a second `--user-data-dir` instance
+        // while the first is alive only opens a duplicate tab in it and then
+        // exits, leaving capture with no DevTools endpoint. (Two Akagi
+        // instances against one profile is unsupported.) `reclaim_singleton`
+        // blocks while waiting for the owner to exit, so run it off the async
+        // runtime.
+        {
+            let pd = profile_dir.clone();
+            tokio::task::spawn_blocking(move || profile::reclaim_singleton(&pd))
+                .await
+                .context("reclaim-singleton task panicked")?
+                .with_context(|| {
+                    format!("reclaiming chromium profile {}", profile_dir.display())
+                })?;
         }
 
         info!(

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -1,20 +1,36 @@
-//! Profile directory resolution and stale-singleton-lock recovery.
+//! Profile directory resolution and singleton-lock reclamation.
 //!
-//! Chromium refuses to launch if `<user-data-dir>/SingletonLock` (Unix
-//! symlink) or `SingletonLock` (Windows file) points at a live PID. If
-//! the previous Akagi run was force-killed (SIGKILL, OOM, power loss),
-//! the lock survives and we'd be unable to launch a fresh browser.
+//! Chromium refuses to start a second instance against a `--user-data-dir`
+//! whose `SingletonLock` (Unix symlink) / `SingletonLock` (Windows file)
+//! points at a live PID. Instead of launching, the second process hands its
+//! start URL to the running browser (a duplicate tab) and exits — leaving our
+//! capture with no DevTools endpoint. So before we spawn, we must guarantee
+//! the profile is free.
 //!
-//! `clear_stale_singleton` reads the lock, identifies the prior PID,
-//! checks whether that process still exists, and unlinks the lock if
-//! and only if it doesn't. This NEVER kills a live process — if a real
-//! user-controlled Chrome happens to be running with our profile (rare
-//! but possible if the user fiddled with `--user-data-dir` manually),
-//! the function returns an error and the supervisor surfaces it.
+//! `reclaim_singleton` reads the lock and identifies the prior PID:
+//! - dead PID (a previous run was SIGKILLed / OOMed / lost power) → remove the
+//!   stale lock files and launch fresh.
+//! - live PID (the user closed Akagi but left the controlled browser open) →
+//!   terminate that browser (staged SIGTERM → SIGKILL), wait for it to exit,
+//!   then remove the lock. We own this profile, so reclaiming it is safe; the
+//!   relaunch reuses the same profile dir, so login/cookies are preserved and
+//!   Mahjong Soul reconnects to an in-progress match on reload.
+//!
+//! Running two Akagi instances against the same profile is unsupported — they
+//! would fight over the lock.
 
 use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
+
+/// How long to wait for a polite SIGTERM/`taskkill` to take effect before
+/// escalating to SIGKILL/`taskkill /F`.
+const TERM_GRACE: Duration = Duration::from_secs(5);
+/// How long to wait for the forced kill to take effect.
+const KILL_GRACE: Duration = Duration::from_secs(2);
+/// Poll cadence while waiting for the owner process to disappear.
+const KILL_POLL: Duration = Duration::from_millis(100);
 
 /// Resolve the user-data-dir path for the controlled Chromium instance.
 /// `configured` empty → exe-adjacent `chrome-profile/` via
@@ -35,20 +51,35 @@ pub fn resolve_profile_dir(configured: &str) -> Result<PathBuf> {
     Ok(crate::util::resolve_dir(Path::new("./chrome-profile")))
 }
 
-/// Detect and clear `SingletonLock` / `SingletonSocket` / `SingletonCookie`
-/// when they reference a process that no longer exists. Returns `Ok` if
-/// the dir is in a launchable state afterwards (no lock, or lock cleared).
-/// Returns `Err` if a live PID owns the lock — caller surfaces that to
-/// the user; we MUST NOT auto-kill.
-pub fn clear_stale_singleton(profile: &Path) -> Result<()> {
+/// Make the profile dir launchable by clearing any `SingletonLock` /
+/// `SingletonSocket` / `SingletonCookie` — terminating the owning browser
+/// first if it is still alive (see module docs). Returns `Err` only when a
+/// live owner could not be terminated; the caller surfaces that to the user.
+///
+/// Blocking (it may sleep while waiting for the owner to exit); call it off
+/// the async runtime via `spawn_blocking`.
+pub fn reclaim_singleton(profile: &Path) -> Result<()> {
     if !profile.exists() {
         return Ok(()); // fresh dir, nothing to clean
     }
-    clear_stale_singleton_inner(profile)
+    reclaim_singleton_inner(profile)
+}
+
+/// Best-effort removal of the three singleton marker files. A clean browser
+/// shutdown removes its own lock, so a `NotFound` here is expected and benign.
+fn remove_singleton_files(profile: &Path) {
+    for name in ["SingletonLock", "SingletonSocket", "SingletonCookie"] {
+        let p = profile.join(name);
+        match std::fs::remove_file(&p) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!("failed to remove {}: {e}", p.display()),
+        }
+    }
 }
 
 #[cfg(unix)]
-fn clear_stale_singleton_inner(profile: &Path) -> Result<()> {
+fn reclaim_singleton_inner(profile: &Path) -> Result<()> {
     let lock = profile.join("SingletonLock");
     let metadata = match std::fs::symlink_metadata(&lock) {
         Ok(m) => m,
@@ -83,29 +114,27 @@ fn clear_stale_singleton_inner(profile: &Path) -> Result<()> {
         return Ok(());
     };
     if process_alive_unix(pid) {
-        return Err(anyhow!(
-            "chromium profile {} is locked by live PID {} — close that browser before retrying \
-             (target={})",
-            profile.display(),
-            pid,
-            target_str
-        ));
-    }
-    info!(
-        "removing stale chromium singleton lock {} → {} (pid {pid} gone)",
-        lock.display(),
-        target_str
-    );
-    if let Err(e) = std::fs::remove_file(&lock) {
-        warn!("failed to remove {}: {e}", lock.display());
-    }
-    // Also remove sibling Singleton{Socket,Cookie} which may be orphaned.
-    for name in ["SingletonSocket", "SingletonCookie"] {
-        let p = profile.join(name);
-        if p.exists() {
-            let _ = std::fs::remove_file(&p);
+        // A browser we previously launched is still running with our profile
+        // (the user closed Akagi but left Chrome open). Terminate it so we can
+        // relaunch a single fresh instance — a second `--user-data-dir` launch
+        // would only hand its start URL to the live browser (a duplicate tab)
+        // and then exit, leaving capture with no DevTools endpoint.
+        info!("terminating existing chromium pid {pid} to relaunch (target={target_str})");
+        if !terminate_pid_unix(pid) {
+            return Err(anyhow!(
+                "couldn't terminate the browser already using profile {} (pid {pid}) — \
+                 close it manually and click Restart",
+                profile.display()
+            ));
         }
+    } else {
+        info!(
+            "removing stale chromium singleton lock {} → {} (pid {pid} gone)",
+            lock.display(),
+            target_str
+        );
     }
+    remove_singleton_files(profile);
     Ok(())
 }
 
@@ -126,8 +155,43 @@ fn process_alive_unix(pid: i32) -> bool {
     }
 }
 
+/// Staged terminate of an arbitrary PID: polite SIGTERM (so Chrome can clean
+/// up its own lock files), wait, then SIGKILL. Returns `true` once the process
+/// is confirmed gone. Mirrors [`super::launch::terminate`] but for a raw PID,
+/// since the owner is not a `Child` of this process.
+#[cfg(unix)]
+fn terminate_pid_unix(pid: i32) -> bool {
+    let _ = std::process::Command::new("/bin/kill")
+        .args(["-TERM", &pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .status();
+    if wait_until_dead_unix(pid, TERM_GRACE) {
+        return true;
+    }
+    warn!("chromium pid {pid} did not exit after SIGTERM, sending SIGKILL");
+    let _ = std::process::Command::new("/bin/kill")
+        .args(["-KILL", &pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .status();
+    wait_until_dead_unix(pid, KILL_GRACE)
+}
+
+#[cfg(unix)]
+fn wait_until_dead_unix(pid: i32, grace: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < grace {
+        if !process_alive_unix(pid) {
+            return true;
+        }
+        std::thread::sleep(KILL_POLL);
+    }
+    !process_alive_unix(pid)
+}
+
 #[cfg(windows)]
-fn clear_stale_singleton_inner(profile: &Path) -> Result<()> {
+fn reclaim_singleton_inner(profile: &Path) -> Result<()> {
     let lock = profile.join("SingletonLock");
     let pid = match std::fs::read_to_string(&lock) {
         Ok(s) => s.trim().parse::<u32>().ok(),
@@ -139,22 +203,24 @@ fn clear_stale_singleton_inner(profile: &Path) -> Result<()> {
             ));
         }
     };
-    let alive = pid.map(process_alive_windows).unwrap_or(false);
-    if alive {
-        return Err(anyhow!(
-            "chromium profile {} is locked by live PID {:?}",
-            profile.display(),
-            pid
-        ));
+    if let Some(pid) = pid {
+        if process_alive_windows(pid) {
+            info!("terminating existing chromium pid {pid} to relaunch");
+            if !terminate_pid_windows(pid) {
+                return Err(anyhow!(
+                    "couldn't terminate the browser already using profile {} (pid {pid}) — \
+                     close it manually and click Restart",
+                    profile.display()
+                ));
+            }
+        } else {
+            info!(
+                "removing stale chromium singleton lock {} (pid {pid} gone)",
+                lock.display()
+            );
+        }
     }
-    info!(
-        "removing stale chromium singleton lock {} (pid {:?} gone)",
-        lock.display(),
-        pid
-    );
-    if let Err(e) = std::fs::remove_file(&lock) {
-        warn!("failed to remove {}: {e}", lock.display());
-    }
+    remove_singleton_files(profile);
     Ok(())
 }
 
@@ -171,6 +237,39 @@ fn process_alive_windows(pid: u32) -> bool {
     };
     let s = String::from_utf8_lossy(&out.stdout);
     s.trim().lines().any(|line| line.contains(&pid.to_string()))
+}
+
+/// Staged terminate of an arbitrary PID on Windows: polite `taskkill`, wait,
+/// then `taskkill /F`. Returns `true` once the process is confirmed gone.
+#[cfg(windows)]
+fn terminate_pid_windows(pid: u32) -> bool {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .status();
+    if wait_until_dead_windows(pid, TERM_GRACE) {
+        return true;
+    }
+    warn!("chromium pid {pid} did not exit after taskkill, forcing /F");
+    let _ = std::process::Command::new("taskkill")
+        .args(["/F", "/PID", &pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .status();
+    wait_until_dead_windows(pid, KILL_GRACE)
+}
+
+#[cfg(windows)]
+fn wait_until_dead_windows(pid: u32, grace: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < grace {
+        if !process_alive_windows(pid) {
+            return true;
+        }
+        std::thread::sleep(KILL_POLL);
+    }
+    !process_alive_windows(pid)
 }
 
 #[cfg(test)]
@@ -207,37 +306,74 @@ mod tests {
     }
 
     #[test]
-    fn clear_singleton_no_lock_is_ok() {
+    fn reclaim_no_lock_is_ok() {
         let dir = tempfile::tempdir().unwrap();
-        clear_stale_singleton(dir.path()).unwrap();
+        reclaim_singleton(dir.path()).unwrap();
     }
 
     #[cfg(unix)]
     #[test]
-    fn clear_singleton_unlinks_dead_pid() {
+    fn reclaim_unlinks_dead_pid() {
         use std::os::unix::fs::symlink;
         let dir = tempfile::tempdir().unwrap();
         let lock = dir.path().join("SingletonLock");
-        // Use PID 0xFFFFFFFE — far past any realistic max_pid; certainly dead.
-        symlink("akagi-test-host-4294967294", &lock).unwrap();
-        clear_stale_singleton(dir.path()).unwrap();
-        assert!(!lock.exists(), "stale lock should have been unlinked");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn clear_singleton_refuses_live_pid() {
-        use std::os::unix::fs::symlink;
-        let dir = tempfile::tempdir().unwrap();
-        let lock = dir.path().join("SingletonLock");
-        let our_pid = std::process::id();
-        symlink(format!("akagi-test-host-{our_pid}"), &lock).unwrap();
-        let r = clear_stale_singleton(dir.path());
-        assert!(r.is_err(), "should refuse to unlink lock owned by live pid");
-        // `exists()` follows symlinks; we want to check the symlink itself.
+        // i32::MAX — a valid (parseable) PID far past any realistic
+        // pid_max, so it is certainly dead.
+        symlink("akagi-test-host-2147483647", &lock).unwrap();
+        reclaim_singleton(dir.path()).unwrap();
         assert!(
-            std::fs::symlink_metadata(&lock).is_ok(),
-            "live-pid lock symlink must be left alone"
+            std::fs::symlink_metadata(&lock).is_err(),
+            "stale lock should have been unlinked"
+        );
+    }
+
+    /// Regression for the duplicate-tab / DevToolsActivePort-timeout bug:
+    /// reopening Akagi while a controlled browser is still running must
+    /// terminate that browser and clear the lock so a fresh instance can
+    /// launch (rather than handing a duplicate tab to the live browser).
+    #[cfg(unix)]
+    #[test]
+    fn reclaim_kills_live_owner_and_clears_lock() {
+        use std::io::Read;
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("SingletonLock");
+
+        // Spawn `sleep` detached so it is reparented to init and reaped
+        // there when killed — mirrors a real browser that outlived the Akagi
+        // process that launched it (avoids leaving a zombie we'd own, which
+        // `kill -0` would still report as alive). Redirect the child's
+        // stdout/stderr to /dev/null so it doesn't inherit (and hold open)
+        // the pipe we read `$!` from — otherwise `read_to_string` blocks
+        // until `sleep` itself exits.
+        let mut launcher = std::process::Command::new("sh")
+            .args(["-c", "sleep 60 >/dev/null 2>&1 & echo $!"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn launcher");
+        let mut out = String::new();
+        launcher
+            .stdout
+            .take()
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        let _ = launcher.wait(); // reap the short-lived shell
+        let pid: i32 = out.trim().parse().expect("background sleep pid");
+
+        assert!(process_alive_unix(pid), "detached sleep should be alive");
+        symlink(format!("akagi-test-host-{pid}"), &lock).unwrap();
+
+        reclaim_singleton(dir.path()).unwrap();
+
+        assert!(
+            !process_alive_unix(pid),
+            "live owner process should have been terminated"
+        );
+        assert!(
+            std::fs::symlink_metadata(&lock).is_err(),
+            "singleton lock should be removed after reclaim"
         );
     }
 }


### PR DESCRIPTION
Fixes #145.

## Problem

In Chromium capture mode, closing Akagi leaves the controlled browser open (intended). But **reopening Akagi** opened a **duplicate tab** in that browser and then capture stopped with a 15s timeout:

> reading chromium CDP endpoint (chromium failed to start?): timed out after 15s waiting for `<config_root>/chrome-profile/DevToolsActivePort`

`ChromiumBackend::run()` always spawned a fresh Chrome with the same `--user-data-dir`. When a previously launched browser was still alive: the live-PID singleton lock was only logged as a warning; `spawn()` deleted the still-valid `DevToolsActivePort`; the new process handed its start URL off to the live browser (the duplicate tab) and exited; nothing rewrote `DevToolsActivePort`, so the endpoint poll timed out.

## Fix

Reclaim the profile **before** launching. If a browser we previously launched still holds the lock, terminate it (staged SIGTERM/`taskkill` → wait → SIGKILL/`taskkill /F`), wait for it to exit, then relaunch a single fresh instance through the normal path. The profile is reused, so login is preserved and Mahjong Soul reconnects to an in-progress match on reload.

### Changes
- **`src/capture/chromium/profile.rs`** — `clear_stale_singleton` → `reclaim_singleton`. The live-PID branch now staged-kills the owner (`terminate_pid_unix` / `terminate_pid_windows`) and clears the lock instead of returning an error. Shared `remove_singleton_files`; rewritten module doc.
- **`src/capture/chromium/mod.rs`** — call `reclaim_singleton` via `spawn_blocking` and propagate its error, so a failed reclaim surfaces a clear message instead of the 15s timeout.
- **`README.md`** — troubleshooting note on the reopen → relaunch behavior.

## Tests
- New regression `reclaim_kills_live_owner_and_clears_lock`: a detached `sleep` (reparented to init) stands in for the running browser; asserts it is terminated and the lock removed.
- Updated dead-PID / no-lock tests; dropped the obsolete `refuses_live_pid` test.
- `cargo test --lib capture::chromium` green (37 passed); `cargo clippy --lib` clean.

## Notes / limitations
- The reopened browser is closed and relaunched (a visible restart), not seamlessly attached.
- Running two Akagi instances against the same profile remains unsupported.