### PR TITLE
fix: v3.3 statusbar, setup-wizard, and Chromium-capture bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.11.0",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2972,6 +2973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3139,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4975,6 +4995,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5025,7 +5059,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5096,7 +5130,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5243,7 +5277,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5268,7 +5302,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6276,7 +6310,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6300,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6365,11 +6399,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6379,6 +6425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6415,7 +6470,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6460,6 +6526,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6609,6 +6685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6930,7 +7015,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,12 @@ sha2 = "0.11"
 thiserror = "2"
 tauri-plugin-dialog = "2"
 
+# Windows-only: find + terminate a surviving controlled Chromium by its command
+# line when reopening (Chrome writes no SingletonLock file on Windows, so the
+# lock-file reclaim can't see it). Unix reclaims via the SingletonLock symlink,
+# so no crate is needed there.
+[target.'cfg(windows)'.dependencies]
+sysinfo = { version = "0.39.5", default-features = false, features = ["system"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/frontend/src/components/Statusbar.tsx
+++ b/frontend/src/components/Statusbar.tsx
@@ -1,16 +1,68 @@
 import { useTranslation } from 'react-i18next'
 import { useConfigStore } from '@/stores/configStore'
 import { useApiStatusStore } from '@/stores/apiStatusStore'
+import { useCaptureStore } from '@/stores/captureStore'
+import { useBotStore } from '@/stores/botStore'
+import {
+  BOT_LABEL,
+  botTone,
+  CAPTURE_LABEL,
+  captureTone,
+  TONE_DOT,
+  type IndicatorTone,
+} from '@/lib/statusIndicators'
 
 // Reserved built-in bot names (see `src/bot/native.rs`).
 const NATIVE_4P = 'akagi-native'
 const NATIVE_3P = 'akagi-native3p'
+
+function IndicatorDot({
+  tone,
+  label,
+  title,
+}: {
+  tone: IndicatorTone
+  label: string
+  title?: string
+}) {
+  return (
+    <span className="flex items-center gap-1.5" title={title}>
+      <span className={`h-1.5 w-1.5 rounded-full ${TONE_DOT[tone]}`} />
+      {label}
+    </span>
+  )
+}
 
 export function Statusbar() {
   const { t } = useTranslation()
   const config = useConfigStore((s) => s.config)
   const degraded = useApiStatusStore((s) => s.degraded)
   const apiError = useApiStatusStore((s) => s.error)
+  const capture = useCaptureStore((s) => s.status)
+  const bot = useBotStore((s) => s.status)
+
+  // Capture LED — "is Akagi reading the game?" (proxy / capture transport).
+  // Tooltip surfaces the capture descriptor, or the error message on failure,
+  // so the user can see *why* it's down.
+  const capTone = captureTone(capture.state)
+  const captureTitle =
+    capture.state === 'error'
+      ? capture.error
+      : capture.state === 'running' || capture.state === 'starting'
+        ? capture.descriptor
+        : undefined
+
+  // Bot LED — "is the recommendation engine up?". Independent of capture: the
+  // bot can error (broken env, failed spawn) while capture keeps running.
+  const botT = botTone(bot.state)
+  const botTitle =
+    bot.state === 'error'
+      ? bot.error
+      : bot.state === 'loading'
+        ? `${bot.bot} · ${bot.stage}`
+        : bot.state === 'ready' || bot.state === 'stopped'
+          ? bot.bot
+          : undefined
 
   // "Using online API" = a native bot is active AND the cloud API is fully
   // configured (enabled + URL + key). Config-derived so it reflects intent even
@@ -30,34 +82,28 @@ export function Statusbar() {
 
   return (
     <footer className="flex items-center justify-between border-t border-border px-4 py-1.5 text-xs text-muted-foreground bg-muted/30">
-      <span className="flex items-center gap-1.5">
-        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-        <span>{t('status.connected')}</span>
-      </span>
+      <IndicatorDot
+        tone={capTone}
+        label={t(CAPTURE_LABEL[capTone])}
+        title={captureTitle}
+      />
       <span className="flex items-center gap-3">
         {usingApi && (
-          <span
-            className="flex items-center gap-1.5"
+          <IndicatorDot
+            tone={degraded ? 'fault' : 'live'}
+            label={degraded ? t('status.api_degraded') : t('status.api_active')}
             title={
               degraded
                 ? apiError ?? t('status.api_degraded_hint')
                 : t('status.api_active_hint')
             }
-          >
-            <span
-              className={`h-1.5 w-1.5 rounded-full ${degraded ? 'bg-red-400' : 'bg-emerald-400'}`}
-            />
-            {degraded ? t('status.api_degraded') : t('status.api_active')}
-          </span>
+          />
         )}
-        <span className="flex items-center gap-1.5">
-          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-          {t('status.events_live')}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-          {t('status.analysis_live')}
-        </span>
+        <IndicatorDot
+          tone={botT}
+          label={t(BOT_LABEL[bot.state])}
+          title={botTitle}
+        />
       </span>
     </footer>
   )

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -560,12 +560,18 @@
   },
   "status": {
     "connected": "Connected",
-    "events_live": "Events: Live",
-    "analysis_live": "Analysis: Live",
     "api_active": "Online API: Live",
     "api_degraded": "Online API: Offline",
     "api_active_hint": "The built-in bot is using the online inference API.",
-    "api_degraded_hint": "The online inference API is unreachable — the built-in bot is using the local model instead."
+    "api_degraded_hint": "The online inference API is unreachable — the built-in bot is using the local model instead.",
+    "connecting": "Connecting…",
+    "disconnected": "Disconnected",
+    "capture_error": "Capture error",
+    "bot_idle": "Bot: Idle",
+    "bot_loading": "Bot: Loading",
+    "bot_ready": "Bot: Ready",
+    "bot_error": "Bot: Error",
+    "bot_stopped": "Bot: Stopped"
   },
   "platform": {
     "majsoul": "Mahjong Soul",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -560,12 +560,18 @@
   },
   "status": {
     "connected": "接続済み",
-    "events_live": "イベント: ライブ",
-    "analysis_live": "解析: ライブ",
     "api_active": "オンラインAPI: ライブ",
     "api_degraded": "オンラインAPI: オフライン",
     "api_active_hint": "内蔵ボットはオンライン推論APIを使用しています。",
-    "api_degraded_hint": "オンライン推論APIに接続できません。内蔵ボットはローカルモデルを使用しています。"
+    "api_degraded_hint": "オンライン推論APIに接続できません。内蔵ボットはローカルモデルを使用しています。",
+    "connecting": "接続中…",
+    "disconnected": "未接続",
+    "capture_error": "キャプチャエラー",
+    "bot_idle": "Bot: 待機",
+    "bot_loading": "Bot: 読み込み中",
+    "bot_ready": "Bot: 準備完了",
+    "bot_error": "Bot: エラー",
+    "bot_stopped": "Bot: 停止"
   },
   "platform": {
     "majsoul": "雀魂",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -560,12 +560,18 @@
   },
   "status": {
     "connected": "已连接",
-    "events_live": "事件：实时",
-    "analysis_live": "分析：实时",
     "api_active": "在线 API：实时",
     "api_degraded": "在线 API：离线",
     "api_active_hint": "内建 Bot 正在使用在线推理 API。",
-    "api_degraded_hint": "无法连接到在线推理 API —— 内建 Bot 已改用本地模型。"
+    "api_degraded_hint": "无法连接到在线推理 API —— 内建 Bot 已改用本地模型。",
+    "connecting": "连接中…",
+    "disconnected": "未连接",
+    "capture_error": "捕获错误",
+    "bot_idle": "Bot：待命",
+    "bot_loading": "Bot：加载中",
+    "bot_ready": "Bot：就绪",
+    "bot_error": "Bot：错误",
+    "bot_stopped": "Bot：已停止"
   },
   "platform": {
     "majsoul": "雀魂",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -560,12 +560,18 @@
   },
   "status": {
     "connected": "已連線",
-    "events_live": "事件：即時",
-    "analysis_live": "分析：即時",
     "api_active": "線上 API：即時",
     "api_degraded": "線上 API：離線",
     "api_active_hint": "內建 Bot 正在使用線上推論 API。",
-    "api_degraded_hint": "無法連線到線上推論 API —— 內建 Bot 已改用本機模型。"
+    "api_degraded_hint": "無法連線到線上推論 API —— 內建 Bot 已改用本機模型。",
+    "connecting": "連線中…",
+    "disconnected": "未連線",
+    "capture_error": "擷取錯誤",
+    "bot_idle": "Bot：待命",
+    "bot_loading": "Bot：載入中",
+    "bot_ready": "Bot：就緒",
+    "bot_error": "Bot：錯誤",
+    "bot_stopped": "Bot：已停止"
   },
   "platform": {
     "majsoul": "雀魂",

--- a/frontend/src/lib/statusIndicators.ts
+++ b/frontend/src/lib/statusIndicators.ts
@@ -1,0 +1,85 @@
+import type { BotStatus, CaptureStatus } from '@/types'
+
+/**
+ * Visual tone for a status-bar indicator LED.
+ * - `live`    → green  (subsystem healthy / running)
+ * - `pending` → amber  (starting up, not yet live)
+ * - `off`     → gray   (cleanly stopped / never started)
+ * - `fault`   → red    (errored)
+ */
+export type IndicatorTone = 'live' | 'pending' | 'off' | 'fault'
+
+/** Tailwind dot background per tone. */
+export const TONE_DOT: Record<IndicatorTone, string> = {
+  live: 'bg-emerald-400',
+  pending: 'bg-amber-400',
+  off: 'bg-zinc-400',
+  fault: 'bg-red-400',
+}
+
+/**
+ * Capture-pipeline tone — "is Akagi reading the game?". Driven by the capture
+ * supervisor (`src/ipc/capture_supervisor.rs`). `starting` is reserved but not
+ * emitted today; both backends start synchronously and jump straight to
+ * `running`.
+ */
+export function captureTone(state: CaptureStatus['state']): IndicatorTone {
+  switch (state) {
+    case 'running':
+      return 'live'
+    case 'starting':
+      return 'pending'
+    case 'error':
+      return 'fault'
+    case 'stopped':
+      return 'off'
+    default: {
+      // Exhaustiveness guard: a new `CaptureStatus` state that isn't mapped
+      // fails `tsc -b` (which CI runs) — the regression net for "a capture
+      // state that no longer drives the LED".
+      const unreachable: never = state
+      return unreachable
+    }
+  }
+}
+
+/**
+ * Bot tone — "is the recommendation engine up?". A separate signal from
+ * capture: the bot can error (broken env, failed spawn) while capture is
+ * happily running, so it gets its own LED.
+ */
+export function botTone(state: BotStatus['state']): IndicatorTone {
+  switch (state) {
+    case 'ready':
+      return 'live'
+    case 'loading':
+      return 'pending'
+    case 'error':
+      return 'fault'
+    case 'idle':
+    case 'stopped':
+      return 'off'
+    default: {
+      const unreachable: never = state
+      return unreachable
+    }
+  }
+}
+
+/** i18n key for the capture LED's label, keyed by tone. */
+export const CAPTURE_LABEL: Record<IndicatorTone, string> = {
+  live: 'status.connected',
+  pending: 'status.connecting',
+  off: 'status.disconnected',
+  fault: 'status.capture_error',
+}
+
+/** i18n key for the bot LED's label, keyed by the raw bot state (idle and
+ * stopped share the `off` tone but read differently). */
+export const BOT_LABEL: Record<BotStatus['state'], string> = {
+  idle: 'status.bot_idle',
+  loading: 'status.bot_loading',
+  ready: 'status.bot_ready',
+  error: 'status.bot_error',
+  stopped: 'status.bot_stopped',
+}

--- a/frontend/src/routes/Setup.tsx
+++ b/frontend/src/routes/Setup.tsx
@@ -43,6 +43,11 @@ const BOT_4P_NAME = 'mortal'
 const BOT_3P_NAME = 'mortal3p'
 const BOT_4P_ASSET = 'release4p.zip'
 const BOT_3P_ASSET = 'release3p.zip'
+// Reserved names of the built-in, pure-Rust bots (see `src/bot/native.rs`).
+// Always available (weights are embedded in the binary), so a native active bot
+// is a working assistant — the wizard must not report "no bot / no analysis".
+const NATIVE_4P_NAME = 'akagi-native'
+const NATIVE_3P_NAME = 'akagi-native3p'
 
 export function Setup() {
   const { t } = useTranslation()
@@ -922,13 +927,20 @@ function FinishStep({ draft }: { draft: AppConfig }) {
   }, [])
   const has4p = installed?.some((b) => b.name === BOT_4P_NAME) ?? false
   const has3p = installed?.some((b) => b.name === BOT_3P_NAME) ?? false
-  const botSummary = has4p && has3p
-    ? `${BOT_4P_NAME} (4P), ${BOT_3P_NAME} (3P)`
-    : has4p
-      ? `${BOT_4P_NAME} (4P)`
-      : has3p
-        ? `${BOT_3P_NAME} (3P)`
-        : t('setup.finish.bots_none')
+  // Mirror what `finish()` actually persists: prefer the author Mortal bot when
+  // installed, otherwise keep the configured active bot (which defaults to the
+  // built-in native bot). A native active bot is a working assistant, so the
+  // summary must reflect it instead of claiming analysis is unavailable.
+  const eff4p = has4p ? BOT_4P_NAME : draft.bot.active_4p
+  const eff3p = has3p ? BOT_3P_NAME : draft.bot.active_3p
+  const botLabel = (name: string) =>
+    name === NATIVE_4P_NAME || name === NATIVE_3P_NAME ? t('bots.native_builtin') : name
+  const botParts = [
+    eff4p ? `${botLabel(eff4p)} (4P)` : null,
+    eff3p ? `${botLabel(eff3p)} (3P)` : null,
+  ].filter((p): p is string => p !== null)
+  const botSummary =
+    botParts.length > 0 ? botParts.join(', ') : t('setup.finish.bots_none')
   return (
     <div className="grid gap-3">
       <h2 className="text-lg font-semibold">{t('setup.finish.title')}</h2>

--- a/src/capture/chromium/detect.rs
+++ b/src/capture/chromium/detect.rs
@@ -182,6 +182,9 @@ fn detect_into(found: &mut Vec<DetectedBrowser>) {
 }
 
 #[cfg(target_os = "windows")]
+use crate::util::NoConsoleWindow;
+
+#[cfg(target_os = "windows")]
 fn reg_query_app_paths(exe: &str) -> Option<PathBuf> {
     let key = format!(
         "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\{}",
@@ -189,6 +192,7 @@ fn reg_query_app_paths(exe: &str) -> Option<PathBuf> {
     );
     let out = std::process::Command::new("reg")
         .args(["query", &key, "/ve"])
+        .no_console_window()
         .output()
         .ok()?;
     if !out.status.success() {

--- a/src/capture/chromium/launch.rs
+++ b/src/capture/chromium/launch.rs
@@ -16,6 +16,8 @@ use std::path::Path;
 use std::time::Duration;
 use tokio::process::{Child, Command};
 use tracing::{debug, warn};
+#[cfg(windows)]
+use crate::util::NoConsoleWindow;
 
 const DEVTOOLS_FILE: &str = "DevToolsActivePort";
 const PORT_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -317,6 +319,7 @@ pub async fn terminate(child: &mut Child) {
                 .args(["/PID", &pid.to_string()])
                 .stderr(std::process::Stdio::null())
                 .stdout(std::process::Stdio::null())
+                .no_console_window()
                 .status();
         }
     }

--- a/src/capture/chromium/mod.rs
+++ b/src/capture/chromium/mod.rs
@@ -80,14 +80,15 @@ impl CaptureBackend for ChromiumBackend {
         let profile_dir = profile::resolve_profile_dir(&self.cfg.user_data_dir)?;
         std::fs::create_dir_all(&profile_dir)
             .with_context(|| format!("creating chromium profile dir {}", profile_dir.display()))?;
-        // If a browser we previously launched is still running with this
-        // profile (e.g. the user closed Akagi but left Chrome open), terminate
-        // it before relaunching. Spawning a second `--user-data-dir` instance
-        // while the first is alive only opens a duplicate tab in it and then
-        // exits, leaving capture with no DevTools endpoint. (Two Akagi
-        // instances against one profile is unsupported.) `reclaim_singleton`
-        // blocks while waiting for the owner to exit, so run it off the async
-        // runtime.
+        // A browser we previously launched may still be running with this
+        // profile (e.g. the user closed Akagi but left Chrome open). Spawning a
+        // second `--user-data-dir` instance while the first is alive only opens
+        // a duplicate tab in it and then exits, leaving capture with no DevTools
+        // endpoint. (Two Akagi instances against one profile is unsupported.)
+        // `reclaim_singleton` finds and terminates that browser before we
+        // relaunch — via the `SingletonLock` symlink on Unix, or, on Windows
+        // (where Chrome writes no such file), by matching its command-line
+        // `--user-data-dir`. It blocks, so run it off the async runtime.
         {
             let pd = profile_dir.clone();
             tokio::task::spawn_blocking(move || profile::reclaim_singleton(&pd))

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -24,6 +24,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 #[cfg(windows)]
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+#[cfg(windows)]
+use crate::util::NoConsoleWindow;
 use tracing::{debug, info, warn};
 
 /// How long to wait for a polite SIGTERM/`taskkill` to take effect before
@@ -303,6 +305,7 @@ fn process_alive_windows(pid: u32) -> bool {
     // line if the PID is gone. Avoids pulling in `windows-sys` for one syscall.
     let out = match std::process::Command::new("tasklist")
         .args(["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"])
+        .no_console_window()
         .output()
     {
         Ok(o) => o,
@@ -320,6 +323,7 @@ fn terminate_pid_windows(pid: u32) -> bool {
         .args(["/PID", &pid.to_string()])
         .stderr(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
+        .no_console_window()
         .status();
     if wait_until_dead_windows(pid, TERM_GRACE) {
         return true;
@@ -329,6 +333,7 @@ fn terminate_pid_windows(pid: u32) -> bool {
         .args(["/F", "/PID", &pid.to_string()])
         .stderr(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
+        .no_console_window()
         .status();
     wait_until_dead_windows(pid, KILL_GRACE)
 }

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -22,6 +22,8 @@
 use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+#[cfg(windows)]
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 use tracing::{debug, info, warn};
 
 /// How long to wait for a polite SIGTERM/`taskkill` to take effect before
@@ -59,10 +61,81 @@ pub fn resolve_profile_dir(configured: &str) -> Result<PathBuf> {
 /// Blocking (it may sleep while waiting for the owner to exit); call it off
 /// the async runtime via `spawn_blocking`.
 pub fn reclaim_singleton(profile: &Path) -> Result<()> {
+    // On Windows, Chrome writes no `SingletonLock` file (it uses a named mutex +
+    // hidden message window), so the lock-file path below can't see a surviving
+    // controlled browser — a second `--user-data-dir` launch would just open a
+    // duplicate tab in it, leaving our relaunch with no DevTools endpoint. So on
+    // Windows we locate that browser by its command-line `--user-data-dir` and
+    // terminate it first. On Unix, Chrome *does* write SingletonLock, so
+    // `reclaim_singleton_inner` already handles the live owner — that proven
+    // path is left untouched (this block is compiled out on non-Windows).
+    #[cfg(windows)]
+    {
+        if let Some(pid) = find_controlled_browser_pid(profile) {
+            info!(
+                "terminating existing controlled chromium pid {pid} to reclaim profile {}",
+                profile.display()
+            );
+            if !terminate_pid_windows(pid) {
+                return Err(anyhow!(
+                    "couldn't terminate the browser already using profile {} (pid {pid}) — \
+                     close it manually and click Restart",
+                    profile.display()
+                ));
+            }
+        }
+    }
     if !profile.exists() {
-        return Ok(()); // fresh dir, nothing to clean
+        return Ok(()); // fresh dir, nothing else to clean
     }
     reclaim_singleton_inner(profile)
+}
+
+/// True when a process with this `name` and command-line `cmd` is the **browser
+/// process** of the controlled Chromium for `profile`: it carries our
+/// `--user-data-dir=<profile>` and is not a `--type=…` renderer/GPU child
+/// (killing the browser process takes its children down with it). Pure so the
+/// matching is unit-testable without a live browser.
+///
+/// Windows-only: this is the reclaim mechanism there because Chrome writes no
+/// SingletonLock file. Unix uses the lock symlink instead (see module docs).
+#[cfg(windows)]
+fn is_controlled_browser(name: &str, cmd: &[String], profile: &Path) -> bool {
+    let name = name.to_ascii_lowercase();
+    if !name.contains("chrome") && !name.contains("chromium") {
+        return false;
+    }
+    let needle = format!("--user-data-dir={}", profile.display());
+    let has_profile = cmd.iter().any(|a| a.contains(needle.as_str()));
+    let is_child = cmd.iter().any(|a| a.starts_with("--type="));
+    has_profile && !is_child
+}
+
+/// Find the PID of the controlled Chromium **browser** process for `profile`,
+/// if one is still running, by matching the process command line via `sysinfo`.
+/// Windows-only (Unix reclaims via the SingletonLock symlink instead).
+#[cfg(windows)]
+fn find_controlled_browser_pid(profile: &Path) -> Option<u32> {
+    let mut sys = System::new();
+    // The default refresh does NOT fetch the command line; ask for it
+    // explicitly (that's what we match `--user-data-dir` against).
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always),
+    );
+    for proc in sys.processes().values() {
+        let name = proc.name().to_string_lossy();
+        let cmd: Vec<String> = proc
+            .cmd()
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        if is_controlled_browser(name.as_ref(), &cmd, profile) {
+            return Some(proc.pid().as_u32());
+        }
+    }
+    None
 }
 
 /// Best-effort removal of the three singleton marker files. A clean browser
@@ -309,6 +382,90 @@ mod tests {
     fn reclaim_no_lock_is_ok() {
         let dir = tempfile::tempdir().unwrap();
         reclaim_singleton(dir.path()).unwrap();
+    }
+
+    /// Regression for the Windows duplicate-tab / DevToolsActivePort-timeout
+    /// bug: the surviving controlled browser must be identified by its
+    /// command-line `--user-data-dir` (Chrome writes no SingletonLock on
+    /// Windows), matching the browser process but not its renderer children or
+    /// an unrelated Chrome on a different profile.
+    #[cfg(windows)]
+    #[test]
+    fn is_controlled_browser_matches_browser_not_children() {
+        let profile = Path::new(if cfg!(windows) {
+            r"C:\p\chrome-profile"
+        } else {
+            "/p/chrome-profile"
+        });
+        let udir = format!("--user-data-dir={}", profile.display());
+
+        // Browser process: our --user-data-dir, no --type.
+        assert!(is_controlled_browser(
+            "chrome.exe",
+            &[udir.clone(), "--remote-debugging-port=1234".into()],
+            profile
+        ));
+        assert!(is_controlled_browser("chromium", &[udir.clone()], profile));
+
+        // Renderer/GPU child: has --type → not the process we target directly.
+        assert!(!is_controlled_browser(
+            "chrome.exe",
+            &[udir.clone(), "--type=renderer".into()],
+            profile
+        ));
+
+        // A chrome using a *different* profile is not ours.
+        let other = format!(
+            "--user-data-dir={}",
+            Path::new(if cfg!(windows) { r"C:\other" } else { "/other" }).display()
+        );
+        assert!(!is_controlled_browser("chrome.exe", &[other], profile));
+
+        // A non-chrome process is never matched, even with the arg.
+        assert!(!is_controlled_browser("firefox", &[udir], profile));
+    }
+
+    /// Real end-to-end check (run with `--ignored` and `AKAGI_TEST_CHROME` set
+    /// to a chrome/chromium binary): launch an actual headless browser with a
+    /// temp profile, confirm `find_controlled_browser_pid` locates it via the
+    /// live process command line (exercising the sysinfo `with_cmd` refresh),
+    /// and that `reclaim_singleton` terminates it. Skipped when the env var is
+    /// unset so CI without a browser stays green.
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "needs a real browser binary via AKAGI_TEST_CHROME"]
+    fn find_and_reclaim_real_browser() {
+        let Ok(chrome) = std::env::var("AKAGI_TEST_CHROME") else {
+            eprintln!("AKAGI_TEST_CHROME not set; skipping");
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path();
+        let mut child = std::process::Command::new(&chrome)
+            .arg(format!("--user-data-dir={}", profile.display()))
+            .arg("--remote-debugging-port=0")
+            .arg("--headless=new")
+            .arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .spawn()
+            .expect("spawn browser");
+        std::thread::sleep(Duration::from_secs(3));
+
+        let found = find_controlled_browser_pid(profile);
+        assert!(
+            found.is_some(),
+            "find_controlled_browser_pid should locate the browser by its command line"
+        );
+
+        reclaim_singleton(profile).expect("reclaim should terminate the browser");
+        std::thread::sleep(Duration::from_millis(500));
+        assert!(
+            find_controlled_browser_pid(profile).is_none(),
+            "browser should be gone after reclaim"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[cfg(unix)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -68,6 +68,29 @@ fn resolve_dir_inner(configured: &Path, appimage: bool, user_root: Option<PathBu
     exe_candidate.unwrap_or(cwd_candidate)
 }
 
+/// Extension for [`std::process::Command`] that stops Windows from briefly
+/// flashing a console window when the GUI app spawns a console helper
+/// (`tasklist`, `taskkill`, `reg`, …). Chainable and a **no-op off Windows**:
+///
+/// ```ignore
+/// Command::new("tasklist").args(["/FI", filter]).no_console_window().output()
+/// ```
+pub trait NoConsoleWindow {
+    fn no_console_window(&mut self) -> &mut Self;
+}
+
+impl NoConsoleWindow for std::process::Command {
+    fn no_console_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            // CREATE_NO_WINDOW: the child gets no console, so no window flashes.
+            self.creation_flags(0x0800_0000);
+        }
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/bot_lifecycle.rs
+++ b/tests/bot_lifecycle.rs
@@ -119,7 +119,7 @@ async fn loading_emits_syncing_then_spawning_then_ready() {
     let mut notify_rx = notify.subscribe();
 
     let mut mgr = BotManager::new(
-        runtime,
+        Some(runtime),
         registry_root.path().to_path_buf(),
         cfg_with("echo"),
         response_bus,
@@ -210,7 +210,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
         let status_bus = bot_status_bus();
         let notify = notify_bus();
         let mut mgr = BotManager::new(
-            runtime.clone(),
+            Some(runtime.clone()),
             registry_root.path().to_path_buf(),
             cfg_with("echo"),
             response_bus,
@@ -241,7 +241,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
     let notify = notify_bus();
     let mut status_rx = status_bus.subscribe();
     let mut mgr = BotManager::new(
-        runtime,
+        Some(runtime),
         registry_root.path().to_path_buf(),
         cfg_with("echo"),
         response_bus,


### PR DESCRIPTION
Batch of bug fixes for the v3.3 line, found and fixed together. Each is an independent, self-contained commit.

## Fixes

### 1. Statusbar LEDs reflect real state (`1b56fd5`)
The footer's Connected / Events / Analysis dots were hardcoded green placeholders wired to nothing — they never reflected a capture error or a bot failure. Replaced the three redundant dots with two independent LEDs driven by live state:
- **Capture** ← capture pipeline state (running / starting / error / stopped).
- **Bot** ← bot runner state (ready / loading / error / idle / stopped).

Each maps to a tone (green / amber / gray / red) via pure functions with a `never` exhaustiveness guard, and the capture descriptor (or the error message on failure) is shown as a hover tooltip. Capture and bot are independent subsystems, so a bot failure now shows red instead of the whole bar staying green.

### 2. Setup wizard Finish step recognizes the built-in bot (`5125d11`)
The wizard's final summary only recognized the author Mortal bot and showed "Bot: none — analysis unavailable" when it wasn't installed, ignoring the built-in native bot that is the zero-install default. The saved config was already correct, so this was a misleading display only. The summary now reflects the effective active bots the wizard actually persists.

### 3. Chromium reopen no longer duplicates a tab + Capture Error (`a94f764`)
Reopening while the controlled Chromium was still running (the app was closed but the browser left open) opened a duplicate tab and failed capture with a 15s `DevToolsActivePort` timeout. Root cause: the reclaim step reads Chrome's `SingletonLock` file, which Chrome does not create on Windows (it uses a named mutex + hidden message window), so reclaim was a no-op there. On Windows the surviving browser is now located by its command line (the process carrying our `--user-data-dir` and no `--type=` child flag) via `sysinfo` and terminated before relaunch. Unix keeps its existing, tested `SingletonLock` path — the `sysinfo` code and dependency are gated to Windows.

### 4. Fix compile break in the bot-lifecycle test (`0a05119`)
`BotManager::new` takes `Option<PythonRuntime>` since the built-in-bot work, but the integration test still passed a bare `PythonRuntime`, which broke compilation of the whole test suite. Wrapped the call sites in `Some(...)`.

### 5. No console-window flash from Windows helpers (`4341b54`)
Opening Settings (browser detection via `reg`) and reopening with a leftover Chromium (reclaim via `tasklist` / `taskkill`), plus stopping capture (`taskkill`), each briefly flashed a console window on Windows. Added a chainable `no_console_window()` `Command` extension (`CREATE_NO_WINDOW` on Windows, a no-op elsewhere) and applied it to those spawns.

## Testing
- Rust: `cargo test` for the affected modules, including an `#[ignore]`d real-browser integration test that verifies the Windows reclaim actually finds + terminates a live browser.
- Frontend: `tsc -b` + `eslint` clean.
- Manual: statusbar LEDs, the setup-wizard summary, Chromium reopen, and the console-flash fixes were each verified in a build.
