### PR TITLE
feat(bridge): recover in-progress Majsoul hand on reconnect via GameRestore

### DIFF
--- a/src/bridge/majsoul/README.md
+++ b/src/bridge/majsoul/README.md
@@ -258,6 +258,40 @@ Sanma has no chi. `build_chi_peng_gang` drops `ActionChiPengGang(chi)`
 with a warn log when `num_players == 3` (defense in depth — Majsoul
 shouldn't send it for sanma tables). Pon / kan stay enabled.
 
+## Mid-game reconnect — syncGame / enterGame (GameRestore)
+
+When a client reconnects to an in-progress match (page reload, or the
+controlled-Chromium relaunch Akagi does on restart), Majsoul re-runs
+`authGame` and then sends a `.lq.FastTest.syncGame` (or `.lq.FastTest.enterGame`)
+**response** whose `game_restore.actions[]` replays every action of the current
+kyoku, from `ActionNewRound` up to the present. Without this, a restarted Akagi
+would have no hand until the next kyoku.
+
+`handle_game_restore` reconstructs the in-progress hand by replaying that log:
+
+- It reads `game_restore.actions[]` (each entry an
+  `ActionPrototype { name, data, step }`). An absent/empty list — e.g. a
+  first-entry `enterGame` or a finished game — is a no-op.
+- Each action is decoded and re-wrapped into the same `{name, data}` shape a
+  live `ActionPrototype` carries, then fed through `handle_action_prototype`, so
+  **every `build_*` conversion and the `pending_reach_accepted` bookkeeping is
+  reused verbatim**. A riichi left pending at the end of the replay drains onto
+  the first subsequent live action, exactly as in live play.
+- **No `start_game` is emitted** — the preceding `authGame` already did that
+  (the single reset point for the downstream tracker / bot / autoplay). The
+  leading `ActionMJStart` has no handler and is a no-op, as is any other
+  unrecognised action. The `GameRestore.snapshot` field is ignored; replaying
+  the actions reconstructs the full state.
+
+> **No XOR on restore actions.** Unlike live `.lq.ActionPrototype.data` (which is
+> XOR-obfuscated, see *Action XOR* below), the `data` of actions embedded in a
+> `GameRestore` is plain base64 protobuf. `parser::decode_restore_action`
+> base64-decodes and protobuf-decodes directly, skipping `wtf_decode` — running
+> the XOR on them would corrupt the bytes.
+
+The whole kyoku is emitted as one event burst; see `event_bus::DEFAULT_CAPACITY`
+for why the mjai bus buffer must comfortably exceed a full kyoku's event count.
+
 ## mjai event log
 
 When constructed with an `Arc<Session>`, the bridge rotates a fresh

--- a/src/bridge/majsoul/mod.rs
+++ b/src/bridge/majsoul/mod.rs
@@ -203,9 +203,7 @@ impl MajsoulBridge {
             }
             (MessageType::Notify, METHOD_ACTION_PROTOTYPE) => self.handle_action_prototype(msg),
             (MessageType::Response, METHOD_SYNC_GAME)
-            | (MessageType::Response, METHOD_ENTER_GAME) => {
-                self.handle_game_restore(&msg.payload)
-            }
+            | (MessageType::Response, METHOD_ENTER_GAME) => self.handle_game_restore(&msg.payload),
             (MessageType::Notify, METHOD_NOTIFY_GAME_END_RESULT) => {
                 // `result.players[]` carries final standings. Mjai
                 // `end_game` has no payload — the standings live in the
@@ -1380,9 +1378,7 @@ mod tests {
         );
         let events = bridge.dispatch(&restore);
         assert!(matches!(&events[0], MjaiEvent::Reach { actor: 1, pai } if pai.is_none()));
-        assert!(
-            matches!(&events[1], MjaiEvent::Dahai { actor: 1, pai, .. } if pai == "5p")
-        );
+        assert!(matches!(&events[1], MjaiEvent::Dahai { actor: 1, pai, .. } if pai == "5p"));
         assert_eq!(bridge.pending_reach_accepted, Some(1));
 
         // First live action after the replay drains the queued reach_accepted.

--- a/src/bridge/majsoul/mod.rs
+++ b/src/bridge/majsoul/mod.rs
@@ -29,6 +29,10 @@ use tracing::{info, warn};
 const METHOD_AUTH_GAME: &str = ".lq.FastTest.authGame";
 const METHOD_ACTION_PROTOTYPE: &str = ".lq.ActionPrototype";
 const METHOD_NOTIFY_GAME_END_RESULT: &str = ".lq.NotifyGameEndResult";
+/// Reconnect replay: both responses carry a `GameRestore { actions[] }` of the
+/// current kyoku. See `handle_game_restore`.
+const METHOD_SYNC_GAME: &str = ".lq.FastTest.syncGame";
+const METHOD_ENTER_GAME: &str = ".lq.FastTest.enterGame";
 const ACTION_NEW_ROUND: &str = "ActionNewRound";
 const ACTION_DEAL_TILE: &str = "ActionDealTile";
 const ACTION_DISCARD_TILE: &str = "ActionDiscardTile";
@@ -198,6 +202,10 @@ impl MajsoulBridge {
                 self.handle_auth_game_response(&msg.payload)
             }
             (MessageType::Notify, METHOD_ACTION_PROTOTYPE) => self.handle_action_prototype(msg),
+            (MessageType::Response, METHOD_SYNC_GAME)
+            | (MessageType::Response, METHOD_ENTER_GAME) => {
+                self.handle_game_restore(&msg.payload)
+            }
             (MessageType::Notify, METHOD_NOTIFY_GAME_END_RESULT) => {
                 // `result.players[]` carries final standings. Mjai
                 // `end_game` has no payload — the standings live in the
@@ -211,6 +219,91 @@ impl MajsoulBridge {
             }
             _ => Vec::new(),
         }
+    }
+
+    /// Replay a `GameRestore` carried by a `.lq.FastTest.syncGame` /
+    /// `.lq.FastTest.enterGame` response. Majsoul sends this right after
+    /// `authGame` when a client reconnects to an in-progress match;
+    /// `game_restore.actions[]` is the full action log of the current kyoku
+    /// (from `ActionNewRound` up to the present moment). Replaying each action
+    /// through the normal per-action path rebuilds the mjai stream so the
+    /// engine / bot / UI recover the in-progress hand.
+    ///
+    /// Each entry is an `ActionPrototype { name, data, step }`. Unlike the live
+    /// `.lq.ActionPrototype` notify, the embedded `data` is plain base64
+    /// protobuf with no XOR — see [`parser::decode_restore_action`]. We re-wrap
+    /// each decoded action into the same `{name, data}` shape
+    /// `handle_action_prototype` expects and feed it through, so every `build_*`
+    /// conversion and the `pending_reach_accepted` bookkeeping is reused
+    /// verbatim (a reach left pending at the end of the replay is drained by the
+    /// first subsequent live action, exactly as in live play).
+    ///
+    /// No `start_game` is emitted — the preceding `authGame` already did that
+    /// (the single reset point for the downstream tracker / bot / autoplay). The
+    /// leading `ActionMJStart` has no handler and is a no-op, as is any other
+    /// unrecognised action. The `snapshot` field is intentionally ignored;
+    /// replaying the actions reconstructs the full state.
+    fn handle_game_restore(&mut self, payload: &JsonValue) -> Vec<MjaiEvent> {
+        let is_end = payload
+            .get("is_end")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        let step = payload.get("step").and_then(JsonValue::as_u64);
+        let actions = payload
+            .pointer("/game_restore/actions")
+            .and_then(JsonValue::as_array);
+        let Some(actions) = actions.filter(|a| !a.is_empty()) else {
+            // First-entry `enterGame` (or a finished game) carries no replay
+            // actions — nothing to reconstruct.
+            info!(
+                target: "akagi::bridge::majsoul",
+                "GameRestore with no actions to replay (step={step:?} is_end={is_end})"
+            );
+            return Vec::new();
+        };
+        info!(
+            target: "akagi::bridge::majsoul",
+            "replaying {} GameRestore actions (step={step:?} is_end={is_end})",
+            actions.len()
+        );
+
+        let mut events = Vec::new();
+        for action in actions {
+            let Some(name) = action.get("name").and_then(JsonValue::as_str) else {
+                warn!(
+                    target: "akagi::bridge::majsoul",
+                    "GameRestore action missing name: {action}"
+                );
+                continue;
+            };
+            let Some(b64) = action.get("data").and_then(JsonValue::as_str) else {
+                warn!(
+                    target: "akagi::bridge::majsoul",
+                    "GameRestore action {name} missing data string"
+                );
+                continue;
+            };
+            let decoded = match parser::decode_restore_action(name, b64) {
+                Ok(decoded) => decoded,
+                Err(e) => {
+                    warn!(
+                        target: "akagi::bridge::majsoul",
+                        "failed to decode GameRestore action {name}: {e:#}"
+                    );
+                    continue;
+                }
+            };
+            // Re-wrap as the same `{name, data}` shape a live ActionPrototype
+            // carries, then run it through the shared conversion path.
+            let synthetic = ParsedMessage {
+                msg_type: MessageType::Notify,
+                msg_id: None,
+                method_name: Arc::from(METHOD_ACTION_PROTOTYPE),
+                payload: json!({ "name": name, "data": decoded }),
+            };
+            events.extend(self.handle_action_prototype(&synthetic));
+        }
+        events
     }
 
     fn handle_action_prototype(&mut self, msg: &ParsedMessage) -> Vec<MjaiEvent> {
@@ -1156,6 +1249,173 @@ mod tests {
             method_name: Arc::from(method),
             payload,
         }
+    }
+
+    /// Full `.lq.FastTest.syncGame` response captured from a real mid-game
+    /// reconnect (4p; our account at seat 3; 32 replay actions; East-1, no
+    /// melds/riichi/kan). This is exactly the JSON the parser produces for the
+    /// response — each action `data` is still base64 (decoded during replay).
+    const SYNC_GAME_SAMPLE: &str = r#"{"game_restore":{"actions":[{"data":"","name":"ActionMJStart","step":0},{"data":"CAAQABgAIgI0cCICMW0iAjNwIgI0eiICN3oiAjZ6IgIwcCICM3MiAjBtIgI0cyICMXMiAjlzIgIyejIMqMMBqMMBqMMBqMMBQABYAGhFcgIxenoCCAB6AggBegIIAnoCCAOaAUA1NWQ2NzQ3MTRjNjAzODFhNGJjOTJmYzBmOWIwNWVjNDU4OWZlMzI0NTQ4OWVmOGY3NTc5NTVmMzIzZWIzZTE1qgFAYzFmNmY1YTQwOGFjMzgyZGEyZGE1MTA3OTUzYmUzYTg1N2M5OTdmNGNkMjg2M2JlZjczY2M3ZjE3MDllMDA4Mw==","name":"ActionNewRound","step":1},{"data":"CAASAjR6GAAoADAASAA=","name":"ActionDiscardTile","step":2},{"data":"CAEYRDgA","name":"ActionDealTile","step":3},{"data":"CAESAjJwGAAoATAASAA=","name":"ActionDiscardTile","step":4},{"data":"CAIYQzgA","name":"ActionDealTile","step":5},{"data":"CAISAjlwGAAoADAASAA=","name":"ActionDiscardTile","step":6},{"data":"CAMSAjdwGEIiDAgDEgIIASAAKOCnEjgA","name":"ActionDealTile","step":7},{"data":"CAMSAjd6GAAoADAASAA=","name":"ActionDiscardTile","step":8},{"data":"CAAYQTgA","name":"ActionDealTile","step":9},{"data":"CAASAjN6GAAoATAASAA=","name":"ActionDiscardTile","step":10},{"data":"CAEYQDgA","name":"ActionDealTile","step":11},{"data":"CAESAjR6GAAoADAASAA=","name":"ActionDiscardTile","step":12},{"data":"CAIYPzgA","name":"ActionDealTile","step":13},{"data":"CAISAjRwGAAiEwgDEgkIAhIFM3B8MHAgACjgpxIoATAASAA=","name":"ActionDiscardTile","step":14},{"data":"CAMSAjZ6GD4iDAgDEgIIASAAKOCnEjgA","name":"ActionDealTile","step":15},{"data":"CAMSAjR6GAAoADAASAA=","name":"ActionDiscardTile","step":16},{"data":"CAAYPTgA","name":"ActionDealTile","step":17},{"data":"CAASAjV6GAAoADAASAA=","name":"ActionDiscardTile","step":18},{"data":"CAEYPDgA","name":"ActionDealTile","step":19},{"data":"CAESAjNzGAAoATAASAA=","name":"ActionDiscardTile","step":20},{"data":"CAIYOzgA","name":"ActionDealTile","step":21},{"data":"CAISAjlzGAAoADAASAA=","name":"ActionDiscardTile","step":22},{"data":"CAMSAjRtGDoiDAgDEgIIASAAKOCnEjgA","name":"ActionDealTile","step":23},{"data":"CAMSAjFtGAAoADAASAA=","name":"ActionDiscardTile","step":24},{"data":"CAAYOTgA","name":"ActionDealTile","step":25},{"data":"CAASAjd6GAAoADAASAA=","name":"ActionDiscardTile","step":26},{"data":"CAEYODgA","name":"ActionDealTile","step":27},{"data":"CAESAjZ6GAAiEwgDEgkIAxIFNnp8NnogACjgpxIoADAASAA=","name":"ActionDiscardTile","step":28},{"data":"CAIYNzgA","name":"ActionDealTile","step":29},{"data":"CAISAjF6GAAoADAASAA=","name":"ActionDiscardTile","step":30},{"data":"CAMSAjdzGDYiDAgDEgIIASAAKOCnEjgA","name":"ActionDealTile","step":31}],"game_state":1,"last_pause_time_ms":0,"passed_waiting_time":16,"start_time":0},"is_end":false,"step":32}"#;
+
+    /// Resolve the bridge to seat 3 / 4 players via a real authGame exchange,
+    /// matching `SYNC_GAME_SAMPLE` (our account_id 12345 sits at `seat_list[3]`).
+    fn seated_for_sample() -> MajsoulBridge {
+        let mut bridge = MajsoulBridge::new(None, None);
+        bridge.dispatch(&req(METHOD_AUTH_GAME, json!({ "account_id": 12345 })));
+        bridge.dispatch(&resp(
+            METHOD_AUTH_GAME,
+            json!({
+                "players": [{ "account_id": 12345, "nickname": "player_a" }],
+                "seat_list": [10u64, 20, 30, 12345u64],
+            }),
+        ));
+        assert_eq!(bridge.seat, Some(3));
+        assert_eq!(bridge.num_players, 4);
+        bridge
+    }
+
+    /// A `.lq.FastTest.syncGame` response replays the whole in-progress kyoku
+    /// through the normal conversion path, rebuilding the mjai stream. Regression
+    /// for mid-game reconnect recovery (issue #147).
+    #[test]
+    fn sync_game_replays_in_progress_kyoku() {
+        let mut bridge = seated_for_sample();
+        let payload: JsonValue = serde_json::from_str(SYNC_GAME_SAMPLE).unwrap();
+        let events = bridge.dispatch(&resp(METHOD_SYNC_GAME, payload));
+
+        // 1 start_kyoku + 16 tsumo (dealer's opening draw + 15 draws) + 15 dahai.
+        assert_eq!(events.len(), 32, "unexpected replay event count");
+
+        // The replay must NOT emit start_game — that belongs to the preceding
+        // authGame (the single downstream reset point).
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MjaiEvent::StartGame { .. })),
+            "replay must not emit start_game"
+        );
+        // Exactly one start_kyoku, and it is the very first event.
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, MjaiEvent::StartKyoku { .. }))
+                .count(),
+            1
+        );
+        match &events[0] {
+            MjaiEvent::StartKyoku {
+                bakaze,
+                kyoku,
+                oya,
+                honba,
+                kyotaku,
+                num_players,
+                tehais,
+                ..
+            } => {
+                assert_eq!(bakaze.as_str(), "E");
+                assert_eq!(*kyoku, 1);
+                assert_eq!(*oya, 0);
+                assert_eq!(*honba, 0);
+                assert_eq!(*kyotaku, 0);
+                assert_eq!(*num_players, 4);
+                // Our seat-3 tehai is fully known (13 real tiles, no "?"); the
+                // restore actions decoded WITHOUT the XOR step.
+                assert_eq!(tehais[3].len(), TEHAI_SIZE);
+                assert!(tehais[3].iter().all(|t| t != UNKNOWN_TILE));
+                // Opponents' hands stay hidden.
+                assert!(tehais[0].iter().all(|t| t == UNKNOWN_TILE));
+            }
+            other => panic!("expected StartKyoku first, got {other:?}"),
+        }
+        // Dealer's opening draw is unknown to us.
+        assert!(matches!(&events[1], MjaiEvent::Tsumo { actor: 0, pai } if pai == "?"));
+        // First discard: seat 0 cuts 4z (= mjai "N"), tedashi.
+        assert!(
+            matches!(&events[2], MjaiEvent::Dahai { actor: 0, pai, tsumogiri: false } if pai == "N")
+        );
+        // Our own draw (step 7) carries the real tile 7p.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, MjaiEvent::Tsumo { actor: 3, pai } if pai == "7p")));
+        // Replay ends on our latest draw (step 31): 7s, known.
+        assert!(
+            matches!(events.last().unwrap(), MjaiEvent::Tsumo { actor: 3, pai } if pai == "7s")
+        );
+
+        let dahai = events
+            .iter()
+            .filter(|e| matches!(e, MjaiEvent::Dahai { .. }))
+            .count();
+        let tsumo = events
+            .iter()
+            .filter(|e| matches!(e, MjaiEvent::Tsumo { .. }))
+            .count();
+        assert_eq!(dahai, 15);
+        assert_eq!(tsumo, 16);
+    }
+
+    /// A riichi declared on the LAST replayed action leaves `reach_accepted`
+    /// pending; it must be drained (prepended) onto the first subsequent *live*
+    /// action — identical to live semantics, proving the replay loop carries
+    /// `pending_reach_accepted` across the replay→live boundary.
+    #[test]
+    fn game_restore_riichi_drains_on_next_live_action() {
+        let mut bridge = MajsoulBridge::new(None, None);
+        bridge.seat = Some(0);
+
+        // GameRestore whose only action is a riichi discard by seat 1
+        // (ActionDiscardTile{seat:1, tile:"5p", is_liqi:true}, plain base64).
+        let restore = resp(
+            METHOD_SYNC_GAME,
+            json!({
+                "game_restore": {
+                    "actions": [
+                        { "name": "ActionDiscardTile", "data": "CAESAjVwGAE=", "step": 1 }
+                    ]
+                },
+                "is_end": false,
+                "step": 2
+            }),
+        );
+        let events = bridge.dispatch(&restore);
+        assert!(matches!(&events[0], MjaiEvent::Reach { actor: 1, pai } if pai.is_none()));
+        assert!(
+            matches!(&events[1], MjaiEvent::Dahai { actor: 1, pai, .. } if pai == "5p")
+        );
+        assert_eq!(bridge.pending_reach_accepted, Some(1));
+
+        // First live action after the replay drains the queued reach_accepted.
+        let live = bridge.dispatch(&action_msg("ActionDealTile", json!({ "seat": 2 })));
+        assert!(matches!(&live[0], MjaiEvent::ReachAccepted { actor: 1 }));
+        assert!(matches!(&live[1], MjaiEvent::Tsumo { actor: 2, pai } if pai == "?"));
+        assert_eq!(bridge.pending_reach_accepted, None);
+    }
+
+    /// A first-entry `.lq.FastTest.enterGame` (or any response) with no replay
+    /// actions is a no-op — no events, no panic.
+    #[test]
+    fn enter_game_empty_restore_is_noop() {
+        let mut bridge = seated_for_sample();
+        // Empty actions array.
+        let empty = bridge.dispatch(&resp(
+            METHOD_ENTER_GAME,
+            json!({ "game_restore": { "actions": [] }, "is_end": false, "step": 0 }),
+        ));
+        assert!(empty.is_empty());
+        // Only the leading ActionMJStart (no handler) → still nothing.
+        let mj_start_only = bridge.dispatch(&resp(
+            METHOD_ENTER_GAME,
+            json!({
+                "game_restore": {
+                    "actions": [{ "name": "ActionMJStart", "data": "", "step": 0 }]
+                }
+            }),
+        ));
+        assert!(mj_start_only.is_empty());
+        // Missing game_restore entirely.
+        let missing = bridge.dispatch(&resp(METHOD_ENTER_GAME, json!({ "is_end": false })));
+        assert!(missing.is_empty());
     }
 
     #[test]

