### PR TITLE
Show per-hand-tile deal-in risk in the Mixed Deal-in Risk panel

### DIFF
--- a/frontend/src/lib/mahgenRegistry.ts
+++ b/frontend/src/lib/mahgenRegistry.ts
@@ -6,7 +6,7 @@
 
 export type MahgenKind =
   | 'river' | 'hand' | 'melds' | 'dora' | 'rec' | 'bot-action' | 'bot-show'
-  | 'board-hand' | 'board-river' | 'board-meld'
+  | 'board-hand' | 'board-river' | 'board-meld' | 'hand-risk'
 
 type SizeCtx =
   | { mode: 'river'; maxScale?: number; minScale?: number }
@@ -42,6 +42,12 @@ const SIZE_CTX: Record<MahgenKind, SizeCtx> = {
   'board-hand':  { mode: 'linear', base: 28, ref: 250, min: 16, max: 80 },
   'board-river': { mode: 'river',  maxScale: 1.0, minScale: 0.14 },
   'board-meld':  { mode: 'linear', base: 34, ref: 240, min: 16, max: 80 },
+  // hand-risk: individual hand tiles in the RiskChartTile, each rendered as its
+  // own <mah-gen> so a per-tile risk glow + badge can sit around it. Container
+  // ref is the shared content row, so all tiles get the same height and the
+  // strip wraps when the panel is narrow. Tuned for a ~13–14 tile hand; refine
+  // visually in the webview.
+  'hand-risk':   { mode: 'linear', base: 36, ref: 230, min: 26, max: 64 },
 }
 
 const RIVER_FULL_ROW_W = 420

--- a/frontend/src/lib/tileIdx.ts
+++ b/frontend/src/lib/tileIdx.ts
@@ -74,3 +74,22 @@ export function mjaiToMahgen(tiles: string[] | null | undefined): string {
   if (backs > 0) out += '0'.repeat(backs) + 'z'
   return out
 }
+
+// Display-order rank for an mjai tile: m < p < s < honors (E S W N P F C),
+// ascending within suit, with red fives (5mr/5pr/5sr) placed just after the
+// plain 5. Mirrors the ordering inside mjaiToMahgen.
+function tileSortRank(mjai: string): number {
+  if (HONOR_INDEX[mjai] !== undefined) return 300 + (Z_INDEX[mjai] ?? 0)
+  const isRed = mjai.endsWith('r')
+  const suit = isRed ? mjai[mjai.length - 2] : mjai[mjai.length - 1]
+  const suitRank = suit === 'm' ? 0 : suit === 'p' ? 100 : suit === 's' ? 200 : 900
+  const num = isRed ? 5.5 : parseInt(mjai[0], 10)
+  return suitRank + (Number.isNaN(num) ? 99 : num)
+}
+
+// Sort mjai tile strings into the same display order the Self Hand panel uses
+// (via mjaiToMahgen), returned as an array so callers can annotate each tile
+// individually. Stable, so duplicate tiles keep their relative order.
+export function sortMjaiTiles(tiles: string[]): string[] {
+  return [...tiles].sort((a, b) => tileSortRank(a) - tileSortRank(b))
+}

--- a/frontend/src/tiles/RiskChartTile.tsx
+++ b/frontend/src/tiles/RiskChartTile.tsx
@@ -47,29 +47,28 @@ export function RiskChartTile({ bp }: { bp: Breakpoint }) {
   )
 }
 
-// Risk tiers reuse the original RiskChartTile cutoffs (>=20 red, >=10 amber,
-// else emerald). Each tier maps to a colored glow ring around the tile plus a
-// matching badge tint; foreground colors are split light/dark so the numbers
-// stay legible in both themes. The glow is an inline box-shadow rather than an
-// arbitrary `shadow-[...]` class: Tailwind's scanner drops multi-layer arbitrary
-// shadows (the commas break candidate extraction), so the class would be purged.
-type Tier = { glow: string; badge: string }
+// Map deal-in risk to a smooth blue -> green -> yellow -> red colour (continuous,
+// not bucketed). Hue runs linearly from 240 deg (blue, safest) down to 0 deg
+// (red) over a 0..RISK_MAX range; values past RISK_MAX clamp to red. RISK_MAX is
+// tuned so green lands near a ~10% deal-in and red near ~20%, lining up with the
+// risk levels the old discrete cutoffs used. Colours are inline styles (not
+// Tailwind classes) since the hue is computed per tile.
+const RISK_MAX = 20
 
