### PR TITLE
fix(board): constant hand tile size + light-mode panel theming

### DIFF
--- a/frontend/src/lib/mahgenRegistry.ts
+++ b/frontend/src/lib/mahgenRegistry.ts
@@ -30,14 +30,16 @@ const SIZE_CTX: Record<MahgenKind, SizeCtx> = {
   'bot-show': { mode: 'linear', base: 30, ref: 260, min: 22, max: 64 },
   // board-*: compact tiles for the 2D table tile (BoardTile). Each seat's
   // mahgen container is a fraction of the square board, so these scale down
-  // when the tile is small. `board-hand` uses linear (constant-ish tile size,
-  // width grows with tile count) rather than `hand`'s 'fit' min:44 which would
-  // overflow a small seat. Values are tunable — refine visually in the webview.
-  // 'fit' makes the hand fill its container width (which is a fraction of the
-  // square board) so it scales with the board and never overflows. River uses
-  // 'river' scaling with a high cap so it grows with the board too; its smaller
-  // container width keeps river tiles smaller than hand tiles.
-  'board-hand':  { mode: 'fit', min: 16, max: 100 },
+  // when the tile is small. `board-hand` uses linear so each tile keeps a
+  // constant height (scaling only with the board) and the strip *width* grows
+  // with the tile count — like `board-meld`. (Earlier 'fit' forced the hand to
+  // fill its fixed-width container, so fewer hand tiles after melds blew each
+  // tile up huge.) base/ref are tuned so hand tile height ≈ meld tile height
+  // (meld is base 34 over a 44% container; hand here is over a 56% container)
+  // and a full 13-tile hand still ≈ fills the container — refine visually in
+  // the webview. River uses 'river' scaling with a high cap so it grows with
+  // the board too; its smaller container width keeps river tiles smaller.
+  'board-hand':  { mode: 'linear', base: 28, ref: 250, min: 16, max: 80 },
   'board-river': { mode: 'river',  maxScale: 1.0, minScale: 0.14 },
   'board-meld':  { mode: 'linear', base: 34, ref: 240, min: 16, max: 80 },
 }

--- a/frontend/src/tiles/BoardTile.css
+++ b/frontend/src/tiles/BoardTile.css
@@ -48,17 +48,25 @@
   align-items: center;
   gap: 5px;
   padding: 3px 7px;
-  background: rgba(0, 0, 0, 0.5);
+  /* light mode: white panel; dark mode restored under `.dark` below */
+  background: oklch(1 0 0 / 0.9);
   border: 1px solid var(--border);
   border-radius: 8px;
   /* scale with the board so the dora doesn't look tiny on a large tile */
   transform: scale(var(--board-scale, 1));
   transform-origin: top left;
 }
+.dark .board-dora {
+  background: rgba(0, 0, 0, 0.5);
+}
 .board-dora-label {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  /* light mode: black text on the white panel; dark mode muted under `.dark` */
+  color: var(--foreground);
+}
+.dark .board-dora-label {
   color: var(--muted-foreground);
 }
 
@@ -114,9 +122,10 @@
   display: grid;
   grid-template-columns: 1fr 1.25fr 1fr;
   grid-template-rows: 1fr 1.25fr 1fr;
+  /* var(--foreground) is black in light mode, white in dark mode */
   color: var(--foreground);
-  /* lighter translucent grey over the dark board, with a border */
-  background: oklch(0.30 0 0 / 0.55);
+  /* light mode: white panel; dark mode restored under `.dark` below */
+  background: oklch(1 0 0 / 0.9);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
@@ -125,6 +134,10 @@
   overflow: hidden;
   /* panel text scales with the board (see --board-scale on .board-square) */
   font-size: calc(11px * var(--board-scale, 1));
+}
+.dark .board-center {
+  /* lighter translucent grey over the dark board, with a border */
+  background: oklch(0.30 0 0 / 0.55);
 }
 .board-score {
   display: flex;


### PR DESCRIPTION
Fixes #151.

Three display fixes for the 2D top-down board tile (`BoardTile`).

## 1. Hand tiles no longer balloon with melds
`board-hand` used `mode: 'fit'`, which forces the hand strip to fill its fixed-width container (`.board-seat-hand` = 56% of the square) regardless of tile count. As a player called more melds, their concealed hand shrank (13 → 10 → 7 → 4 → 1 tiles) and the same width was split among fewer tiles, blowing each tile up to the height cap.

Switched to `{ mode: 'linear', base: 28, ref: 250, min: 16, max: 80 }`, so each tile keeps a constant height (scaling only with the board) and the strip *width* grows with the tile count — the same model `board-meld` already uses. `base`/`ref` are tuned so hand tile height ≈ meld tile height and a full 13-tile hand still ≈ fills its container. Only `BoardTile` uses `board-hand`; the standalone self-hand tile (separate entry) is unaffected.

## 2 & 3. Info / dora panels readable in light mode
The central info panel and top-left dora panel had hardcoded dark backgrounds, so in light mode their text (which turns black) was black-on-dark and unreadable. Made the backgrounds theme-aware: white in light mode, with the original dark values restored under `.dark` so **dark mode is pixel-identical**. The board felt itself intentionally stays dark in both modes — only the two panels change.

## Verification
- `tsc -b && vite build` passes clean (no new type errors).
- Manual (no automated test fits CSS/visual changes): hand tiles stay a constant size across 0–4 melds with no overflow on a full hand; in light mode both panels are white-bg with readable black text while the felt stays dark; dark mode looks exactly as before.