--- a/src/bridge/majsoul/parser.rs
+++ b/src/bridge/majsoul/parser.rs
@@ -245,11 +245,11 @@ fn maybe_decode_action(mut payload: JsonValue) -> Result<JsonValue> {
     Ok(payload)
 }
 
-pub fn decode_action(name: &str, b64: &str) -> Result<JsonValue> {
-    let mut bytes = BASE64
-        .decode(b64)
-        .with_context(|| format!("base64 decode failed for action {name}"))?;
-    wtf_decode(&mut bytes);
+/// Resolve an action `name` (`.lq.ActionFoo`, or a bare `ActionFoo`) to its
+/// liqi message descriptor and decode `bytes` as that message into JSON.
+/// Shared by the live-action path (post-XOR) and the GameRestore path
+/// (no XOR).
+fn decode_named_action(name: &str, bytes: &[u8]) -> Result<JsonValue> {
     let parts: Vec<&str> = name.split('.').filter(|s| !s.is_empty()).collect();
     ensure!(!parts.is_empty(), "empty action name");
     // Action names are typically `.lq.ActionFoo`; fall back to last segment.
@@ -261,7 +261,32 @@ pub fn decode_action(name: &str, b64: &str) -> Result<JsonValue> {
     let desc = POOL
         .get_message_by_name(&fqn)
         .with_context(|| format!("unknown action type: {fqn}"))?;
-    decode_to_json(&desc, &bytes)
+    decode_to_json(&desc, bytes)
+}
+
+/// Decode a live `.lq.ActionPrototype.data` payload: base64 → XOR-decrypt →
+/// protobuf. The live notify obfuscates the action bytes (see [`wtf_decode`]).
+pub fn decode_action(name: &str, b64: &str) -> Result<JsonValue> {
+    let mut bytes = BASE64
+        .decode(b64)
+        .with_context(|| format!("base64 decode failed for action {name}"))?;
+    wtf_decode(&mut bytes);
+    decode_named_action(name, &bytes)
+}
+
+/// Decode an action embedded in a `GameRestore` replay (the `game_restore`
+/// field of a `.lq.FastTest.syncGame` / `.lq.FastTest.enterGame` response).
+///
+/// Unlike the live `.lq.ActionPrototype.data` notify, actions stored inside a
+/// `GameRestore` are **plain base64 protobuf** — the server does not apply the
+/// position-dependent XOR ([`wtf_decode`]) to them. Running the XOR here would
+/// corrupt the bytes, so this path base64-decodes and protobuf-decodes
+/// directly, with no XOR step.
+pub fn decode_restore_action(name: &str, b64: &str) -> Result<JsonValue> {
+    let bytes = BASE64
+        .decode(b64)
+        .with_context(|| format!("base64 decode failed for restore action {name}"))?;
+    decode_named_action(name, &bytes)
 }
 
 /// Position-dependent XOR scheme used by Majsoul for action payloads.
@@ -298,5 +323,41 @@ mod tests {
         wtf_decode(&mut buf);
         wtf_decode(&mut buf);
         assert_eq!(buf, original);
+    }
+
+    /// Real captured `ActionNewRound` from a GameRestore replay. The action
+    /// `data` is plain base64 protobuf (NOT XOR-obfuscated), so the no-XOR
+    /// `decode_restore_action` path must recover the readable tehai, while the
+    /// XOR-applying `decode_action` path must NOT (it sees corrupted bytes).
+    /// This locks in the "restore actions skip the XOR" decision.
+    const RESTORE_NEW_ROUND_B64: &str = "CAAQABgAIgI0cCICMW0iAjNwIgI0eiICN3oiAjZ6IgIwcCICM3MiAjBtIgI0cyICMXMiAjlzIgIyejIMqMMBqMMBqMMBqMMBQABYAGhFcgIxenoCCAB6AggBegIIAnoCCAOaAUA1NWQ2NzQ3MTRjNjAzODFhNGJjOTJmYzBmOWIwNWVjNDU4OWZlMzI0NTQ4OWVmOGY3NTc5NTVmMzIzZWIzZTE1qgFAYzFmNmY1YTQwOGFjMzgyZGEyZGE1MTA3OTUzYmUzYTg1N2M5OTdmNGNkMjg2M2JlZjczY2M3ZjE3MDllMDA4Mw==";
+
+    #[test]
+    fn decode_restore_action_skips_xor() {
+        let expected = vec![
+            "4p", "1m", "3p", "4z", "7z", "6z", "0p", "3s", "0m", "4s", "1s", "9s", "2z",
+        ];
+
+        let json = decode_restore_action("ActionNewRound", RESTORE_NEW_ROUND_B64)
+            .expect("restore action should decode without XOR");
+        let tiles: Vec<&str> = json["tiles"]
+            .as_array()
+            .expect("tiles array")
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(tiles, expected);
+
+        // Same bytes through the live (XOR) path must not yield the same tehai:
+        // it either fails to decode or produces garbage.
+        let via_xor = decode_action("ActionNewRound", RESTORE_NEW_ROUND_B64);
+        let same = via_xor.ok().and_then(|j| {
+            j["tiles"].as_array().map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            })
+        }) == Some(expected.iter().map(|s| s.to_string()).collect());
+        assert!(!same, "XOR path unexpectedly produced the plain tehai");
     }
 }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -59,9 +59,15 @@ pub type PostTrackerBus = broadcast::Sender<MjaiEvent>;
 /// frontend.
 pub type HistoryBus = broadcast::Sender<HistoryEvent>;
 
