### PR TITLE
fix(i18n): label the online-API indicator "Connected", not "Live"

### DIFF
--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -606,7 +606,7 @@
   },
   "status": {
     "connected": "Connected",
-    "api_active": "Online API: Live",
+    "api_active": "Online API: Connected",
     "api_degraded": "Online API: Offline",
     "api_active_hint": "The built-in bot is using the online inference API.",
     "api_degraded_hint": "The online inference API is unreachable — the built-in bot is using the local model instead.",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -606,7 +606,7 @@
   },
   "status": {
     "connected": "接続済み",
-    "api_active": "オンラインAPI: ライブ",
+    "api_active": "オンラインAPI: 接続済み",
     "api_degraded": "オンラインAPI: オフライン",
     "api_active_hint": "内蔵ボットはオンライン推論APIを使用しています。",
     "api_degraded_hint": "オンライン推論APIに接続できません。内蔵ボットはローカルモデルを使用しています。",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -606,7 +606,7 @@
   },
   "status": {
     "connected": "已连接",
-    "api_active": "在线 API：实时",
+    "api_active": "在线 API：已连接",
     "api_degraded": "在线 API：离线",
     "api_active_hint": "内建 Bot 正在使用在线推理 API。",
     "api_degraded_hint": "无法连接到在线推理 API —— 内建 Bot 已改用本地模型。",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -606,7 +606,7 @@
   },
   "status": {
     "connected": "已連線",
-    "api_active": "線上 API：即時",
+    "api_active": "線上 API：已連線",
     "api_degraded": "線上 API：離線",
     "api_active_hint": "內建 Bot 正在使用線上推論 API。",
     "api_degraded_hint": "無法連線到線上推論 API —— 內建 Bot 已改用本機模型。",


### PR DESCRIPTION
## Problem

The statusbar's online-API indicator was labelled **`Online API: Live`**.

That indicator only renders when the built-in bot is *actually* routing
inference through the cloud API (native bot active + API enabled + URL + key).
So the label is a statement about **your own session**. But "Live" reads as a
claim about the **API server's health** — as in "the server is up" — which is
not what the indicator tracks.

## Fix

Rename the `status.api_active` label to "Connected" in all four locales:

| locale | before | after |
| --- | --- | --- |
| `en` | `Online API: Live` | `Online API: Connected` |
| `ja` | `オンラインAPI: ライブ` | `オンラインAPI: 接続済み` |
| `zh-CN` | `在线 API：实时` | `在线 API：已连接` |
| `zh-TW` | `線上 API：即時` | `線上 API：已連線` |

Each new value reuses the wording the same locale already uses for the sibling
`status.connected` key, so the phrasing stays internally consistent.

## Scope

Values only — **no keys added, renamed, or removed**, and no code change:

- `Statusbar.tsx` already renders `t('status.api_active')`.
- The `api_active_hint` tooltip already says "The built-in bot is using the
  online inference API", so it needed no adjustment.
- `status.api_degraded` (`Online API: Offline`) is left as-is — Connected /
  Offline still reads as a clean pair.

## Verification

- All four JSON resource files parse and return the new value.
- No test, README, or doc referenced the literal string `Online API: Live`.
- `tsc` skipped: keys are unchanged, so the generated resource type is
  identical.