### PR TITLE
fix(bot): repair relocated bot venv; never uv sync inline at game-start (#159)

### DIFF
--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -317,9 +317,7 @@ impl BotManager {
                 bot: bot_name.clone(),
                 error: msg.clone(),
             });
-            self.emit_notify(
-                Notification::error("Bot environment needs reinstalling").body(msg),
-            );
+            self.emit_notify(Notification::error("Bot environment needs reinstalling").body(msg));
             self.runner = None;
             self.pending.clear();
             return Ok(());

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -293,6 +293,38 @@ impl BotManager {
             bail!(msg);
         }
 
+        // Game-start must never run a slow `uv sync` inline: it would stall
+        // the live game while the bot misses its turns (the historical
+        // game-start-timeout bug, otherwise prevented by `set_active_bot`
+        // refusing to activate a bot whose env isn't pre-installed). A
+        // moved/renamed Akagi folder can silently invalidate an *already
+        // active* bot's venv in a way only a full re-sync can repair —
+        // Windows bakes the base-python path into the `Scripts/python.exe`
+        // trampoline, so it can't be repointed in place the way `ensure_synced`
+        // repoints the Unix symlink. Detect that here and fall back to
+        // analysis-only with a reinstall prompt instead of blocking the game;
+        // the user repairs it out-of-band (Bots page → Install environment)
+        // and the next game spawns cleanly. Returning Ok (not bail) leaves the
+        // runner unset so this game simply runs analysis-only.
+        if crate::bot::runtime::needs_out_of_band_resync(&entry.dir) {
+            let msg = format!(
+                "{bot_name}'s Python environment needs reinstalling — the Akagi \
+                 folder was moved or renamed. Open the Bots page and click \
+                 Install environment."
+            );
+            warn!(bot = %bot_name, "{msg}");
+            self.emit_status(BotStatus::Error {
+                bot: bot_name.clone(),
+                error: msg.clone(),
+            });
+            self.emit_notify(
+                Notification::error("Bot environment needs reinstalling").body(msg),
+            );
+            self.runner = None;
+            self.pending.clear();
+            return Ok(());
+        }
+
         let load_id = format!("bot-loading-{bot_name}");
 
         // Phase 1: dep sync. ensure_synced is a no-op when stamp matches,
@@ -999,6 +1031,84 @@ mod tests {
             !msg.contains("not found in registry"),
             "registry rescan failed to pick up post-construction install: {msg}"
         );