-function riskTier(v: number | null): Tier {
-  if (v == null) return { glow: 'none', badge: 'bg-muted text-muted-foreground' }
-  if (v >= 20)
-    return {
-      glow: '0 0 0 2px rgba(239,68,68,0.75), 0 0 10px 2px rgba(239,68,68,0.55)',
-      badge: 'bg-red-500/15 text-red-600 dark:text-red-400',
-    }
-  if (v >= 10)
-    return {
-      glow: '0 0 0 2px rgba(245,158,11,0.75), 0 0 10px 2px rgba(245,158,11,0.5)',
-      badge: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
-    }
+type RiskColor = { ring: string; glow: string; chip: string }
+
+function riskColor(value: number | null): RiskColor {
+  if (value == null) {
+    // No analysis yet: neutral grey, no hue.
+    return { ring: 'hsl(0 0% 55%)', glow: 'hsl(0 0% 55% / 0.4)', chip: 'hsl(0 0% 45%)' }
+  }
+  const t = Math.min(1, Math.max(0, value / RISK_MAX))
+  const hue = 240 * (1 - t)
   return {
-    glow: '0 0 0 2px rgba(16,185,129,0.55), 0 0 8px 1px rgba(16,185,129,0.4)',
-    badge: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+    ring: `hsl(${hue} 80% 55%)`,
+    glow: `hsl(${hue} 85% 55% / 0.5)`,
+    // Darker so white text on the chip stays legible across the whole gradient.
+    chip: `hsl(${hue} 70% 40%)`,
   }
 }
 
@@ -82,14 +81,21 @@ function RiskTile({
   value: number | null
   rowRef: RefObject<HTMLDivElement | null>
 }) {
-  const tier = riskTier(value)
+  const c = riskColor(value)
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className="rounded-[3px] leading-none" style={{ boxShadow: tier.glow }}>
-        <Mahgen seq={mjaiToMahgen([tile])} kind="hand-risk" containerRef={rowRef} />
+      {/* flex + leading-0 so the wrapper shrink-wraps the <mah-gen> tile exactly
+          (the host is display:inline, which otherwise reserves line-box space the
+          ring would expose as a gap above the tile). */}
+      <div
+        className="flex rounded-[3px] leading-[0]"
+        style={{ boxShadow: `0 0 0 2px ${c.ring}, 0 0 8px 2px ${c.glow}` }}
+      >
+        <Mahgen seq={mjaiToMahgen([tile])} kind="hand-risk" containerRef={rowRef} className="leading-[0]" />
       </div>
       <span
-        className={`min-w-[2.4em] rounded px-1 py-0.5 text-center text-[10px] font-mono tabular-nums leading-none ${tier.badge}`}
+        className="min-w-[2.4em] rounded px-1 py-0.5 text-center text-[10px] font-mono tabular-nums leading-none text-white"
+        style={{ backgroundColor: c.chip }}
       >
         {value == null ? '—' : value.toFixed(1)}
       </span>

--- a/frontend/src/tiles/RiskChartTile.tsx
+++ b/frontend/src/tiles/RiskChartTile.tsx
@@ -1,39 +1,98 @@
+import { useMemo, useRef, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TileFrame } from '@/components/TileFrame'
+import { Mahgen } from '@/components/Mahgen'
+import { useGameStore } from '@/stores/gameStore'
 import { useAnalysisStore } from '@/stores/analysisStore'
-import { TILE_LABELS_34 } from '@/lib/tileIdx'
+import { tileIdx, mjaiToMahgen, sortMjaiTiles } from '@/lib/tileIdx'
 import type { Breakpoint } from '@/tiles/defaults'
 
+// Deal-in risk, but only for the tiles in our own hand — laid out like the Self
+// Hand panel (suit order) with each tile annotated by its mixed-risk value. The
+// full 34-tile chart was noise; what matters when choosing a discard is how
+// dangerous each tile *you actually hold* is.
 export function RiskChartTile({ bp }: { bp: Breakpoint }) {
   const { t } = useTranslation()
+  const game = useGameStore((s) => s.game)
   const risk = useAnalysisStore((s) => s.result?.mixed_risk ?? null)
+  // Mahgen sizes off this ref (the content row), so every tile shares one height
+  // and the strip wraps when the panel is narrow.
+  const rowRef = useRef<HTMLDivElement>(null)
+
+  const ourSeat = game?.our_seat ?? null
+  const sorted = useMemo(() => {
+    const tehai = ourSeat != null ? game?.players[ourSeat]?.tehai ?? [] : []
+    return sortMjaiTiles(tehai)
+  }, [game, ourSeat])
 
   return (
-    <TileFrame id="risk-chart" title={t('tile.risk_chart')} bp={bp} contentClassName="flex flex-col gap-1.5">
-      {!risk ? (
-        <span className="text-muted-foreground text-sm">{t('tile.risk_chart_empty')}</span>
+    <TileFrame id="risk-chart" title={t('tile.risk_chart')} bp={bp}>
+      {sorted.length === 0 ? (
+        <div className="flex h-full items-center justify-center">
+          <span className="text-muted-foreground text-sm">{t('tile.risk_chart_empty')}</span>
+        </div>
       ) : (
-        <div className="grid grid-cols-[auto_1fr_auto] gap-x-2 gap-y-0.5 text-[10px] font-mono">
-          {risk.map((v, i) => (
-            <Row key={i} label={TILE_LABELS_34[i]} value={v} />
-          ))}
+        <div
+          ref={rowRef}
+          className="flex flex-wrap content-start items-start justify-center gap-x-2 gap-y-3"
+        >
+          {sorted.map((tile, i) => {
+            const idx = tileIdx(tile)
+            const v = risk && idx >= 0 ? risk[idx] : null
+            return <RiskTile key={i} tile={tile} value={v} rowRef={rowRef} />
+          })}
         </div>
       )}
     </TileFrame>
   )
 }
 
-function Row({ label, value }: { label: string; value: number }) {
-  const v = value ?? 0
-  const w = Math.min(100, Math.max(0, v))
-  const color = v >= 20 ? 'bg-red-500' : v >= 10 ? 'bg-amber-500' : 'bg-emerald-500'
+// Risk tiers reuse the original RiskChartTile cutoffs (>=20 red, >=10 amber,
+// else emerald). Each tier maps to a colored glow ring around the tile plus a
+// matching badge tint; foreground colors are split light/dark so the numbers
+// stay legible in both themes. The glow is an inline box-shadow rather than an
+// arbitrary `shadow-[...]` class: Tailwind's scanner drops multi-layer arbitrary
+// shadows (the commas break candidate extraction), so the class would be purged.
+type Tier = { glow: string; badge: string }
+
+function riskTier(v: number | null): Tier {
+  if (v == null) return { glow: 'none', badge: 'bg-muted text-muted-foreground' }
+  if (v >= 20)
+    return {
+      glow: '0 0 0 2px rgba(239,68,68,0.75), 0 0 10px 2px rgba(239,68,68,0.55)',
+      badge: 'bg-red-500/15 text-red-600 dark:text-red-400',
+    }
+  if (v >= 10)
+    return {
+      glow: '0 0 0 2px rgba(245,158,11,0.75), 0 0 10px 2px rgba(245,158,11,0.5)',
+      badge: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+    }
+  return {
+    glow: '0 0 0 2px rgba(16,185,129,0.55), 0 0 8px 1px rgba(16,185,129,0.4)',
+    badge: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  }
+}
+
+function RiskTile({
+  tile,
+  value,
+  rowRef,
+}: {
+  tile: string
+  value: number | null
+  rowRef: RefObject<HTMLDivElement | null>
+}) {
+  const tier = riskTier(value)
   return (
-    <>
-      <span className="text-muted-foreground">{label}</span>
-      <span className="bg-muted/40 rounded h-3 overflow-hidden flex">
-        <span className={`${color} h-full`} style={{ width: `${w}%` }} />
+    <div className="flex flex-col items-center gap-1">
+      <div className="rounded-[3px] leading-none" style={{ boxShadow: tier.glow }}>
+        <Mahgen seq={mjaiToMahgen([tile])} kind="hand-risk" containerRef={rowRef} />
+      </div>
+      <span
+        className={`min-w-[2.4em] rounded px-1 py-0.5 text-center text-[10px] font-mono tabular-nums leading-none ${tier.badge}`}
+      >
+        {value == null ? '—' : value.toFixed(1)}
       </span>
-      <span className="text-right">{v.toFixed(1)}</span>
-    </>
+    </div>
   )
 }

--- a/frontend/src/tiles/RiskChartTile.tsx
+++ b/frontend/src/tiles/RiskChartTile.tsx
@@ -47,13 +47,31 @@ export function RiskChartTile({ bp }: { bp: Breakpoint }) {
   )
 }
 
-// Map deal-in risk to a smooth blue -> green -> yellow -> red colour (continuous,
-// not bucketed). Hue runs linearly from 240 deg (blue, safest) down to 0 deg
-// (red) over a 0..RISK_MAX range; values past RISK_MAX clamp to red. RISK_MAX is
-// tuned so green lands near a ~10% deal-in and red near ~20%, lining up with the
-// risk levels the old discrete cutoffs used. Colours are inline styles (not
-// Tailwind classes) since the hue is computed per tile.
-const RISK_MAX = 20
+// Map deal-in risk (%) to a hue via a piecewise-linear ramp anchored to the
+// deal-in thresholds that matter for defence. The curve is deliberately
+// non-linear: mixed_risk is a deal-in % whose decision-critical band sits in
+// ~0..16%, so a plain linear 0..20 map left genuinely dangerous tiles (~13%)
+// looking yellow-green and almost never reached red. The anchors line up with
+// the engine's own risk table (src/analysis/data/risk.rs): suji ~2-5%, no-suji
+// 3/7 ~9.5%, no-suji 5 ~12.8%, with dora/late/ippatsu/multi-tenpai pushing 16%+.
+// Colours are inline styles (not Tailwind classes) since the hue is per tile.
+const RISK_HUE_ANCHORS: ReadonlyArray<readonly [risk: number, hue: number]> = [
+  [0, 225], // blue  — genbutsu / guaranteed safe
+  [5, 130], // green — suji, low risk
+  [10, 45], // amber — no-suji 3/7, moderate
+  [16, 0], //  red   — no-suji 5 + dora, late, ippatsu, multi-tenpai
+]
+
+function riskHue(v: number): number {
+  const a = RISK_HUE_ANCHORS
+  if (v <= a[0][0]) return a[0][1]
+  for (let i = 1; i < a.length; i++) {
+    const [v0, h0] = a[i - 1]
+    const [v1, h1] = a[i]
+    if (v <= v1) return h0 + ((h1 - h0) * (v - v0)) / (v1 - v0)
+  }
+  return a[a.length - 1][1] // clamp >= last anchor (16%) to full red
+}
 
 type RiskColor = { ring: string; glow: string; chip: string }
 
@@ -62,8 +80,7 @@ function riskColor(value: number | null): RiskColor {
     // No analysis yet: neutral grey, no hue.
     return { ring: 'hsl(0 0% 55%)', glow: 'hsl(0 0% 55% / 0.4)', chip: 'hsl(0 0% 45%)' }
   }
-  const t = Math.min(1, Math.max(0, value / RISK_MAX))
-  const hue = 240 * (1 - t)
+  const hue = riskHue(value)
   return {
     ring: `hsl(${hue} 80% 55%)`,
     glow: `hsl(${hue} 85% 55% / 0.5)`,


### PR DESCRIPTION
Closes #164.

## What

Redesigns the Game dashboard's **Mixed Deal-in Risk** panel (`risk-chart`) from a chart of **all 34 tile types** into a **Self-Hand-style** view: it now renders only the tiles in your own hand (in the same suit order as the **Self Hand** panel) and annotates each tile with its deal-in risk — a risk-colored **glow ring** on the tile plus the numeric **deal-in % below it**.

### Why

While playing, the only thing that matters for a discard decision is how dangerous each tile *in your own hand* is. The full 34-tile chart was noise — you had to scan the whole list and mentally cross-reference it against your hand.

## How

- **`frontend/src/lib/tileIdx.ts`** — add `sortMjaiTiles(tiles)` (with an internal `tileSortRank`), which sorts mjai tile strings into the same display order `mjaiToMahgen` produces (m < p < s < honors, red fives at the 5 position) but returns an **array**, so each tile can be annotated individually. Stable, so duplicates keep their order.
- **`frontend/src/lib/mahgenRegistry.ts`** — add a `'hand-risk'` `MahgenKind` + sizing entry for individual hand tiles laid out in a shared-ref wrapping row.
- **`frontend/src/tiles/RiskChartTile.tsx`** — rewritten. Reads our own-seat `tehai` from the game store and `mixed_risk` from the analysis store, sorts, and renders each tile as its own `<Mahgen kind="hand-risk">` (sharing one row ref as the size driver, mirroring `BotActionTile`) wrapped in a risk-colored glow with a monospace % badge underneath. Risk thresholds reuse the previous cutoffs (≥20 red, ≥10 amber, else emerald).

The panel keeps the same id, title, grid slot, and i18n keys — no registry/layout/locale changes, and no backend changes (the data already existed).

### Edge cases

- Red fives show the plain five's risk (`tileIdx` already collapses them).
- Before analysis arrives, tiles still render with a `—` badge (no crash).
- Empty state (no hand / spectator) shows the existing empty message.

### Implementation note

The per-tile glow is an inline `style={{ boxShadow }}` rather than an arbitrary `shadow-[…]` class: Tailwind v4's scanner drops multi-layer arbitrary shadows (the commas break candidate extraction), so the class would be purged from the CSS. Confirmed against the built stylesheet.

## Verification

There is no JS test harness in `frontend/` (no vitest), so:

- `npm run build` (tsc + vite) — clean.
- eslint on the touched files — clean.
- Manual in-app check recommended: confirm the panel shows your hand tiles in Self-Hand order with glow + deal-in %, colors follow the thresholds, red fives use the 5's risk, it renders before analysis arrives, and tiles rescale/wrap on resize in both light and dark mode (3p and 4p).