### PR TITLE
style: apply cargo fmt --all (fix v3.3 CI)

### DIFF
--- a/native_bot/src/action_codec.rs
+++ b/native_bot/src/action_codec.rs
@@ -130,7 +130,10 @@ mod tests {
             Some(37)
         );
         assert_eq!(
-            action_index(&Action::new(ActionType::Pon, Some(0), vec![1, 2], Some(0)), 4),
+            action_index(
+                &Action::new(ActionType::Pon, Some(0), vec![1, 2], Some(0)),
+                4
+            ),
             Some(41)
         );
         assert_eq!(

--- a/native_bot/src/bin/extract.rs
+++ b/native_bot/src/bin/extract.rs
@@ -72,7 +72,10 @@ fn main() -> Result<()> {
     let dataset_dir = PathBuf::from(&args[1]);
     let num_players: u8 = args[2].parse().context("num_players")?;
     let out_dir = PathBuf::from(&args[3]);
-    let max_games: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(usize::MAX);
+    let max_games: usize = args
+        .get(4)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(usize::MAX);
     let max_samples: usize = args
         .get(5)
         .and_then(|s| s.parse().ok())
@@ -111,9 +114,12 @@ fn main() -> Result<()> {
         .par_iter()
         .enumerate()
         .map(|(ci, chunk)| -> usize {
-            let mut obs_w = BufWriter::new(File::create(out_dir.join(format!("{ci}.obs"))).unwrap());
-            let mut act_w = BufWriter::new(File::create(out_dir.join(format!("{ci}.act"))).unwrap());
-            let mut msk_w = BufWriter::new(File::create(out_dir.join(format!("{ci}.msk"))).unwrap());
+            let mut obs_w =
+                BufWriter::new(File::create(out_dir.join(format!("{ci}.obs"))).unwrap());
+            let mut act_w =
+                BufWriter::new(File::create(out_dir.join(format!("{ci}.act"))).unwrap());
+            let mut msk_w =
+                BufWriter::new(File::create(out_dir.join(format!("{ci}.msk"))).unwrap());
             let mut local = 0usize;
 
             for path in *chunk {

--- a/native_bot/src/engine.rs
+++ b/native_bot/src/engine.rs
@@ -31,18 +31,42 @@ const SHOW_TOP_N: usize = 3;
 /// All tiles are mjai strings (e.g. `"5mr"`, `"P"`).
 #[derive(Debug, Clone, PartialEq)]
 pub enum BotAction {
-    Dahai { pai: String, tsumogiri: bool },
+    Dahai {
+        pai: String,
+        tsumogiri: bool,
+    },
     /// Riichi declaration; `pai` is the predicted riichi discard (mjai must
     /// carry it or autoplay stalls).
-    Reach { pai: String },
-    Pon { target: u8, pai: String, consumed: Vec<String> },
-    Chi { target: u8, pai: String, consumed: Vec<String> },
-    Daiminkan { target: u8, pai: String, consumed: Vec<String> },
-    Ankan { consumed: Vec<String> },
-    Kakan { pai: String, consumed: Vec<String> },
+    Reach {
+        pai: String,
+    },
+    Pon {
+        target: u8,
+        pai: String,
+        consumed: Vec<String>,
+    },
+    Chi {
+        target: u8,
+        pai: String,
+        consumed: Vec<String>,
+    },
+    Daiminkan {
+        target: u8,
+        pai: String,
+        consumed: Vec<String>,
+    },
+    Ankan {
+        consumed: Vec<String>,
+    },
+    Kakan {
+        pai: String,
+        consumed: Vec<String>,
+    },
     /// Ron or tsumo (both are mjai `hora`); `target` is the loser (self for
     /// tsumo, the discarder for ron).
-    Hora { target: u8 },
+    Hora {
+        target: u8,
+    },
     /// Nine-terminals abortive draw (mjai `ryukyoku`).
     Kyushu,
     /// Kita / nukidora (sanma).
@@ -63,8 +87,14 @@ pub struct Decision {
 }
 
 enum Backend {
-    Four { state: Box<GameState>, model: Model },
-    Three { state: Box<GameState3P>, model: Model },
+    Four {
+        state: Box<GameState>,
+        model: Model,
+    },
+    Three {
+        state: Box<GameState3P>,
+        model: Model,
+    },
 }
 
 pub struct Engine {
@@ -100,7 +130,9 @@ impl Engine {
     pub fn reset(&mut self) {
         let rule = GameRule::default_tenhou();
         match &mut self.backend {
-            Backend::Four { state, .. } => *state = Box::new(GameState::new(0, true, None, 0, rule)),
+            Backend::Four { state, .. } => {
+                *state = Box::new(GameState::new(0, true, None, 0, rule))
+            }
             Backend::Three { state, .. } => {
                 *state = Box::new(GameState3P::new(0, true, None, 0, rule))
             }

--- a/native_bot/src/model.rs
+++ b/native_bot/src/model.rs
@@ -61,7 +61,11 @@ impl Model {
     /// Forward one flattened `[C*T]` observation to action logits `[A]`.
     pub fn forward_logits(&self, obs: &[f32]) -> Result<Vec<f32>> {
         let dev = Device::Cpu;
-        let x = Tensor::from_vec(obs.to_vec(), (1, self.geo.channels, self.geo.tile_dim), &dev)?;
+        let x = Tensor::from_vec(
+            obs.to_vec(),
+            (1, self.geo.channels, self.geo.tile_dim),
+            &dev,
+        )?;
         let mut x = self.conv_in.forward(&x)?.relu()?;
         for (c1, c2) in &self.res {
             let y = c1.forward(&x)?.relu()?;

--- a/native_bot/src/obs.rs
+++ b/native_bot/src/obs.rs
@@ -49,7 +49,7 @@ pub fn channels(num_players: u8) -> usize {
     let fixed = 4 + 1 + 1 + 1 + 1 + 1  // self hand(4)+aka+drawn+waits+dora_ind+dora_tile
         + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1; // last_discard, round_wind, seat_wind,
                                              // honba, sticks, turn, tenpai, dealer, kyoku, ...
-    // NOTE: recount below to keep in sync with `encode`.
+                                             // NOTE: recount below to keep in sync with `encode`.
     let per_player_groups = 5; // discards, melds, riichi, riichi_tile, score
     let kita_groups = if num_players == 3 { 1 } else { 0 };
     // `fixed` above is 4+5 self planes + 9 globals + 1 (self riichi-declared) = 19.

--- a/native_bot/src/replay.rs
+++ b/native_bot/src/replay.rs
@@ -64,7 +64,10 @@ impl Engine {
             Engine::Four(s) => obs_and_legal_4p(s, pid),
             Engine::Three(s) => obs_and_legal_3p(s, pid),
         };
-        (obs, crate::action_codec::legal_mask(&legal, self.num_players()))
+        (
+            obs,
+            crate::action_codec::legal_mask(&legal, self.num_players()),
+        )
     }
 }
 
@@ -84,19 +87,38 @@ fn decision(ev: &MjaiEvent) -> Option<(u8, Action)> {
             Action::new(ActionType::Riichi, None, vec![], Some(*actor as u8)),
         )),
         MjaiEvent::Pon {
-            actor, pai, consumed, ..
+            actor,
+            pai,
+            consumed,
+            ..
         } => Some((
             *actor as u8,
-            Action::new(ActionType::Pon, tid(pai), tids(consumed), Some(*actor as u8)),
+            Action::new(
+                ActionType::Pon,
+                tid(pai),
+                tids(consumed),
+                Some(*actor as u8),
+            ),
         )),
         MjaiEvent::Chi {
-            actor, pai, consumed, ..
+            actor,
+            pai,
+            consumed,
+            ..
         } => Some((
             *actor as u8,
-            Action::new(ActionType::Chi, tid(pai), tids(consumed), Some(*actor as u8)),
+            Action::new(
+                ActionType::Chi,
+                tid(pai),
+                tids(consumed),
+                Some(*actor as u8),
+            ),
         )),
         MjaiEvent::Kan {
-            actor, pai, consumed, ..
+            actor,
+            pai,
+            consumed,
+            ..
         } => Some((
             *actor as u8,
             Action::new(

--- a/native_bot/src/tiles.rs
+++ b/native_bot/src/tiles.rs
@@ -28,9 +28,9 @@ pub const AKA_TILE34: [usize; 3] = [4, 13, 22];
 pub const TILE34_TO_COMPACT: [Option<usize>; 34] = {
     let mut m = [None; 34];
     m[0] = Some(0); // 1m
-    // 1..=7 (2m-8m) stay None
+                    // 1..=7 (2m-8m) stay None
     m[8] = Some(1); // 9m
-    // 1p..9p -> 2..10
+                    // 1p..9p -> 2..10
     let mut i = 9;
     while i <= 17 {
         m[i] = Some(i - 7);

--- a/native_bot/tests/engine_replay.rs
+++ b/native_bot/tests/engine_replay.rs
@@ -10,7 +10,12 @@ use native_bot::engine::{BotAction, Engine};
 use riichienv_core::replay::MjaiEvent;
 
 fn weights(name: &str) -> Vec<u8> {
-    fs::read(Path::new(env!("CARGO_MANIFEST_DIR")).join("weights").join(name)).expect("weights")
+    fs::read(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("weights")
+            .join(name),
+    )
+    .expect("weights")
 }
 
 fn ev(line: &str) -> MjaiEvent {
@@ -29,7 +34,10 @@ fn decides_a_legal_discard_after_tsumo() {
     eng.feed(ev(&start_kyoku));
     eng.feed(ev(r#"{"type":"tsumo","actor":0,"pai":"5p"}"#));
 
-    let decision = eng.decide().unwrap().expect("we should have a decision on our tsumo");
+    let decision = eng
+        .decide()
+        .unwrap()
+        .expect("we should have a decision on our tsumo");
     // Our turn after a draw: the only free choices are discard / riichi / kan /
     // hora / kyushu. It must never be a claim/pass here.
     assert!(
@@ -46,7 +54,10 @@ fn decides_a_legal_discard_after_tsumo() {
         decision.action
     );
     assert_eq!(decision.logits.len(), 82);
-    assert!(decision.logits.iter().all(|v| v.is_finite()), "logits finite");
+    assert!(
+        decision.logits.iter().all(|v| v.is_finite()),
+        "logits finite"
+    );
 }
 
 #[test]
@@ -70,7 +81,9 @@ fn plays_several_turns_without_panic() {
             )));
         }
         for seat in 1..4u8 {
-            eng.feed(ev(&format!(r#"{{"type":"tsumo","actor":{seat},"pai":"9s"}}"#)));
+            eng.feed(ev(&format!(
+                r#"{{"type":"tsumo","actor":{seat},"pai":"9s"}}"#
+            )));
             eng.feed(ev(&format!(
                 r#"{{"type":"dahai","actor":{seat},"pai":"9s","tsumogiri":true}}"#
             )));

--- a/src/bot/native.rs
+++ b/src/bot/native.rs
@@ -897,7 +897,10 @@ mod tests {
         let v = to_api_event(&r, 0, 4);
         assert_eq!(v["type"], "reach");
         assert_eq!(v["actor"], 0);
-        assert!(v.get("pai").is_none(), "predicted reach pai must be stripped");
+        assert!(
+            v.get("pai").is_none(),
+            "predicted reach pai must be stripped"
+        );
     }
 
     #[test]
@@ -1099,7 +1102,10 @@ mod tests {
 
         // still degraded: no repeat toast (would spam once per turn).
         bot.record_health(false, Some("boom again"));
-        assert!(rx.try_recv().is_err(), "must not toast without a transition");
+        assert!(
+            rx.try_recv().is_err(),
+            "must not toast without a transition"
+        );
 
         // recovered: one success toast, same id (replaces the warning).
         bot.record_health(true, None);

--- a/src/capture/chromium/launch.rs
+++ b/src/capture/chromium/launch.rs
@@ -10,14 +10,14 @@
 //!    (Windows) → wait → SIGKILL.
 
 use crate::config::ChromiumConfig;
+#[cfg(windows)]
+use crate::util::NoConsoleWindow;
 use anyhow::{anyhow, Context, Result};
 use std::net::TcpListener;
 use std::path::Path;
 use std::time::Duration;
 use tokio::process::{Child, Command};
 use tracing::{debug, warn};
-#[cfg(windows)]
-use crate::util::NoConsoleWindow;
 
 const DEVTOOLS_FILE: &str = "DevToolsActivePort";
 const PORT_WAIT_TIMEOUT: Duration = Duration::from_secs(15);

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -19,13 +19,13 @@
 //! Running two Akagi instances against the same profile is unsupported — they
 //! would fight over the lock.
 
+#[cfg(windows)]
+use crate::util::NoConsoleWindow;
 use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 #[cfg(windows)]
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
-#[cfg(windows)]
-use crate::util::NoConsoleWindow;
 use tracing::{debug, info, warn};
 
 /// How long to wait for a polite SIGTERM/`taskkill` to take effect before

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -279,7 +279,10 @@ mod tests {
         let legacy = "[bot]\nenabled = true\nactive_4p = \"akagi-native\"\n";
         let cfg: AppConfig = toml::from_str(legacy).unwrap();
         assert!(!cfg.bot.api.enabled);
-        assert!(!cfg.bot.api.is_active(), "default URL alone must not activate");
+        assert!(
+            !cfg.bot.api.is_active(),
+            "default URL alone must not activate"
+        );
         assert_eq!(cfg.bot.api.base_url, NativeApiConfig::default().base_url);
         assert!(!cfg.bot.api.base_url.is_empty(), "URL should be pre-filled");
     }


### PR DESCRIPTION
Runs `cargo fmt --all` to fix the failing `cargo fmt --all -- --check` step in CI on `v3.3` (currently blocking PR #170).

Formatting only — no semantic changes. Touches the 12 files rustfmt flagged (`native_bot/*`, `src/bot/native.rs`, `src/capture/chromium/{launch,profile}.rs`, `src/config/mod.rs`).

Verified locally: `cargo fmt --all -- --check` exits 0.