+    }
+
+    /// Regression: an ACTIVE bot whose venv was invalidated by a folder move
+    /// (the interpreter file survived but its base `home` is gone — the
+    /// Windows shape, where `Scripts/python.exe` is a real trampoline copy)
+    /// must NOT trigger an inline `uv sync` at game-start. That would stall
+    /// the live game while the bot misses its turns — the historical
+    /// game-start-timeout bug. `spawn_runner` detects the un-repointable venv
+    /// up front and runs analysis-only with a reinstall prompt, never calling
+    /// `ensure_synced`.
+    #[tokio::test]
+    async fn moved_venv_skips_inline_sync_and_runs_analysis_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bot_dir = tmp.path().to_path_buf();
+        let bot = bot_dir.join("mybot");
+        std::fs::create_dir_all(&bot).unwrap();
+        std::fs::write(bot.join("bot.py"), b"").unwrap();
+        std::fs::write(bot.join("pyproject.toml"), b"[project]\nname='x'\n").unwrap();
+        // Moved-venv state: interpreter file present, but pyvenv.cfg `home`
+        // points at a directory that no longer exists.
+        let venv = bot.join(".akagi").join("venv");
+        std::fs::create_dir_all(venv.join("bin")).unwrap();
+        std::fs::write(venv.join("bin").join("python"), b"").unwrap();
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            b"home = /vanished/old/runtime/bin\n",
+        )
+        .unwrap();
+
+        let bus = bot_response_bus();
+        let status = bot_status_bus();
+        let notify = notify_bus();
+        let mut status_rx = status.subscribe();
+        let mut notify_rx = notify.subscribe();
+        let mut mgr = BotManager::new(
+            dummy_runtime(),
+            bot_dir,
+            cfg_with("mybot"),
+            bus,
+            status,
+            notify,
+            dummy_inspector(),
+            fresh_syncs(),
+        );
+
+        mgr.handle(MjaiEvent::StartGame {
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            kyoku_first: None,
+            aka_flag: None,
+            id: Some(0),
+            num_players: 4,
+        })
+        .await
+        .expect("handle returns Ok (analysis-only), not an error");
+
+        assert!(mgr.runner.is_none(), "must not spawn a bot needing re-sync");
+
+        // The guard fired BEFORE ensure_synced: an Error status naming the
+        // bot with the reinstall message — NOT a 'uv sync failed' message,
+        // which is what we'd see if the inline sync had been attempted.
+        let s = status_rx.try_recv().expect("status emitted");
+        match s {
+            BotStatus::Error { bot, error } => {
+                assert_eq!(bot, "mybot");
+                assert!(
+                    error.contains("reinstalling"),
+                    "expected reinstall prompt, got: {error}"
+                );
+                assert!(
+                    !error.contains("uv sync"),
+                    "must not have attempted an inline sync: {error}"
+                );
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+        let n = notify_rx.try_recv().expect("notification emitted");
+        assert_eq!(n.level, crate::schema::NotifyLevel::Error);
+        assert!(n.title.contains("reinstalling"), "got title: {}", n.title);
     }
 
     #[tokio::test]

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -105,19 +105,29 @@ impl PythonRuntime {
 
         let current = current_signature(&pyproject, &lock)?;
         if venv.is_dir() && stamp_matches(&stamp_path, &current).await? {
-            if venv_python_alive(&venv) {
+            if venv_python_alive(&venv) && venv_home_exists(&venv) {
                 return Ok(());
             }
-            // Stamp says the deps are in sync, but `bin/python` is a
-            // dangling symlink. The AppImage case: each launch creates a
-            // fresh `/tmp/.mount_Akagi_<rand>/` mount, and uv bakes that
-            // absolute path into `bin/python` + `pyvenv.cfg.home` at
-            // sync time, so the venv built under a previous mount has
-            // dead pointers on the next launch. The standalone python +
-            // installed wheels are binary-identical across launches, so
-            // we repoint the venv to the current python without paying
-            // for a full re-sync (which would otherwise re-run on every
-            // single launch under AppImage).
+            // Stamp says the deps are in sync, but the venv's baked-in
+            // absolute pointers to the base interpreter are stale. Two
+            // ways this happens:
+            //   1. AppImage: each launch creates a fresh
+            //      `/tmp/.mount_Akagi_<rand>/` mount, so the `bin/python`
+            //      symlink built under a previous mount now dangles
+            //      (`venv_python_alive` is false).
+            //   2. The user moved/renamed the whole Akagi folder, so the
+            //      `pyvenv.cfg.home` directory uv baked in at sync time is
+            //      gone (`venv_home_exists` is false). On Unix this also
+            //      dangles the symlink, but on Windows `Scripts/python.exe`
+            //      is a real copy that survives the move, so the missing
+            //      `home` dir is the only on-disk tell — without it we'd
+            //      hand a dead interpreter to the runner and the first
+            //      stdin write dies with `os error 232` ("The pipe is
+            //      being closed").
+            // The standalone python + installed wheels are binary-identical
+            // regardless of location, so we repoint the venv to the current
+            // python without paying for a full re-sync (which would
+            // otherwise re-run on every single launch under AppImage).
             match repoint_venv(&venv, &self.python).await {
                 Ok(()) => {
                     info!(
@@ -301,6 +311,52 @@ fn venv_python_alive(venv: &Path) -> bool {
     std::fs::metadata(venv_python(venv))
         .map(|m| m.is_file())
         .unwrap_or(false)
+}
+
+/// Pull the `home = …` value out of a `pyvenv.cfg` body, if present.
+/// Matches the `home` key exactly (not `homepage` etc.) and tolerates
+/// the surrounding whitespace uv writes (`home = /path`).
+fn home_dir_from_cfg(cfg: &str) -> Option<String> {
+    for line in cfg.lines() {
+        if let Some(rest) = line.trim_start().strip_prefix("home") {
+            if let Some(value) = rest.trim_start().strip_prefix('=') {
+                return Some(value.trim().to_string());
+            }
+        }
+    }
+    None
+}
+
+/// True when the venv's recorded base-python `home` directory still
+/// exists on disk. `uv` bakes the *absolute* path of the base
+/// interpreter into `pyvenv.cfg` (`home = …`) at sync time. When the
+/// Akagi folder is moved or renamed, that absolute path is gone: the
+/// venv python can no longer find its base interpreter/stdlib and dies
+/// at startup, which surfaces downstream as a broken pipe on the first
+/// stdin write — `os error 232` ("The pipe is being closed") on Windows,
+/// `Broken pipe (os error 32)` on Unix.
+///
+/// On Unix a moved venv is already caught by `venv_python_alive` (the
+/// `bin/python` symlink dangles), but on Windows `Scripts/python.exe` is
+/// a real copy that survives the move, so the missing `home` directory
+/// is the only on-disk tell. Checking it lets `ensure_synced` fall
+/// through to repair (repoint, or re-sync) instead of handing a dead
+/// interpreter to the runner.
+///
+/// Returns `true` (assume current) when there is no `pyvenv.cfg` or it
+/// carries no `home` key — there is nothing to invalidate on, and
+/// `venv_python_alive` stays the backstop. Note a *copy* of the folder
+/// (original left in place) keeps the old `home` dir alive, so the venv
+/// still works and we correctly leave it untouched; only a true
+/// move/rename trips this.
+fn venv_home_exists(venv: &Path) -> bool {
+    let Ok(cfg) = std::fs::read_to_string(venv.join("pyvenv.cfg")) else {
+        return true;
+    };
+    match home_dir_from_cfg(&cfg) {
+        Some(home) => Path::new(&home).is_dir(),
+        None => true,
+    }
 }
 
 /// Repoint a venv at `new_python` without re-running `uv sync`. Used
@@ -605,6 +661,142 @@ mod tests {
             !cfg.contains("mount_OLD"),
             "pyvenv.cfg must not retain the stale mount path, got:\n{cfg}"
         );
+    }
+
+    #[test]
+    fn home_dir_from_cfg_extracts_home() {
+        let cfg = "home = /opt/py/bin\nimplementation = CPython\nversion_info = 3.12.13\n";
+        assert_eq!(home_dir_from_cfg(cfg).as_deref(), Some("/opt/py/bin"));
+        // Tolerate the no-space form uv never writes but is still legal.
+        assert_eq!(home_dir_from_cfg("home=/x").as_deref(), Some("/x"));
+    }
+
+    #[test]
+    fn home_dir_from_cfg_ignores_lookalike_keys_and_missing_home() {
+        // `homepage`/`home_dir` must not be mistaken for the `home` key.
+        assert_eq!(home_dir_from_cfg("homepage = /x\nhome_dir = /y\n"), None);
+        // No home line at all.
+        assert_eq!(home_dir_from_cfg("implementation = CPython\n"), None);
+    }
+
+    #[test]
+    fn venv_home_exists_tracks_the_baked_home_dir() {
+        let tmp = TempDir::new().unwrap();
+        let venv = tmp.path().join(AKAGI_DIR).join(VENV_DIR);
+        std::fs::create_dir_all(&venv).unwrap();
+
+        // No pyvenv.cfg → nothing to invalidate on → assume current.
+        assert!(venv_home_exists(&venv));
+
+        // home points at a directory that exists → current.
+        let live_home = tmp.path().join("runtime/python/bin");
+        std::fs::create_dir_all(&live_home).unwrap();
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            format!("home = {}\nversion_info = 3.12.13\n", live_home.display()),
+        )
+        .unwrap();
+        assert!(venv_home_exists(&venv));
+
+        // home points at a vanished directory (folder was moved) → stale.
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            "home = /no/such/old/runtime/python/bin\n",
+        )
+        .unwrap();
+        assert!(!venv_home_exists(&venv));
+
+        // pyvenv.cfg with no home key → assume current (alive check backstops).
+        std::fs::write(venv.join("pyvenv.cfg"), "implementation = CPython\n").unwrap();
+        assert!(venv_home_exists(&venv));
+    }
+
+    /// Regression (the Windows folder-move bug → `write newline: The pipe is
+    /// being closed. (os error 232)`): a venv whose interpreter file still
+    /// exists — on Windows `Scripts/python.exe` is a real copy that survives a
+    /// move, unlike the Unix symlink which dangles — but whose pyvenv.cfg
+    /// `home` directory is gone must NOT short-circuit as ready. The
+    /// `ensure_synced` fast path now requires BOTH `venv_python_alive` AND
+    /// `venv_home_exists`; before this fix only the former was checked, so the
+    /// dead venv was handed to the runner and its first stdin write hit
+    /// `os error 232`.
+    #[test]
+    fn venv_with_live_python_but_missing_home_reads_as_stale() {
+        let tmp = TempDir::new().unwrap();
+        let venv = tmp.path().join(AKAGI_DIR).join(VENV_DIR);
+        // Create the per-platform interpreter file so the test is correct on
+        // both Unix (`bin/python`) and Windows (`Scripts/python.exe`).
+        let py = venv_python(&venv);
+        std::fs::create_dir_all(py.parent().unwrap()).unwrap();
+        std::fs::write(&py, "").unwrap();
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            "home = /vanished/old/akagi/runtime/python/bin\n",
+        )
+        .unwrap();
+
+        assert!(
+            venv_python_alive(&venv),
+            "interpreter file is present (Windows copy survives the move)"
+        );
+        assert!(
+            !venv_home_exists(&venv),
+            "but the baked `home` dir is gone → the venv is stale and must be repaired"
+        );
+    }
+
+    /// Regression: end-to-end, `ensure_synced` must repair (not silently
+    /// accept) a moved venv whose python is alive but whose `home` is stale.
+    /// On Unix the repair is an in-place repoint; this asserts the observable
+    /// outcome — afterwards the venv's `home` resolves again. (On Windows the
+    /// same detection routes to a full re-sync, since the base path is baked
+    /// into the trampoline `.exe` and can't be edited in place.)
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ensure_synced_repairs_venv_with_live_python_but_stale_home() {
+        let tmp = TempDir::new().unwrap();
+        let bot = tmp.path();
+        write(&bot.join("pyproject.toml"), "[project]\nname='a'\n");
+
+        // The current (post-move) bundled interpreter, at a valid path.
+        let py_dir = tmp.path().join("runtime/bin");
+        std::fs::create_dir_all(&py_dir).unwrap();
+        let python = py_dir.join("python3");
+        std::fs::write(&python, "").unwrap();
+
+        // Pre-seed the "moved" venv: bin/python present, but home vanished,
+        // and a stamp that matches so the short-circuit branch is reached.
+        let akagi = bot.join(AKAGI_DIR);
+        let venv = akagi.join(VENV_DIR);
+        std::fs::create_dir_all(venv.join("bin")).unwrap();
+        std::fs::write(venv.join("bin").join("python"), "").unwrap();
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            "home = /no/such/old/runtime/bin\nversion_info = 3.12.13\n",
+        )
+        .unwrap();
+        let sig =
+            current_signature(&bot.join("pyproject.toml"), &bot.join("uv.lock")).unwrap();
+        std::fs::write(akagi.join(STAMP_FILE), &sig).unwrap();
+        assert!(
+            venv_python_alive(&venv) && !venv_home_exists(&venv),
+            "precondition: the os-error-232 state — live python, dead home"
+        );
+
+        // uv is never invoked: the Unix repoint succeeds in place. A bogus
+        // path proves we didn't fall through to a real sync.
+        let rt = PythonRuntime::from_paths(
+            python,
+            PathBuf::from("/dev/null/uv"),
+            RuntimeMode::System,
+        );
+        rt.ensure_synced(bot).await.unwrap();
+
+        assert!(
+            venv_home_exists(&venv),
+            "ensure_synced must repair the stale home in place"
+        );
+        assert!(venv_python_alive(&venv));
     }
 
     #[test]

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -810,8 +810,7 @@ mod tests {
             "home = /no/such/old/runtime/bin\nversion_info = 3.12.13\n",
         )
         .unwrap();
-        let sig =
-            current_signature(&bot.join("pyproject.toml"), &bot.join("uv.lock")).unwrap();
+        let sig = current_signature(&bot.join("pyproject.toml"), &bot.join("uv.lock")).unwrap();
         std::fs::write(akagi.join(STAMP_FILE), &sig).unwrap();
         assert!(
             venv_python_alive(&venv) && !venv_home_exists(&venv),
@@ -820,11 +819,8 @@ mod tests {
 
         // uv is never invoked: the Unix repoint succeeds in place. A bogus
         // path proves we didn't fall through to a real sync.
-        let rt = PythonRuntime::from_paths(
-            python,
-            PathBuf::from("/dev/null/uv"),
-            RuntimeMode::System,
-        );
+        let rt =
+            PythonRuntime::from_paths(python, PathBuf::from("/dev/null/uv"), RuntimeMode::System);
         rt.ensure_synced(bot).await.unwrap();
 
         assert!(

--- a/src/bot/runtime.rs
+++ b/src/bot/runtime.rs
@@ -218,6 +218,13 @@ fn scrub_python_env(cmd: &mut Command) {
 /// NOT require `venv_python_alive`: a dangling venv symlink (the AppImage
 /// mount-changed case) is repaired by a cheap repoint inside `ensure_synced`,
 /// not a slow full re-sync, so it shouldn't block a bot from being activated.
+///
+/// It DOES, however, report not-installed for a venv that survived a
+/// folder move but can only be repaired by a full re-sync (see
+/// [`needs_out_of_band_resync`]). That keeps the readiness signal honest:
+/// the UI re-offers "Install environment", `set_active_bot` won't (re)gate
+/// it active, and game-start skips it instead of stalling a live game on an
+/// inline `uv sync`.
 pub fn is_synced(bot_dir: &Path) -> bool {
     let pyproject = bot_dir.join("pyproject.toml");
     if !pyproject.is_file() {
@@ -232,10 +239,38 @@ pub fn is_synced(bot_dir: &Path) -> bool {
     if !venv.is_dir() {
         return false;
     }
+    if needs_out_of_band_resync(bot_dir) {
+        return false;
+    }
     match std::fs::read_to_string(&stamp_path) {
         Ok(saved) => saved.trim() == current,
         Err(_) => false,
     }
+}
+
+/// True when the bot's venv is present but in a state that game-start
+/// **cannot cheaply repair**, so letting `ensure_synced` run inline there
+/// would do a slow `uv sync` that stalls the live game while the bot misses
+/// its turns — the historical game-start-timeout hazard that `set_active_bot`
+/// guards against by requiring a pre-installed env.
+///
+/// The one production trigger is a moved/renamed Akagi folder whose venv
+/// interpreter file *survived* the move but whose baked base-python `home`
+/// is gone. That happens on **Windows**, where the venv's
+/// `Scripts/python.exe` is a real trampoline copy with the base path
+/// embedded in the binary — `ensure_synced` can't repoint it in place and
+/// must re-sync from scratch. On **Unix** the same move dangles the
+/// `bin/python` symlink instead (interpreter not "alive"), which
+/// `ensure_synced` repoints cheaply, so this returns false and game-start
+/// proceeds as before. A genuinely absent venv also returns false — the
+/// cold first install is a separate, out-of-band concern.
+///
+/// The check is the *semantic* condition (interpreter alive AND base `home`
+/// gone), not an OS `cfg`, so it's testable on any platform and naturally
+/// fires only for the move shape that actually needs a re-sync.
+pub fn needs_out_of_band_resync(bot_dir: &Path) -> bool {
+    let venv = bot_dir.join(AKAGI_DIR).join(VENV_DIR);
+    venv.is_dir() && venv_python_alive(&venv) && !venv_home_exists(&venv)
 }
 
 /// Wipe the stamp file and the venv so the next `ensure_synced` runs from
@@ -797,6 +832,87 @@ mod tests {
             "ensure_synced must repair the stale home in place"
         );
         assert!(venv_python_alive(&venv));
+    }
+
+    /// `needs_out_of_band_resync` must fire only for the move shape that
+    /// truly can't be repaired cheaply at game-start: the interpreter file
+    /// survived (Windows copy) but its baked base `home` is gone. A dangling
+    /// symlink (the Unix move/AppImage shape) is cheaply repointable, and an
+    /// absent or healthy venv needs nothing — all three must return false so
+    /// game-start isn't needlessly downgraded to analysis-only.
+    #[test]
+    fn needs_out_of_band_resync_only_for_alive_interp_with_dead_home() {
+        let tmp = TempDir::new().unwrap();
+        let bot = tmp.path();
+        let venv = bot.join(AKAGI_DIR).join(VENV_DIR);
+
+        // No venv at all (cold install) → not a re-sync-needed state.
+        assert!(!needs_out_of_band_resync(bot));
+
+        // Interpreter present + home dir present (healthy / warm) → false.
+        let py = venv_python(&venv);
+        std::fs::create_dir_all(py.parent().unwrap()).unwrap();
+        std::fs::write(&py, "").unwrap();
+        let live_home = tmp.path().join("runtime/python/bin");
+        std::fs::create_dir_all(&live_home).unwrap();
+        std::fs::write(
+            venv.join("pyvenv.cfg"),
+            format!("home = {}\n", live_home.display()),
+        )
+        .unwrap();
+        assert!(!needs_out_of_band_resync(bot));
+
+        // Interpreter present but home dir vanished (the Windows folder-move
+        // shape) → the one true case.
+        std::fs::write(venv.join("pyvenv.cfg"), "home = /no/such/old/bin\n").unwrap();
+        assert!(needs_out_of_band_resync(bot));
+    }
+
+    /// Unix move shape: the interpreter is a dangling symlink, so it's NOT
+    /// "alive" — `ensure_synced` repoints it cheaply and `needs_out_of_band_resync`
+    /// must stay false (no analysis-only downgrade, no out-of-band reinstall).
+    #[cfg(unix)]
+    #[test]
+    fn needs_out_of_band_resync_false_for_dangling_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let bot = tmp.path();
+        let venv = bot.join(AKAGI_DIR).join(VENV_DIR);
+        std::fs::create_dir_all(venv.join("bin")).unwrap();
+        std::os::unix::fs::symlink("/no/such/old/bin/python3", venv.join("bin").join("python"))
+            .unwrap();
+        std::fs::write(venv.join("pyvenv.cfg"), "home = /no/such/old/bin\n").unwrap();
+        assert!(!venv_python_alive(&venv), "dangling symlink is not alive");
+        assert!(!needs_out_of_band_resync(bot));
+    }
+
+    /// Regression: a moved venv that needs a full re-sync must read as
+    /// not-installed so the UI re-offers "Install environment" and game-start
+    /// skips it — even though its stamp still matches (a move preserves the
+    /// pyproject/lock mtimes the stamp is keyed on).
+    #[test]
+    fn is_synced_false_for_moved_venv_needing_resync() {
+        let tmp = TempDir::new().unwrap();
+        let bot = tmp.path();
+        let py = bot.join("pyproject.toml");
+        write(&py, "[project]\nname='a'\n");
+        let venv = bot.join(AKAGI_DIR).join(VENV_DIR);
+        // Alive interpreter (survived the move) + vanished home.
+        let interp = venv_python(&venv);
+        std::fs::create_dir_all(interp.parent().unwrap()).unwrap();
+        std::fs::write(&interp, "").unwrap();
+        std::fs::write(venv.join("pyvenv.cfg"), "home = /vanished/old/bin\n").unwrap();
+        // Stamp matches current signature — the move kept the mtimes.
+        let sig = current_signature(&py, &bot.join("uv.lock")).unwrap();
+        std::fs::write(bot.join(AKAGI_DIR).join(STAMP_FILE), &sig).unwrap();
+
+        assert!(
+            needs_out_of_band_resync(bot),
+            "precondition: this venv needs a re-sync"
+        );
+        assert!(
+            !is_synced(bot),
+            "a moved venv needing a re-sync must not read as installed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #159.

## Problem

Moving/renaming the Akagi folder after installing a bot breaks it on Windows with `write newline: The pipe is being closed. (os error 232)`. `uv` bakes the **absolute** path of the bundled base interpreter into the venv (`pyvenv.cfg` `home = …`, and on Unix the `bin/python` symlink), so a move makes that path stale.

The game-start readiness fast path short-circuited to "ready" whenever the venv's interpreter file existed. On Unix a move dangles the `bin/python` symlink (already detected → repaired in place). On Windows the venv's `Scripts/python.exe` is a real trampoline copy that **survives** the move, so the stale venv was handed to the runner; `python.exe` couldn't find its base stdlib, died at startup, and the first stdin write hit `os error 232`.

## Fix

**1. Detect the relocated venv.** `ensure_synced`'s short-circuit now requires both that the interpreter is alive **and** that the base `home` directory baked into `pyvenv.cfg` still exists. A missing `home` dir is the only on-disk tell on Windows (the interpreter copy survives a move). When stale, the venv is repaired: Unix repoints in place; Windows re-syncs (the base path is embedded inside the `Scripts/python.exe` trampoline binary, so editing `pyvenv.cfg` alone cannot relocate it — a full re-sync is the only reliable repair there).

**2. Never run `uv sync` inline at game-start.** `set_active_bot` already gates activation on a pre-installed env so game-start is normally a no-op — but a move silently invalidated that on Windows (the readiness check didn't look at `home`), which would have made the self-heal re-sync inline and stall a live game while the bot missed its turns. New `needs_out_of_band_resync` flags the un-repointable move shape (interpreter alive but base `home` gone). It now:
   - makes `is_synced` report not-installed, so the UI re-offers **Install environment** and `set_active_bot` stays consistent, and
   - makes `spawn_runner` fall back to analysis-only with a reinstall prompt instead of syncing inline. The user reinstalls out-of-band and the next game spawns cleanly.

The condition is semantic (interpreter alive **and** base `home` gone), not an OS flag, so it fires only on the Windows-style move (a Unix move dangles the symlink → not "alive" → cheap repoint as before) and the cold first-sync path is untouched.

## Behaviour after a move

| | Before | After |
|---|---|---|
| **Windows** | `os error 232` every game, permanently | Analysis-only + reinstall prompt for one game; click Install → fixed. No inline sync. |
| **Unix** | already worked | Sub-second auto-repoint at game-start, transparent |

## Tests

9 new regression tests in `runtime.rs` / `manager.rs`, including:
- `venv_with_live_python_but_missing_home_reads_as_stale` — encodes the exact `os error 232` state (live interpreter + dead `home`).
- `ensure_synced_repairs_venv_with_live_python_but_stale_home` — end-to-end repair.
- `needs_out_of_band_resync_*` — fires only for the alive-but-dead-`home` shape; stays false for a dangling symlink (Unix move) and an absent venv (cold install).
- `moved_venv_skips_inline_sync_and_runs_analysis_only` — asserts no inline sync was attempted (the surfaced error is the reinstall prompt, not "uv sync failed").

`cargo test --lib` 533 passed; `bot_lifecycle` (cold game-start sync) and `example_bot` integration green; clippy clean. The existing cold-sync coverage stays green, confirming the first-install path is unchanged.