-/// Default capacity. ~1 second of mjai events at peak game pace
-/// (start_kyoku + 13 tehai + many tsumo/dahai pairs) is well under 256.
-pub const DEFAULT_CAPACITY: usize = 256;
+/// Default capacity. Live pacing produces ~1 second of mjai events at a time
+/// (start_kyoku + 13 tehai + a few tsumo/dahai pairs), which is tiny. The
+/// sizing constraint is the **one-shot GameRestore replay**: on reconnect the
+/// bridge emits an entire kyoku's events in a single synchronous burst (the
+/// CDP send loop does not yield between `send`s), and consumers treat overflow
+/// as `Lagged → skip`. A skipped mid-hand `dahai`/`pon` would silently corrupt
+/// the game-state tracker with no self-heal until the next kyoku, so the buffer
+/// must comfortably exceed a worst-case full-kyoku event count (~a few hundred).
+pub const DEFAULT_CAPACITY: usize = 1024;
 
 /// Smaller buffer for status / notification streams — these are bursty
 /// but low-rate; 64 is plenty.


### PR DESCRIPTION
## Summary

Adds Majsoul mid-game reconnect recovery. On a reconnect (page reload, or the
controlled-Chromium relaunch Akagi does on restart), Majsoul re-runs `authGame`
and then sends a `.lq.FastTest.syncGame` / `.lq.FastTest.enterGame` **response**
whose `game_restore.actions[]` replays the whole current kyoku. The bridge
previously dropped both methods, so a restarted Akagi had no hand and gave no
recommendations until the next kyoku. This PR replays that action log to rebuild
the in-progress hand.

