### PR TITLE
fix(board): correct opponent hand count + scale opponent melds

### DIFF
--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -92,7 +92,9 @@
   position: absolute;
   bottom: 1.5%;
   right: 0.5%;
-  max-width: 46%;
+  /* definite width (fraction of the square board) so mahgen's container-width
+     sizing scales the melds with the board, like the hand and river. */
+  width: 44%;
   display: flex;
   flex-wrap: wrap;
   gap: 3px;

--- a/src/game_state/mahgen_view.rs
+++ b/src/game_state/mahgen_view.rs
@@ -19,7 +19,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::snapshot::{DiscardEntry, GameStateSnapshot, MeldKind, MeldSnapshot, PlayerSnapshot};
+use super::snapshot::{
+    DiscardEntry, GameStateSnapshot, MeldKind, MeldSnapshot, Phase, PlayerSnapshot,
+};
 
 /// One player's view in the mahgen DSL.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,11 +58,16 @@ impl MahgenView {
         let players: Vec<PlayerMahgenView> = snap
             .players
             .iter()
-            .map(|p| PlayerMahgenView {
-                seat: p.seat,
-                hand: encode_hand(p, snap.our_seat),
-                melds: p.melds.iter().map(|m| encode_meld(m, p.seat, np)).collect(),
-                river: encode_river(&p.river),
+            .map(|p| {
+                // A seat is "drawing" (holds a freshly drawn tile / must
+                // discard) when it's the current actor awaiting an action.
+                let drawing = snap.current_player == p.seat && snap.phase == Phase::WaitAct;
+                PlayerMahgenView {
+                    seat: p.seat,
+                    hand: encode_hand(p, snap.our_seat, drawing),
+                    melds: p.melds.iter().map(|m| encode_meld(m, p.seat, np)).collect(),
+                    river: encode_river(&p.river),
+                }
             })
             .collect();
         Self {
@@ -152,21 +159,31 @@ fn encode_concat(tiles: &[String]) -> String {
 }
 
 /// Encode the closed hand for one player. The observer seat sees real
-/// tiles; other seats see `"0z" × hand_size` (back tiles).
-fn encode_hand(p: &PlayerSnapshot, our_seat: Option<u8>) -> String {
-    let hand_size = p.tehai.len();
-    if hand_size == 0 {
+/// tiles; other seats see `"0z" × n` (tile backs).
+///
+/// For non-observer seats the back count is derived from the melds, NOT from
+/// `tehai.len()`. For an *observed* opponent the engine's hand accumulates
+/// unknown draws — each `tsumo` adds an unknown tile, but the following
+/// `dahai` carries a *known* discard that can't be matched against the unknown
+/// tile, so it's never removed and the count grows by one per turn. The true
+/// concealed size is `13 - 3 * melds` (each called set consumes three of the
+/// thirteen tiles), plus one while that seat is holding a freshly drawn tile.
+fn encode_hand(p: &PlayerSnapshot, our_seat: Option<u8>, drawing: bool) -> String {
+    if our_seat == Some(p.seat) {
+        if p.tehai.is_empty() {
+            return String::new();
+        }
+        return encode_concat(&p.tehai);
+    }
+    let n = (13 - 3 * p.melds.len() as i32 + drawing as i32).max(0) as usize;
+    if n == 0 {
         return String::new();
     }
-    if our_seat == Some(p.seat) {
-        encode_concat(&p.tehai)
-    } else {
-        // n × `0z` — but mahgen wants `nz` form: `0` repeated, suffix `z`.
-        // i.e. 13 backs = "0000000000000z". Each `0` is one tile back.
-        let mut s = "0".repeat(hand_size);
-        s.push('z');
-        s
-    }
+    // n × `0z` in mahgen's `nz` form: `0` repeated, suffix `z`.
+    // i.e. 13 backs = "0000000000000z". Each `0` is one tile back.
+    let mut s = "0".repeat(n);
+    s.push('z');
+    s
 }
 
 /// Encode one meld in mahgen DSL.
@@ -495,7 +512,7 @@ mod tests {
     #[test]
     fn opponent_hand_renders_as_backs() {
         let p = pl(1, vec!["?"; 13], vec![], vec![]);
-        assert_eq!(encode_hand(&p, Some(0)), "0000000000000z");
+        assert_eq!(encode_hand(&p, Some(0), false), "0000000000000z");
     }
 
     #[test]
@@ -504,7 +521,22 @@ mod tests {
             "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "1s",
         ];
         let p = pl(0, tiles, vec![], vec![]);
-        assert_eq!(encode_hand(&p, Some(0)), "123456789m123p1s");
+        assert_eq!(encode_hand(&p, Some(0), false), "123456789m123p1s");
+    }
+
+    #[test]
+    fn opponent_back_count_derived_from_melds_not_tehai() {
+        // An observed opponent's `tehai` is unreliable (unknown draws pile up),
+        // so the back count comes from melds: 13 - 3 * melds (+1 while drawing).
+        let one_meld = vec![chi_meld("3m", &["1m", "2m"], 3)];
+        let p = pl(1, vec!["?"; 99], one_meld.clone(), vec![]);
+        // One called set, not drawing → 13 - 3 = 10 backs (tehai length ignored).
+        assert_eq!(encode_hand(&p, Some(0), false), "0000000000z");
+        // While that seat is drawing (holds a fresh tile) → one more: 11.
+        assert_eq!(encode_hand(&p, Some(0), true), "00000000000z");
+        // No melds, not drawing → the full 13 backs.
+        let p0 = pl(2, vec![], vec![], vec![]);
+        assert_eq!(encode_hand(&p0, Some(0), false), "0000000000000z");
     }
 
     fn chi_meld(called: &str, hand: &[&str], from_who: i8) -> MeldSnapshot {

--- a/src/game_state/mahgen_view.rs
+++ b/src/game_state/mahgen_view.rs
@@ -19,9 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::snapshot::{
-    DiscardEntry, GameStateSnapshot, MeldKind, MeldSnapshot, Phase, PlayerSnapshot,
-};
+use super::snapshot::{DiscardEntry, GameStateSnapshot, MeldKind, MeldSnapshot, PlayerSnapshot};
 
 /// One player's view in the mahgen DSL.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -58,16 +56,11 @@ impl MahgenView {
         let players: Vec<PlayerMahgenView> = snap
             .players
             .iter()
-            .map(|p| {
-                // A seat is "drawing" (holds a freshly drawn tile / must
-                // discard) when it's the current actor awaiting an action.
-                let drawing = snap.current_player == p.seat && snap.phase == Phase::WaitAct;
-                PlayerMahgenView {
-                    seat: p.seat,
-                    hand: encode_hand(p, snap.our_seat, drawing),
-                    melds: p.melds.iter().map(|m| encode_meld(m, p.seat, np)).collect(),
-                    river: encode_river(&p.river),
-                }
+            .map(|p| PlayerMahgenView {
+                seat: p.seat,
+                hand: encode_hand(p, snap.our_seat),
+                melds: p.melds.iter().map(|m| encode_meld(m, p.seat, np)).collect(),
+                river: encode_river(&p.river),
             })
             .collect();
         Self {
@@ -159,31 +152,21 @@ fn encode_concat(tiles: &[String]) -> String {
 }
 
 /// Encode the closed hand for one player. The observer seat sees real
-/// tiles; other seats see `"0z" × n` (tile backs).
-///
-/// For non-observer seats the back count is derived from the melds, NOT from
-/// `tehai.len()`. For an *observed* opponent the engine's hand accumulates
-/// unknown draws — each `tsumo` adds an unknown tile, but the following
-/// `dahai` carries a *known* discard that can't be matched against the unknown
-/// tile, so it's never removed and the count grows by one per turn. The true
-/// concealed size is `13 - 3 * melds` (each called set consumes three of the
-/// thirteen tiles), plus one while that seat is holding a freshly drawn tile.
-fn encode_hand(p: &PlayerSnapshot, our_seat: Option<u8>, drawing: bool) -> String {
-    if our_seat == Some(p.seat) {
-        if p.tehai.is_empty() {
-            return String::new();
-        }
-        return encode_concat(&p.tehai);
-    }
-    let n = (13 - 3 * p.melds.len() as i32 + drawing as i32).max(0) as usize;
-    if n == 0 {
+/// tiles; other seats see `"0z" × hand_size` (back tiles).
+fn encode_hand(p: &PlayerSnapshot, our_seat: Option<u8>) -> String {
+    let hand_size = p.tehai.len();
+    if hand_size == 0 {
         return String::new();
     }
-    // n × `0z` in mahgen's `nz` form: `0` repeated, suffix `z`.
-    // i.e. 13 backs = "0000000000000z". Each `0` is one tile back.
-    let mut s = "0".repeat(n);
-    s.push('z');
-    s
+    if our_seat == Some(p.seat) {
+        encode_concat(&p.tehai)
+    } else {
+        // n × `0z` — but mahgen wants `nz` form: `0` repeated, suffix `z`.
+        // i.e. 13 backs = "0000000000000z". Each `0` is one tile back.
+        let mut s = "0".repeat(hand_size);
+        s.push('z');
+        s
+    }
 }
 
 /// Encode one meld in mahgen DSL.
@@ -512,7 +495,7 @@ mod tests {
     #[test]
     fn opponent_hand_renders_as_backs() {
         let p = pl(1, vec!["?"; 13], vec![], vec![]);
-        assert_eq!(encode_hand(&p, Some(0), false), "0000000000000z");
+        assert_eq!(encode_hand(&p, Some(0)), "0000000000000z");
     }
 
     #[test]
@@ -521,22 +504,7 @@ mod tests {
             "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "1s",
         ];
         let p = pl(0, tiles, vec![], vec![]);
-        assert_eq!(encode_hand(&p, Some(0), false), "123456789m123p1s");
-    }
-
-    #[test]
-    fn opponent_back_count_derived_from_melds_not_tehai() {
-        // An observed opponent's `tehai` is unreliable (unknown draws pile up),
-        // so the back count comes from melds: 13 - 3 * melds (+1 while drawing).
-        let one_meld = vec![chi_meld("3m", &["1m", "2m"], 3)];
-        let p = pl(1, vec!["?"; 99], one_meld.clone(), vec![]);
-        // One called set, not drawing → 13 - 3 = 10 backs (tehai length ignored).
-        assert_eq!(encode_hand(&p, Some(0), false), "0000000000z");
-        // While that seat is drawing (holds a fresh tile) → one more: 11.
-        assert_eq!(encode_hand(&p, Some(0), true), "00000000000z");
-        // No melds, not drawing → the full 13 backs.
-        let p0 = pl(2, vec![], vec![], vec![]);
-        assert_eq!(encode_hand(&p0, Some(0), false), "0000000000000z");
+        assert_eq!(encode_hand(&p, Some(0)), "123456789m123p1s");
     }
 
     fn chi_meld(called: &str, hand: &[&str], from_who: i8) -> MeldSnapshot {

--- a/src/game_state/snapshot.rs
+++ b/src/game_state/snapshot.rs
@@ -153,6 +153,7 @@ impl GameStateSnapshot {
     /// Build a snapshot from a 4-player engine state. `our_seat` is threaded
     /// in by the tracker — see [`crate::game_state::tracker`].
     pub fn from_state(s: &GameState, our_seat: Option<u8>) -> Self {
+        let in_wait_act = matches!(s.phase, riichienv_core::action::Phase::WaitAct);
         let players: Vec<PlayerSnapshot> = (0..s.players.len())
             .map(|i| {
                 let p = &s.players[i];
@@ -166,10 +167,12 @@ impl GameStateSnapshot {
                         is_riichi: p.discard_is_riichi.get(idx).copied().unwrap_or(false),
                     })
                     .collect();
+                let melds: Vec<MeldSnapshot> = p.melds.iter().map(MeldSnapshot::from).collect();
+                let drawing = i as u8 == s.current_player && in_wait_act;
                 PlayerSnapshot {
                     seat: i as u8,
-                    tehai: p.hand.iter().copied().map(tid_to_mjai).collect(),
-                    melds: p.melds.iter().map(MeldSnapshot::from).collect(),
+                    tehai: seat_tehai(&p.hand, melds.len(), our_seat == Some(i as u8), drawing),
+                    melds,
                     river,
                     score: p.score,
                     riichi_declared: p.riichi_declared,
@@ -216,6 +219,7 @@ impl GameStateSnapshot {
     /// `from_state` but populates `PlayerSnapshot.kita_tiles` from the 3p
     /// engine's per-player kita pool.
     pub fn from_state_3p(s: &GameState3P, our_seat: Option<u8>) -> Self {
+        let in_wait_act = matches!(s.phase, riichienv_core::action::Phase::WaitAct);
         let players: Vec<PlayerSnapshot> = (0..s.players.len())
             .map(|i| {
                 let p = &s.players[i];
@@ -229,10 +233,12 @@ impl GameStateSnapshot {
                         is_riichi: p.discard_is_riichi.get(idx).copied().unwrap_or(false),
                     })
                     .collect();
+                let melds: Vec<MeldSnapshot> = p.melds.iter().map(MeldSnapshot::from).collect();
+                let drawing = i as u8 == s.current_player && in_wait_act;
                 PlayerSnapshot {
                     seat: i as u8,
-                    tehai: p.hand.iter().copied().map(tid_to_mjai).collect(),
-                    melds: p.melds.iter().map(MeldSnapshot::from).collect(),
+                    tehai: seat_tehai(&p.hand, melds.len(), our_seat == Some(i as u8), drawing),
+                    melds,
                     river,
                     score: p.score,
                     riichi_declared: p.riichi_declared,
@@ -271,6 +277,24 @@ impl GameStateSnapshot {
             our_seat,
         }
     }
+}
+
+/// Build the `tehai` for one seat.
+///
+/// The observer's own hand is maintained correctly by the engine, so its real
+/// tiles are used. Every other seat's hand is hidden, and riichienv-core 0.4.8
+/// inflates it by one tile per turn: `apply_mjai_event(Tsumo)` pushes the
+/// unknown drawn tile, but the following `Dahai` removes by matching the
+/// *known* discard — which never matches the unknown tile — so it is never
+/// removed. We therefore reconstruct the concealed count from the melds
+/// (13 - 3 per called set, +1 while that seat holds a freshly drawn tile) and
+/// render it as `"?"` placeholders rather than trusting the engine's `hand`.
+fn seat_tehai(hand: &[u8], n_melds: usize, is_observer: bool, drawing: bool) -> Vec<String> {
+    if is_observer {
+        return hand.iter().copied().map(tid_to_mjai).collect();
+    }
+    let n = (13 - 3 * n_melds as i32 + drawing as i32).max(0) as usize;
+    vec!["?".to_string(); n]
 }
 
 fn wind_to_str(w: u8) -> &'static str {

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -497,6 +497,46 @@ mod tests {
         assert_eq!(t.our_seat(), Some(1));
     }
 
+    /// Regression (issue #149): `riichienv-core 0.4.8` grows a hidden seat's
+    /// `hand` every turn — `Tsumo` pushes the unknown drawn tile but the
+    /// following `Dahai` removes by matching the *known* discard, which never
+    /// matches, so nothing is removed. The snapshot must reconstruct the
+    /// concealed count (`seat_tehai`) so an opponent never shows > 13 backs.
+    #[test]
+    fn opponent_tehai_count_does_not_grow() {
+        let mut t = GameTracker::new();
+        t.handle(&start_game()).unwrap(); // observer = seat 0 (start_game id=0)
+        t.handle(&start_kyoku(0)).unwrap();
+
+        // Seat 1 (a hidden opponent) draws an unknown tile and discards a known
+        // one, several times — the exact path that inflates the engine's hand.
+        for _ in 0..6 {
+            t.handle(&AkagiEvent::Tsumo {
+                actor: 1,
+                pai: "?".into(),
+            })
+            .unwrap();
+            t.handle(&AkagiEvent::Dahai {
+                actor: 1,
+                pai: "3p".into(),
+                tsumogiri: true,
+            })
+            .unwrap();
+        }
+
+        // Precondition: the underlying engine hand really did inflate.
+        assert!(
+            t.state().unwrap().players[1].hand.len() > 13,
+            "engine hand should be inflated by unmatched discards"
+        );
+
+        let snap = t.snapshot().unwrap();
+        // …but the snapshot stays at the true concealed size (no melds → 13).
+        assert_eq!(snap.players[1].tehai.len(), 13);
+        // The observer's own hand is untouched (engine tracks it correctly).
+        assert_eq!(snap.players[0].tehai.len(), 13);
+    }
+
     /// Regression: `riichienv-core 0.4.8::apply_mjai_event(Dahai)` does not
     /// populate `discard_from_hand` / `discard_is_riichi`, so the snapshot
     /// fell back to defaults and the mahgen river rendered with no


### PR DESCRIPTION
Closes #149. Two board-tile fixes.

## 1. Opponent hand tile count

Opponent concealed hands rendered far more than 13 backs. **Root cause is
upstream**: `riichienv-core 0.4.8` `apply_mjai_event` (`state/event_handler.rs`)
grows a *hidden* seat's hand every turn — `Tsumo` pushes the unknown drawn tile
(`hand.push`), but the following `Dahai` removes by matching the *known* discard
(`position(|&t| t == tile)`), which never matches the unknown tile, so nothing
is removed and the count climbs by one per turn. Our `tehai` read that hand
directly.

We don't own that crate, so the fix is at **our** boundary: `from_state` /
`from_state_3p` (`src/game_state/snapshot.rs`) now reconstruct a hidden seat's
concealed count from the melds — `13 - 3 * melds (+1 while that seat is
drawing)` — via the new `seat_tehai` helper, rendered as `"?"` placeholders,
instead of trusting the engine hand. The observer's own hand is unchanged
(the engine tracks it correctly). This is the same pattern the tracker already
uses to compensate for other 0.4.8 quirks (tedashi markers, ippatsu).

Regression test `opponent_tehai_count_does_not_grow` drives the inflating
Tsumo/Dahai path and asserts the engine hand grows while the snapshot stays at
13. (The earlier display-layer patch in `mahgen_view::encode_hand` is reverted —
fixing the DTO makes it unnecessary.)

## 2. Opponent melds don't scale with the board

`.board-seat-melds` had only `max-width` (no definite width), so mahgen's
container-width sizing read an unstable shrink-to-fit width and didn't track the
board. **Fix:** a definite `width: 44%` of the square board, like the hand/river.

## Verification
- `cargo test --lib game_state` — 56 passed (incl. the new regression test,
  whose precondition asserts the engine hand really inflates).
- `cargo fmt --check` and `cargo clippy --lib` clean.
- Standalone binary rebuilt and hash-checked against the fresh release artifact.