### PR TITLE
fix(config): derive Default for GeneralConfig (fix v3.3 clippy)

### DIFF
--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -1,18 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GeneralConfig {
     /// Set to `true` once the first-run setup wizard has finished.
     /// Existing pre-wizard configs default to `true` via migration so
     /// upgraded users don't see the wizard.
     pub first_run_completed: bool,
-}
-
-impl Default for GeneralConfig {
-    fn default() -> Self {
-        Self {
-            first_run_completed: false,
-        }
-    }
 }


### PR DESCRIPTION
Follow-up to the fmt fix. With formatting fixed, CI's clippy step (`cargo clippy --all-targets -- -D warnings`) ran for the first time on v3.3 and flagged `clippy::derivable_impls` at `src/config/general.rs:12`.

Removing the `language` field earlier left a manual `Default` impl that only sets the bool's own default, so clippy wants it derived. Derive `Default` instead — behaviour is identical (`first_run_completed` defaults to `false`).

Verified: `cargo fmt --all -- --check` still exits 0.