### PR TITLE
fix(board): record meld discarder + hide claimed tile from river

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -221,7 +221,14 @@ export type AnalysisResult = {
   best_defence_discard: string | null
 }
 
-export type DiscardEntry = { tile: string; tedashi: boolean; is_riichi: boolean }
+export type DiscardEntry = {
+  tile: string
+  tedashi: boolean
+  is_riichi: boolean
+  /** Claimed by another player (pon/chi/kan); kept for analysis, hidden in the
+   * rendered river. */
+  called?: boolean
+}
 
 export type MeldSnapshot = {
   kind: 'chi' | 'pon' | 'daiminkan' | 'ankan' | 'kakan'

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -1011,6 +1011,7 @@ mod tests {
                 tile: "9m".into(),
                 tedashi: true,
                 is_riichi: false,
+                called: false,
             });
         let act = MjaiEvent::Dahai {
             actor: 0,

--- a/src/game_state/mahgen_view.rs
+++ b/src/game_state/mahgen_view.rs
@@ -587,13 +587,22 @@ mod tests {
             called_tile: Some("1z".into()),
         };
         // Caller = seat 1. kamicha of 1 is seat 0 → rotated left.
-        let kamicha = MeldSnapshot { from_who: 0, ..base.clone() };
+        let kamicha = MeldSnapshot {
+            from_who: 0,
+            ..base.clone()
+        };
         assert_eq!(encode_meld(&kamicha, 1, 4), "_111z");
         // toimen of 1 is seat 3 → rotated middle.
-        let toimen = MeldSnapshot { from_who: 3, ..base.clone() };
+        let toimen = MeldSnapshot {
+            from_who: 3,
+            ..base.clone()
+        };
         assert_eq!(encode_meld(&toimen, 1, 4), "1_11z");
         // shimocha of 1 is seat 2 → rotated right.
-        let shimocha = MeldSnapshot { from_who: 2, ..base.clone() };
+        let shimocha = MeldSnapshot {
+            from_who: 2,
+            ..base.clone()
+        };
         assert_eq!(encode_meld(&shimocha, 1, 4), "11_1z");
     }
 

