### PR TITLE
fix(bot): apply runtime active-bot switch on the next game (#157)

### DIFF
--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -30,6 +30,7 @@ use crate::bot::registry::BotRegistry;
 use crate::bot::runner::{BotRunner, SubprocessBot};
 use crate::bot::runtime::PythonRuntime;
 use crate::bot::sync_guard::SyncGuard;
+use crate::config::AppConfig;
 use crate::event_bus::{BotResponseBus, BotStatusBus, NotifyBus};
 use crate::inspector::InspectorWriter;
 use crate::schema::{BotReaction, BotStatus, InspectorEntry, LoadStage, MjaiEvent, Notification};
@@ -39,7 +40,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, RwLock};
 use tracing::{debug, error, info, warn};
 
 pub struct BotManager {
@@ -50,12 +51,16 @@ pub struct BotManager {
     /// Akagi — the manager's view of "what bots exist" must not be a
     /// snapshot taken at supervisor start.
     bot_dir: PathBuf,
-    /// Active bot subdir name for 4-player games. Empty ⇒ no 4p bot configured.
-    active_4p: String,
-    /// Active bot subdir name for 3-player games. Empty ⇒ no 3p bot configured.
-    active_3p: String,
+    /// Shared, live application config. The active-bot selection
+    /// (`bot.active_4p` / `bot.active_3p`) is read *fresh* at every
+    /// `start_game` rather than snapshotted at construction, so a runtime
+    /// switch via the Bots page (`set_active_bot`) or Settings
+    /// (`update_config`) takes effect on the next game without relaunching
+    /// Akagi.
+    config: Arc<RwLock<AppConfig>>,
     /// Subdir name of the bot currently spawned for the in-progress game
-    /// (one of `active_4p` / `active_3p`, decided at `start_game`).
+    /// (the `active_4p` / `active_3p` value read from `config` at
+    /// `start_game`). Empty until the first `start_game`.
     active_name: String,
     runner: Option<Box<dyn BotRunner>>,
     /// Events seen since the last `react()` call.
@@ -80,21 +85,18 @@ impl BotManager {
     pub fn new(
         runtime: PythonRuntime,
         bot_dir: PathBuf,
-        active_4p: String,
-        active_3p: String,
+        config: Arc<RwLock<AppConfig>>,
         out_tx: BotResponseBus,
         status_tx: BotStatusBus,
         notify_tx: NotifyBus,
         inspector: InspectorWriter,
         syncs_in_flight: Arc<Mutex<HashSet<String>>>,
     ) -> Self {
-        let active_name = active_4p.clone();
         Self {
             runtime,
             bot_dir,
-            active_4p,
-            active_3p,
-            active_name,
+            config,
+            active_name: String::new(),
             runner: None,
             pending: Vec::new(),
             actor_id: None,
@@ -117,10 +119,7 @@ impl BotManager {
     /// `Sender` so the manager doesn't keep the channel alive itself —
     /// makes shutdown deterministic when the proxy stops producing.
     pub async fn run(mut self, mut rx: broadcast::Receiver<MjaiEvent>) -> Result<()> {
-        info!(
-            bot = %self.active_name,
-            "bot manager subscribed to MJAI bus; waiting for start_game"
-        );
+        info!("bot manager subscribed to MJAI bus; waiting for start_game (active bot is read from config at each start_game)");
         // Surface the initial state to any IPC consumer that subscribes
         // late. Send is no-op when no subscribers exist yet.
         self.emit_status(BotStatus::Idle);
@@ -155,12 +154,17 @@ impl BotManager {
         } = &event
         {
             self.actor_id = Some(*seat);
-            // Pick the active bot for this game's player count.
-            let chosen = if *num_players == 3 {
-                &self.active_3p
-            } else {
-                &self.active_4p
-            };
+            // Pick the active bot for this game's player count, reading the
+            // *current* config so a runtime model switch takes effect on the
+            // next game (the manager outlives many games — a snapshot taken
+            // at construction would pin the startup selection forever).
+            let chosen = self
+                .config
+                .read()
+                .await
+                .bot
+                .active_for(*num_players)
+                .to_string();
             if chosen.is_empty() {
                 warn!(
                     "no bot configured for {np}p; running analysis-only for this game",
@@ -171,7 +175,7 @@ impl BotManager {
                 self.emit_status(BotStatus::Idle);
                 return Ok(());
             }
-            self.active_name = chosen.clone();
+            self.active_name = chosen;
             self.spawn_runner().await?;
             self.pending.clear();
         }
@@ -540,6 +544,16 @@ mod tests {
         Arc::new(Mutex::new(HashSet::new()))
     }
 
+    /// Shared config handle pre-seeded with a 4p active bot (and no 3p bot),
+    /// matching how the supervisor hands the manager its live config. The
+    /// active-bot selection is read from this at every `start_game`.
+    fn cfg_with(active_4p: &str) -> Arc<RwLock<AppConfig>> {
+        let mut c = AppConfig::default();
+        c.bot.active_4p = active_4p.to_string();
+        c.bot.active_3p = String::new();
+        Arc::new(RwLock::new(c))
+    }
+
     /// Tempfile-backed inspector writer for tests. The file is leaked
     /// for the test duration (the OS reaps it on process exit) — keeps
     /// the constructor a one-liner without per-test cleanup boilerplate.
@@ -573,8 +587,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             empty_bot_dir(),
-            "mock".into(),
-            String::new(),
+            cfg_with("mock"),
             bus,
             status,
             notify,
@@ -583,7 +596,10 @@ mod tests {
         );
         // Pre-seat the actor and inject the mock so we don't go through
         // the registry / runtime path (covered by runner.rs tests).
+        // `start_game` normally sets `active_name` alongside the runner, so
+        // mirror that invariant here for status emissions to be realistic.
         mgr.actor_id = Some(2);
+        mgr.active_name = "mock".into();
         mgr.runner = Some(Box::new(mock));
         (mgr, calls, resp_rx, status_rx, notify_rx)
     }
@@ -775,8 +791,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             empty_bot_dir(),
-            "mock".into(),
-            String::new(),
+            cfg_with("mock"),
             bus,
             status,
             notify,
@@ -784,6 +799,7 @@ mod tests {
             fresh_syncs(),
         );
         mgr.actor_id = Some(2);
+        mgr.active_name = "mock".into();
         mgr.runner = Some(Box::new(MockBotRunner::failing("kaboom")));
 
         // Trigger a decision point — react() returns error.
@@ -816,8 +832,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             empty_bot_dir(),
-            "ghost".into(),
-            String::new(),
+            cfg_with("ghost"),
             bus,
             status,
             notify,
@@ -847,6 +862,64 @@ mod tests {
         assert!(n.title.contains("Bot not found"));
     }
 
+    /// Regression (issue #157): switching the active bot after the manager
+    /// is constructed must take effect on the next `start_game`. Pre-fix the
+    /// manager snapshotted `active_4p`/`active_3p` at construction, so a
+    /// runtime model switch via the Bots page was silently ignored until
+    /// Akagi was relaunched.
+    ///
+    /// We can't run the full spawn (no real Python runtime in tests), so we
+    /// lean on `spawn_runner`'s registry lookup: with an empty registry the
+    /// spawn errors "bot not found", and the emitted `BotStatus::Error`
+    /// carries the bot name the manager *tried* to spawn. Seeing the
+    /// post-switch name there proves the manager re-read config at
+    /// `start_game` rather than using the construction-time snapshot.
+    #[tokio::test]
+    async fn active_bot_switch_takes_effect_on_next_start_game() {
+        let bus = bot_response_bus();
+        let status = bot_status_bus();
+        let notify = notify_bus();
+        let mut status_rx = status.subscribe();
+
+        let config = cfg_with("old-bot");
+        let mut mgr = BotManager::new(
+            dummy_runtime(),
+            empty_bot_dir(),
+            config.clone(),
+            bus,
+            status,
+            notify,
+            dummy_inspector(),
+            fresh_syncs(),
+        );
+
+        // Switch the active bot AFTER construction, exactly as `set_active_bot`
+        // does to the shared config while the manager task is already running.
+        config.write().await.bot.active_4p = "new-bot".to_string();
+
+        let err = mgr
+            .handle(MjaiEvent::StartGame {
+                names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+                kyoku_first: None,
+                aka_flag: None,
+                id: Some(0),
+                num_players: 4,
+            })
+            .await
+            .unwrap_err();
+        // The spawn must have been attempted for the *new* bot, not the
+        // snapshot taken at construction.
+        let msg = format!("{err:#}");
+        assert!(msg.contains("new-bot"), "error should name new-bot: {msg}");
+        assert!(!msg.contains("old-bot"), "must not use stale bot: {msg}");
+
+        let s = status_rx.try_recv().unwrap();
+        assert!(
+            matches!(s, BotStatus::Error { ref bot, .. } if bot == "new-bot"),
+            "expected Error{{bot=new-bot}}, got {s:?}"
+        );
+    }
+
     #[tokio::test]
     async fn events_before_start_game_are_dropped() {
         // Manager freshly constructed → no actor_id, no runner.
@@ -856,8 +929,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             empty_bot_dir(),
-            "mock".into(),
-            String::new(),
+            cfg_with("mock"),
             bus,
             status,
             notify,
@@ -892,8 +964,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             bot_dir.clone(),
-            "latebot".into(),
-            String::new(),
+            cfg_with("latebot"),
             bus,
             status,
             notify,
@@ -943,8 +1014,7 @@ mod tests {
         let mut mgr = BotManager::new(
             dummy_runtime(),
             empty_bot_dir(),
-            "mock".into(),
-            String::new(),
+            cfg_with("mock"),
             bot_bus,
             status,
             notify,

--- a/src/bot/supervisor.rs
+++ b/src/bot/supervisor.rs
@@ -9,7 +9,7 @@
 use crate::bot::registry::BotRegistry;
 use crate::bot::runtime::PythonRuntime;
 use crate::bot::BotManager;
-use crate::config::BotConfig;
+use crate::config::AppConfig;
 use crate::event_bus::{BotResponseBus, BotStatusBus, MjaiBus, NotifyBus};
 use crate::inspector::InspectorWriter;
 use crate::util;
@@ -17,16 +17,20 @@ use anyhow::{anyhow, Result};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tracing::warn;
 
-/// Build a `BotManager` from `cfg` + `runtime` and run it until the MJAI
-/// bus closes. Returns `Err` only on setup failure (missing runtime,
-/// unscannable bot dir); transient runtime errors are absorbed by the
-/// manager itself.
+/// Build a `BotManager` from the shared `config` + `runtime` and run it
+/// until the MJAI bus closes. Returns `Err` only on setup failure (missing
+/// runtime, unscannable bot dir); transient runtime errors are absorbed by
+/// the manager itself.
+///
+/// The manager holds the shared `Arc<RwLock<AppConfig>>` and re-reads the
+/// active-bot selection at each `start_game`, so a model switch made while
+/// the manager is running takes effect on the next game without a relaunch.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_bot_manager(
-    cfg: BotConfig,
+    config: Arc<RwLock<AppConfig>>,
     mjai: MjaiBus,
     response_bus: BotResponseBus,
     status_bus: BotStatusBus,
@@ -35,23 +39,27 @@ pub async fn run_bot_manager(
     runtime: Option<PythonRuntime>,
     syncs_in_flight: Arc<Mutex<HashSet<String>>>,
 ) -> Result<()> {
-    let bot_dir = util::resolve_dir(Path::new(&cfg.dir));
-    // Diagnostic-only: warn early if the configured bots aren't present
-    // *now*. The manager rescans on every spawn so a bot installed after
-    // this point is still picked up — the warning here is just to surface
-    // mis-config quickly in logs, not to gate startup.
-    let registry = BotRegistry::scan(&bot_dir)?;
-    for (label, name) in [("4p", &cfg.active_4p), ("3p", &cfg.active_3p)] {
-        if !name.is_empty() && registry.find(name).is_none() {
-            warn!(
-                "configured {} bot {:?} not found under {}; available: {:?}",
-                label,
-                name,
-                bot_dir.display(),
-                registry.names().collect::<Vec<_>>()
-            );
+    let bot_dir = {
+        let cfg = config.read().await;
+        let bot_dir = util::resolve_dir(Path::new(&cfg.bot.dir));
+        // Diagnostic-only: warn early if the configured bots aren't present
+        // *now*. The manager rescans on every spawn so a bot installed after
+        // this point is still picked up — the warning here is just to surface
+        // mis-config quickly in logs, not to gate startup.
+        let registry = BotRegistry::scan(&bot_dir)?;
+        for (label, name) in [("4p", &cfg.bot.active_4p), ("3p", &cfg.bot.active_3p)] {
+            if !name.is_empty() && registry.find(name).is_none() {
+                warn!(
+                    "configured {} bot {:?} not found under {}; available: {:?}",
+                    label,
+                    name,
+                    bot_dir.display(),
+                    registry.names().collect::<Vec<_>>()
+                );
+            }
         }
-    }
+        bot_dir
+    };
 
     let runtime = runtime
         .ok_or_else(|| anyhow!("bot mode is enabled but no python3+uv runtime was found"))?;
@@ -59,8 +67,7 @@ pub async fn run_bot_manager(
     let manager = BotManager::new(
         runtime,
         bot_dir,
-        cfg.active_4p,
-        cfg.active_3p,
+        config,
         response_bus,
         status_bus,
         notify_bus,

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -95,7 +95,6 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
     let proxy_changed = prev_proxy != new_config.proxy;
     let platform_changed = prev_platform != new_config.platform.kind;
     let new_platform = new_config.platform.kind;
-    let bot_cfg = new_config.bot.clone();
     let bot_now_enabled = new_config.bot.enabled;
     let autoplay_now_enabled = new_config.autoplay.enabled;
     *state.config.write().await = new_config;
@@ -141,6 +140,7 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
     // toggles only spawn once. The manager runs forever; flipping back to
     // false still requires an Akagi relaunch to actually stop it.
     if claim_bot_manager_spawn(bot_now_enabled, &state.bot_manager_started) {
+        let cfg_for_bot = state.config.clone();
         let mjai = state.mjai_bus.clone();
         let resp = state.bot_response_bus.clone();
         let bs = state.bot_status_bus.clone();
@@ -151,7 +151,8 @@ pub async fn update_config(new_config: AppConfig, state: State<'_, AppState>) ->
         let started_flag = state.bot_manager_started.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(e) =
-                crate::bot::run_bot_manager(bot_cfg, mjai, resp, bs, nb, inspector, rt, syncs).await
+                crate::bot::run_bot_manager(cfg_for_bot, mjai, resp, bs, nb, inspector, rt, syncs)
+                    .await
             {
                 tracing::error!("Bot manager failed: {e:#}");
                 // Setup failure: clear the flag so a follow-up
@@ -248,8 +249,9 @@ pub async fn update_bot_settings(
 }
 
 /// Update the active bot for a given mode (`"4p"` or `"3p"`) in config +
-/// persist. Doesn't restart the running `BotManager` — that respawns on the
-/// next `start_game` event anyway, and picks the matching mode bot then.
+/// persist. Doesn't restart the running `BotManager` — it reads the active
+/// bot fresh from the shared config at each `start_game`, so the next game
+/// picks up this change with no relaunch (an in-progress game keeps its bot).
 ///
 /// Empty `name` clears that mode's active bot (analysis-only in that mode).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ pub fn run() {
 
     let bot_enabled = cfg.bot.enabled;
     let proxy_enabled = cfg.proxy.enabled;
-    let bot_cfg = cfg.bot.clone();
     let autoplay_enabled = cfg.autoplay.enabled;
 
     // Game-state tracker handle is built up front so AppState can carry
@@ -203,6 +202,7 @@ pub fn run() {
                 ));
 
                 if bot_enabled {
+                    let cfg_for_bot = state.config.clone();
                     let mjai_for_bot = mjai_bus.clone();
                     let resp = bot_response_bus.clone();
                     let bs = bot_status_bus.clone();
@@ -215,7 +215,7 @@ pub fn run() {
                         .store(true, std::sync::atomic::Ordering::SeqCst);
                     tauri::async_runtime::spawn(async move {
                         if let Err(e) = bot::run_bot_manager(
-                            bot_cfg,
+                            cfg_for_bot,
                             mjai_for_bot,
                             resp,
                             bs,

--- a/tests/bot_lifecycle.rs
+++ b/tests/bot_lifecycle.rs
@@ -20,14 +20,24 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use akagi::bot::{BotManager, BotRegistry, PythonRuntime};
+use akagi::config::AppConfig;
 use akagi::event_bus::{bot_response_bus, bot_status_bus, notify_bus};
 use akagi::inspector::InspectorWriter;
 use akagi::schema::{BotStatus, LoadStage, MjaiEvent, NotifyLevel};
 use tempfile::TempDir;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, RwLock};
 
 fn fresh_syncs() -> Arc<Mutex<HashSet<String>>> {
     Arc::new(Mutex::new(HashSet::new()))
+}
+
+/// Shared config handle with a 4p active bot, as the supervisor hands the
+/// manager. The active-bot name is read from this at each `start_game`.
+fn cfg_with(active_4p: &str) -> Arc<RwLock<AppConfig>> {
+    let mut c = AppConfig::default();
+    c.bot.active_4p = active_4p.to_string();
+    c.bot.active_3p = String::new();
+    Arc::new(RwLock::new(c))
 }
 
 fn dummy_inspector() -> InspectorWriter {
@@ -111,8 +121,7 @@ async fn loading_emits_syncing_then_spawning_then_ready() {
     let mut mgr = BotManager::new(
         runtime,
         registry_root.path().to_path_buf(),
-        "echo".into(),
-        String::new(),
+        cfg_with("echo"),
         response_bus,
         status_bus,
         notify,
@@ -203,8 +212,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
         let mut mgr = BotManager::new(
             runtime.clone(),
             registry_root.path().to_path_buf(),
-            "echo".into(),
-            String::new(),
+            cfg_with("echo"),
             response_bus,
             status_bus,
             notify,
@@ -235,8 +243,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
     let mut mgr = BotManager::new(
         runtime,
         registry_root.path().to_path_buf(),
-        "echo".into(),
-        String::new(),
+        cfg_with("echo"),
         response_bus,
         status_bus,
         notify,


### PR DESCRIPTION
Closes #157.

## Problem

Switching the active bot from the UI after startup was silently ignored until Akagi was relaunched: start on one bot, switch to another on the Bots page, start a game — the original bot still runs.

## Root cause

`BotManager` snapshotted the active-bot names (`active_4p` / `active_3p`) **once at construction** and read those cached fields at `start_game` to decide which bot to spawn. `set_active_bot` (and the Settings-page `update_config`) wrote the new selection into the shared config (`Arc<RwLock<AppConfig>>`) and persisted it to disk, but never propagated the change to the long-lived `BotManager` task — so it kept using the startup snapshot.

## Fix

Give `BotManager` the shared `Arc<RwLock<AppConfig>>` handle (the autoplay manager already works this way) and read `bot.active_for(num_players)` **fresh at each `start_game`**. Single source of truth — fixes both the Bots-page switch and the Settings-page edit. The switch takes effect on the next game with no relaunch; an in-progress game keeps its current bot.

### Changes
- `src/bot/manager.rs` — replace the snapshot fields with a live config handle; resolve the active bot at `start_game`.
- `src/bot/supervisor.rs` — `run_bot_manager` takes the config handle; reads it once for `bot_dir` + startup diagnostics.
- `src/lib.rs`, `src/ipc/commands.rs` — both call sites pass `state.config.clone()`; drop the unused `BotConfig` snapshots; fix the stale `set_active_bot` doc comment.

## Tests
- New regression `active_bot_switch_takes_effect_on_next_start_game`: switch the config after the manager is built, then `start_game` attempts the **new** bot (proven via the empty-registry error naming the post-switch bot).
- Migrated all `BotManager::new` call sites (unit + integration) to a `cfg_with()` helper; manual-injection tests now also set `active_name` (the `start_game` invariant).
- `cargo test --lib --tests` → 524 lib + integration pass; `cargo clippy --lib --tests` and `cargo fmt --check` clean.

## Manual verification (recommended)
Launch with one bot active → switch to a different installed+synced bot on the Bots page → start a game → confirm the newly selected bot spawns (Bot status / Inspector), no relaunch.