Closes #147.

## Changes

- **`parser.rs`** — `decode_restore_action(name, b64)`: base64 + protobuf, **no
  XOR**. Actions embedded in a `GameRestore` are plain protobuf, unlike the
  XOR-obfuscated live `.lq.ActionPrototype.data` (verified by decoding a real
  capture — the no-XOR path yields readable tiles, the XOR path yields garbage).
  Shared name→descriptor lookup refactored into `decode_named_action`.
- **`mod.rs`** — `handle_game_restore` replays each action through the existing
  `handle_action_prototype` path, reusing every `build_*` conversion and the
  `pending_reach_accepted` bookkeeping. Emits **no** `start_game` (the preceding
  `authGame` already did, which is the single downstream reset point); ignores
  the `GameRestore.snapshot` field; an empty/absent action list is a no-op.
  Wired for both `syncGame` and `enterGame` responses.
- **`event_bus.rs`** — `DEFAULT_CAPACITY` 256 → 1024. The replay emits a whole
  kyoku in one synchronous burst; the old 256 buffer could overflow on a long
  hand and make the game-state tracker `Lagged`-skip a mid-hand event (silent
  corruption with no self-heal until the next kyoku).
- **`README.md`** — documents the replay path and the no-XOR distinction.

## Scope / limitations

- Passive handling only: GameRestore is consumed when Majsoul sends it on a
  reconnect; no forced page reload.
- If Akagi restarts but the browser WebSocket never reconnects (no fresh
  `authGame`), no `syncGame` fires and the current kyoku still waits for the
  next `ActionNewRound`.

## Tests

- `sync_game_replays_in_progress_kyoku` — a real captured 32-action `syncGame`
  sample (4p, our seat 3) replays to 32 mjai events: `start_kyoku` + 16 `tsumo`
  + 15 `dahai`, our tehai rebuilt from known tiles, the first discard mapped
  correctly (`4z`→`N`), no `start_game`.
- `game_restore_riichi_drains_on_next_live_action` — a riichi on the last
  replayed action drains as `reach_accepted` onto the first subsequent live
  action.
- `enter_game_empty_restore_is_noop` — empty / `ActionMJStart`-only / missing
  `game_restore` produce no events.
- `decode_restore_action_skips_xor` — the no-XOR path recovers the tehai; the
  XOR path does not.

`cargo test --lib` 487 passed; `cargo clippy --lib --all-targets` clean.