--- a/src/game_state/mahgen_view.rs
+++ b/src/game_state/mahgen_view.rs
@@ -419,6 +419,12 @@ fn encode_river(river: &[DiscardEntry]) -> String {
     // parser sees `[state?]<digit><suit>` runs back-to-back.
     let mut out = String::new();
     for d in river {
+        // A claimed discard (pon/chi/kan) has physically left the pond, so it
+        // is omitted from the rendered river. It is still present in the
+        // `DiscardEntry` list for the analysis engine (genbutsu/furiten).
+        if d.called {
+            continue;
+        }
         let prefix = match (d.is_riichi, d.tedashi) {
             (true, true) => "_",   // declared riichi via tedashi
             (true, false) => "v",  // declared riichi via tsumogiri
@@ -464,6 +470,7 @@ mod tests {
             tile: tile.into(),
             tedashi,
             is_riichi,
+            called: false,
         }
     }
 
@@ -565,6 +572,46 @@ mod tests {
             ..m.clone()
         };
         assert_eq!(encode_meld(&m3, 0, 4), "11_1z");
+    }
+
+    /// Regression (issue #153): `from_who` is the ABSOLUTE discarder seat, so
+    /// the rotation must be computed relative to the meld owner. The original
+    /// bug only showed for a non-zero caller (with caller 0 the relative and
+    /// absolute seat numbers coincide), so lock the caller-1 case here.
+    #[test]
+    fn pon_orientation_relative_to_nonzero_caller() {
+        let base = MeldSnapshot {
+            kind: MeldKind::Pon,
+            tiles: vec!["1z".into(), "1z".into(), "1z".into()],
+            from_who: 0,
+            called_tile: Some("1z".into()),
+        };
+        // Caller = seat 1. kamicha of 1 is seat 0 → rotated left.
+        let kamicha = MeldSnapshot { from_who: 0, ..base.clone() };
+        assert_eq!(encode_meld(&kamicha, 1, 4), "_111z");
+        // toimen of 1 is seat 3 → rotated middle.
+        let toimen = MeldSnapshot { from_who: 3, ..base.clone() };
+        assert_eq!(encode_meld(&toimen, 1, 4), "1_11z");
+        // shimocha of 1 is seat 2 → rotated right.
+        let shimocha = MeldSnapshot { from_who: 2, ..base.clone() };
+        assert_eq!(encode_meld(&shimocha, 1, 4), "11_1z");
+    }
+
+    /// A claimed discard (`called = true`) is omitted from the rendered river
+    /// but the surrounding tiles render normally and in order.
+    #[test]
+    fn encode_river_skips_claimed_discards() {
+        let river = vec![
+            discard("1m", true, false),
+            DiscardEntry {
+                tile: "2m".into(),
+                tedashi: true,
+                is_riichi: false,
+                called: true,
+            },
+            discard("3m", true, false),
+        ];
+        assert_eq!(encode_river(&river), "1m3m");
     }
 
     #[test]

--- a/src/game_state/snapshot.rs
+++ b/src/game_state/snapshot.rs
@@ -11,6 +11,8 @@
 //! `GameStateBus` straight through to the frontend without further
 //! transform.
 
+use std::collections::HashMap;
+
 use riichienv_core::parser::tid_to_mjai;
 use riichienv_core::state::GameState;
 use riichienv_core::state_3p::GameState3P;
@@ -93,6 +95,14 @@ pub struct DiscardEntry {
     pub tedashi: bool,
     /// `true` if this is the discard that committed riichi.
     pub is_riichi: bool,
+    /// `true` if this discard was claimed by another player (pon/chi/kan) and
+    /// has physically left the pond. **View-only**: the entry is kept in the
+    /// list so the analysis engine still counts it as genbutsu/furiten against
+    /// this seat; only the mahgen river encoder skips it. riichienv-core never
+    /// removes called tiles from its `discards`, so we reconstruct this flag
+    /// from the melds in [`GameStateSnapshot::from_state`].
+    #[serde(default)]
+    pub called: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,21 +164,27 @@ impl GameStateSnapshot {
     /// in by the tracker — see [`crate::game_state::tracker`].
     pub fn from_state(s: &GameState, our_seat: Option<u8>) -> Self {
         let in_wait_act = matches!(s.phase, riichienv_core::action::Phase::WaitAct);
-        let players: Vec<PlayerSnapshot> = (0..s.players.len())
-            .map(|i| {
+        let np = s.players.len();
+        // Build every seat's melds up front so we can tell which discards were
+        // claimed away (a meld's `from_who` is the seat the called tile came
+        // from). riichienv-core keeps called tiles in `discards`, so the view
+        // river hides them via the per-discard `called` flag.
+        let all_melds: Vec<Vec<MeldSnapshot>> = (0..np)
+            .map(|i| s.players[i].melds.iter().map(MeldSnapshot::from).collect())
+            .collect();
+        let mut called_by_seat = called_tiles_by_seat(&all_melds, np);
+        let players: Vec<PlayerSnapshot> = all_melds
+            .into_iter()
+            .enumerate()
+            .map(|(i, melds)| {
                 let p = &s.players[i];
-                let river: Vec<DiscardEntry> = p
-                    .discards
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, &tile)| DiscardEntry {
-                        tile: tid_to_mjai(tile),
-                        tedashi: p.discard_from_hand.get(idx).copied().unwrap_or(true),
-                        is_riichi: p.discard_is_riichi.get(idx).copied().unwrap_or(false),
-                    })
-                    .collect();
-                let melds: Vec<MeldSnapshot> = p.melds.iter().map(MeldSnapshot::from).collect();
                 let drawing = i as u8 == s.current_player && in_wait_act;
+                let river = build_river(
+                    &p.discards,
+                    &p.discard_from_hand,
+                    &p.discard_is_riichi,
+                    std::mem::take(&mut called_by_seat[i]),
+                );
                 PlayerSnapshot {
                     seat: i as u8,
                     tehai: seat_tehai(&p.hand, melds.len(), our_seat == Some(i as u8), drawing),
@@ -220,21 +236,23 @@ impl GameStateSnapshot {
     /// engine's per-player kita pool.
     pub fn from_state_3p(s: &GameState3P, our_seat: Option<u8>) -> Self {
         let in_wait_act = matches!(s.phase, riichienv_core::action::Phase::WaitAct);
-        let players: Vec<PlayerSnapshot> = (0..s.players.len())
-            .map(|i| {
+        let np = s.players.len();
+        let all_melds: Vec<Vec<MeldSnapshot>> = (0..np)
+            .map(|i| s.players[i].melds.iter().map(MeldSnapshot::from).collect())
+            .collect();
+        let mut called_by_seat = called_tiles_by_seat(&all_melds, np);
+        let players: Vec<PlayerSnapshot> = all_melds
+            .into_iter()
+            .enumerate()
+            .map(|(i, melds)| {
                 let p = &s.players[i];
-                let river: Vec<DiscardEntry> = p
-                    .discards
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, &tile)| DiscardEntry {
-                        tile: tid_to_mjai(tile),
-                        tedashi: p.discard_from_hand.get(idx).copied().unwrap_or(true),
-                        is_riichi: p.discard_is_riichi.get(idx).copied().unwrap_or(false),
-                    })
-                    .collect();
-                let melds: Vec<MeldSnapshot> = p.melds.iter().map(MeldSnapshot::from).collect();
                 let drawing = i as u8 == s.current_player && in_wait_act;
+                let river = build_river(
+                    &p.discards,
+                    &p.discard_from_hand,
+                    &p.discard_is_riichi,
+                    std::mem::take(&mut called_by_seat[i]),
+                );
                 PlayerSnapshot {
                     seat: i as u8,
                     tehai: seat_tehai(&p.hand, melds.len(), our_seat == Some(i as u8), drawing),
@@ -277,6 +295,62 @@ impl GameStateSnapshot {
             our_seat,
         }
     }
+}
+
+/// Count, per seat, the tiles claimed away from that seat's pond. A meld's
+/// `from_who` is the absolute seat the called tile was discarded from, and
+/// `called_tile` is that tile; ankan/kakan carry `from_who < 0` and are
+/// ignored. The returned map is keyed by mjai tile string with the number of
+/// copies of that tile taken from the seat.
+fn called_tiles_by_seat(all_melds: &[Vec<MeldSnapshot>], np: usize) -> Vec<HashMap<String, usize>> {
+    let mut by_seat: Vec<HashMap<String, usize>> = vec![HashMap::new(); np];
+    for melds in all_melds {
+        for m in melds {
+            if m.from_who >= 0 && (m.from_who as usize) < np {
+                if let Some(ct) = &m.called_tile {
+                    *by_seat[m.from_who as usize].entry(ct.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+    by_seat
+}
+
+/// Build one seat's view river, flagging the discards that were claimed away.
+/// `called` holds the count of each tile value that left this seat's pond; we
+/// flag the first still-unflagged discard matching each value. Matching by
+/// value (rather than the exact pond index, which riichienv-core doesn't keep)
+/// can pick the wrong copy when the same tile was discarded twice and only one
+/// was called — but the copies are visually identical, so the rendered river is
+/// unaffected and the hidden count is always exact. The flagged entries stay in
+/// the list (the analysis engine still treats them as genbutsu against this
+/// seat); only [`crate::game_state::mahgen_view`]'s river encoder skips them.
+fn build_river(
+    discards: &[u8],
+    from_hand: &[bool],
+    is_riichi: &[bool],
+    mut called: HashMap<String, usize>,
+) -> Vec<DiscardEntry> {
+    discards
+        .iter()
+        .enumerate()
+        .map(|(idx, &tile)| {
+            let t = tid_to_mjai(tile);
+            let claimed = match called.get_mut(&t) {
+                Some(n) if *n > 0 => {
+                    *n -= 1;
+                    true
+                }
+                _ => false,
+            };
+            DiscardEntry {
+                tile: t,
+                tedashi: from_hand.get(idx).copied().unwrap_or(true),
+                is_riichi: is_riichi.get(idx).copied().unwrap_or(false),
+                called: claimed,
+            }
+        })
+        .collect()
 }
 
 /// Build the `tehai` for one seat.

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -695,7 +695,10 @@ mod tests {
         // The rendered strings reflect both fixes: pon rotated toward toimen
         // (middle slot), discarder's river empty.
         let view = MahgenView::from_snapshot(&snap);
-        assert_eq!(view.players[0].melds[0], "1_11m", "pon rotated toward toimen");
+        assert_eq!(
+            view.players[0].melds[0], "1_11m",
+            "pon rotated toward toimen"
+        );
         assert_eq!(view.players[2].river, "", "claimed tile hidden from river");
     }
 

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -152,6 +152,15 @@ impl GameTracker {
                         }
                     }
                     apply_ippatsu_patch_4p(s, ev);
+                    // riichienv-core drops the naki `target`, storing the new
+                    // meld with `from_who = -1`; patch it back so the meld
+                    // renders rotated toward the real discarder (see
+                    // `mahgen_view::call_side`).
+                    if let Some((actor, target)) = meld_target(ev) {
+                        if let Some(m) = s.players.get_mut(actor).and_then(|p| p.melds.last_mut()) {
+                            m.from_who = target;
+                        }
+                    }
                 }
                 TrackedGame::Three(s) => {
                     s.apply_mjai_event(ri);
@@ -169,6 +178,11 @@ impl GameTracker {
                         }
                     }
                     apply_ippatsu_patch_3p(s, ev);
+                    if let Some((actor, target)) = meld_target(ev) {
+                        if let Some(m) = s.players.get_mut(actor).and_then(|p| p.melds.last_mut()) {
+                            m.from_who = target;
+                        }
+                    }
                 }
             }
         }
@@ -227,6 +241,24 @@ impl GameTracker {
 impl Default for GameTracker {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// `(actor, target)` for the open melds that claim another seat's discard
+/// (pon / chi / daiminkan), as `(seat index, discarder seat)`. Returns `None`
+/// for every other event, including ankan / kakan (no external claim).
+///
+/// riichienv-core 0.4.8's `apply_mjai_event` ignores the mjai `target` field
+/// and stores these melds with `from_who = -1`, which `mahgen_view::call_side`
+/// treats as a kamicha default — so every open meld would render rotated to the
+/// left regardless of who was called. The tracker re-applies `target` after
+/// the event so the meld points at the real discarder.
+fn meld_target(ev: &AkagiEvent) -> Option<(usize, i8)> {
+    match ev {
+        AkagiEvent::Pon { actor, target, .. }
+        | AkagiEvent::Chi { actor, target, .. }
+        | AkagiEvent::Daiminkan { actor, target, .. } => Some((*actor as usize, *target as i8)),
+        _ => None,
     }
 }
 
@@ -607,6 +639,64 @@ mod tests {
         assert!(p0.river[2].is_riichi);
 
         assert_eq!(p0.riichi_declaration_index, Some(2));
+    }
+
+    /// Regression (issue #153): `riichienv-core 0.4.8` drops the naki `target`
+    /// (stores the meld with `from_who = -1`) and never removes a claimed tile
+    /// from the discarder's `discards`. The tracker patches `from_who` back to
+    /// the real discarder, and the snapshot flags the claimed discard so the
+    /// rendered river hides it while the analysis-facing entry is retained.
+    #[test]
+    fn pon_records_discarder_and_hides_called_tile() {
+        use crate::game_state::mahgen_view::MahgenView;
+
+        let mut t = GameTracker::new();
+        t.handle(&start_game()).unwrap(); // observer = seat 0
+        t.handle(&start_kyoku(0)).unwrap();
+
+        // Seat 2 (toimen of seat 0) discards 1m; seat 0 pons it. start_kyoku
+        // deals everyone 13×1m, so seat 0 holds the two 1m it consumes.
+        t.handle(&AkagiEvent::Tsumo {
+            actor: 2,
+            pai: "1m".into(),
+        })
+        .unwrap();
+        t.handle(&AkagiEvent::Dahai {
+            actor: 2,
+            pai: "1m".into(),
+            tsumogiri: true,
+        })
+        .unwrap();
+        t.handle(&AkagiEvent::Pon {
+            actor: 0,
+            target: 2,
+            pai: "1m".into(),
+            consumed: ["1m".into(), "1m".into()],
+        })
+        .unwrap();
+
+        let snap = t.snapshot().unwrap();
+
+        // Fix 1: the meld records the real discarder (toimen = seat 2), not the
+        // riichienv-core `-1` default that `call_side` renders as kamicha.
+        assert_eq!(
+            snap.players[0].melds[0].from_who, 2,
+            "meld must record the discarder seat"
+        );
+
+        // Fix 2: seat 2's lone discard is flagged claimed but kept in the list
+        // so the analysis engine still sees it as genbutsu.
+        assert_eq!(snap.players[2].river.len(), 1);
+        assert!(
+            snap.players[2].river[0].called,
+            "claimed discard is retained but flagged"
+        );
+
+        // The rendered strings reflect both fixes: pon rotated toward toimen
+        // (middle slot), discarder's river empty.
+        let view = MahgenView::from_snapshot(&snap);
+        assert_eq!(view.players[0].melds[0], "1_11m", "pon rotated toward toimen");
+        assert_eq!(view.players[2].river, "", "claimed tile hidden from river");
     }
 
     /// 3p `start_game` constructs a `GameState3P` and the snapshot reflects


### PR DESCRIPTION
Fixes #153.

Two game-state correctness bugs visible on the board tile, both rooted in `riichienv-core 0.4.8`'s `apply_mjai_event`.

## 1. Open melds always rendered as "called from kamicha"

For `Pon`/`Chi`/`Daiminkan`, the engine drops the mjai `target` and stores the meld with `from_who = -1`. Our meld encoder's `call_side` treats `from_who < 0` as a kamicha default, so a pon from toimen rendered with the rotated tile on the **left** (`_111`) instead of the **middle** (`1_11`) — and the same for shimocha calls.

**Fix:** in `tracker::handle`, after `apply_mjai_event`, a new `meld_target(ev)` helper extracts `(actor, target)` for the three claim melds and patches the just-pushed meld's `from_who` to the real discarder. This mirrors the existing dahai / ippatsu post-apply patches. (Ankan/Kakan are untouched; a Kakan upgrading a prior pon keeps that pon's already-patched `from_who`.)

## 2. The called tile stayed in the discarder's river

riichi-core never removes a claimed tile from the discarder's `discards` — which is **correct**, because that array feeds furiten/genbutsu. So the removal must be view-only.

**Fix:** `DiscardEntry` gains a `called` flag. `snapshot::from_state`/`from_state_3p` build all seats' melds first, derive the per-seat claimed-tile counts from the melds' `from_who`/`called_tile`, and flag the matching discards; `mahgen_view::encode_river` skips flagged entries. The flagged entry is **kept in the list**, so the analysis engine still counts it as genbutsu and `riichi_declaration_index` stays valid — only the rendered river hides it.

## Tests

- `tracker::pon_records_discarder_and_hides_called_tile` — end to end: feeds Tsumo/Dahai/Pon, asserts `from_who == 2`, the discard is flagged + retained, the meld renders `1_11m`, and the discarder's river is empty.
- `mahgen_view::pon_orientation_relative_to_nonzero_caller` — locks the absolute-vs-relative seat math for a caller seat != 0 (the case the previous caller-0 test couldn't catch).
- `mahgen_view::encode_river_skips_claimed_discards`.

`cargo test --lib game_state::` → 59/59 pass; analysis suite unaffected.
