### PR TITLE
feat(purchase): let the server redeem, so the emailed credential is the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,10 @@ Three ways, all from the **Cloud inference** card:
   server; the app only sends the product id. Once payment clears, the key is
   delivered back into the app and saved automatically — you can close the dialog
   while you pay, and a status chip leads you back. If delivery ever fails, the
-  key is also emailed to the address you gave at checkout.
+  key is also emailed to your PayPal address, so a purchase is never lost.
+  The one exception is buying with *Add the time to my current key* ticked:
+  that stacks the purchased days onto the key you already hold, so what arrives
+  by email is the prepaid **code** used to top it up, not a new key.
 - **Redeem code** — turn a prepaid code into a key, or add time to the key you
   already hold.
 - Ask in the [Discord server](https://discord.gg/Z2wjXUK8bN).

--- a/frontend/src/stores/purchaseStore.ts
+++ b/frontend/src/stores/purchaseStore.ts
@@ -9,6 +9,7 @@ import type { Product } from '@/lib/products'
 import type {
   CreatedOrder,
   CreatedSubscription,
+  KeyStatus,
   OrderResult,
   RedeemResponse,
   SubscriptionResult,
@@ -16,7 +17,20 @@ import type {
 
 // Drives the self-serve key purchase handshake (see the inference server's API documentation):
 // create → open approve_url in the browser → poll *-result every few seconds
-// → one-time: auto-redeem the code into a key / subscription: key directly.
+// → the key.
+//
+// How the key arrives depends on the purchase:
+//  - subscription           → the poll carries it directly.
+//  - one-time, new key      → `create-order` is sent `redeem: true`, so the
+//                             SERVER redeems the prepaid code and the poll
+//                             carries the key. The buyer's backup email then
+//                             holds the key too, not a one-time code the app
+//                             already spent (which reads like a credential and
+//                             is not one).
+//  - one-time, renewal      → `redeem: false`, because stacking time onto an
+//                             existing key needs the raw code: only
+//                             `/v3/redeem` accepts a `renew_key` target. This
+//                             is the one path that still redeems client-side.
 //
 // This lives in a store (not dialog state) so a purchase survives the dialog
 // — or the whole Settings page — unmounting while the buyer is off approving
@@ -40,7 +54,7 @@ export type PurchasePhase =
   | 'idle'
   | 'creating' // create-order / create-subscription in flight
   | 'approving' // buyer is on PayPal; polling *-result
-  | 'redeeming' // one-time only: code arrived, /v3/redeem in flight
+  | 'redeeming' // client-side redeem in flight: code arrived, /v3/redeem running
   | 'redeem_failed' // /v3/redeem failed — code is safe and shown for retry
   | 'done' // key minted / key extended
   | 'delivered' // retrieval window passed — code/key was emailed
@@ -188,14 +202,48 @@ export const usePurchaseStore = create<PurchaseStore>((set, get) => {
     }
   }
 
+  /** `redeem: true` orders resolve server-side, so the poll has no expiry to
+   *  report (unlike `/v3/redeem`, which returns `expires_at`). Ask the server
+   *  for it after the fact. Strictly cosmetic: the key is already delivered
+   *  and saved by the time this runs, so a failure costs only the date line. */
+  const fillExpiry = async (gen: number, key: string) => {
+    try {
+      const st = await invoke<KeyStatus>('native_api_key_status', {
+        baseUrl: get().baseUrl,
+        key,
+      })
+      if (gen !== generation) return
+      if (st.expires_at) set({ until: st.expires_at })
+    } catch {
+      /* the key is in hand; the "valid until" line is optional */
+    }
+  }
+
   const handleOrderResult = (gen: number, r: OrderResult) => {
     switch (r.status) {
       case 'pending':
         return schedulePoll(gen)
-      case 'ready':
-        set({ code: r.code ?? null, plan: r.plan ?? get().plan })
-        if (!r.code) return fail('claim', 'server returned ready without a code')
-        return void redeemCode(gen)
+      case 'ready': {
+        set({ plan: r.plan ?? get().plan })
+        // A key means the server already redeemed the code (`redeem: true`).
+        // Take it and stop: that code is spent, and handing it to /v3/redeem
+        // would fail as already-used. Checked before `code` so a server that
+        // ever returned both can't make us burn a key we already hold.
+        if (r.key) {
+          const key = r.key
+          deliverKey(key, r.plan ?? get().plan, null)
+          void fillExpiry(gen, key)
+          return
+        }
+        // Otherwise the classic flow: a renewal (we asked for the code so we
+        // can aim /v3/redeem at `renewKey`), or an older server that ignored
+        // the `redeem` flag — both redeem client-side from here.
+        if (r.code) {
+          set({ code: r.code })
+          return void redeemCode(gen)
+        }
+        return fail('claim', 'server returned ready without a key or code')
+      }
       case 'delivered':
         clearTimer()
         return set({ phase: 'delivered' })
@@ -282,12 +330,13 @@ export const usePurchaseStore = create<PurchaseStore>((set, get) => {
       pollDelay = POLL_MS
       startedAt = Date.now()
       activeIds = null
+      const renewKey = opts.product.kind === 'onetime' ? (opts.renewKey?.trim() || null) : null
       set({
         ...initial,
         phase: 'creating',
         product: opts.product,
         baseUrl: opts.baseUrl,
-        renewKey: opts.product.kind === 'onetime' ? (opts.renewKey?.trim() || null) : null,
+        renewKey,
       })
       void (async () => {
         try {
@@ -295,6 +344,10 @@ export const usePurchaseStore = create<PurchaseStore>((set, get) => {
             const o = await invoke<CreatedOrder>('native_api_create_order', {
               baseUrl: opts.baseUrl,
               product: opts.product.id,
+              // Let the server redeem, unless we need the code itself to aim
+              // /v3/redeem at an existing key. Server-side redeem is what puts
+              // the KEY in the buyer's backup email instead of a spent code.
+              redeem: renewKey === null,
             })
             if (gen !== generation) return
             activeIds = { orderId: o.order_id, claim: o.claim_secret }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -187,10 +187,16 @@ export type CreatedSubscription = {
   claim_secret: string
 }
 
-/** One poll of `POST /paypal/order-result`. `code` only on `status: ready`. */
+/**
+ * One poll of `POST /paypal/order-result`. On `status: ready` exactly one of
+ * `key` / `code` is set: `key` when the order was created with `redeem: true`
+ * (the server already spent the code), `code` otherwise. Branch on whichever
+ * is present — never re-redeem a code that came back alongside a key.
+ */
 export type OrderResult = {
   status: string
   code?: string | null
+  key?: string | null
   plan?: string | null
   days?: number | null
 }

--- a/src/bot/README.md
+++ b/src/bot/README.md
@@ -72,11 +72,18 @@ bridge to them.
 - `purchase` — the unauthenticated PayPal handshake used by the in-app "Buy
   key" flow: `create_order` / `create_subscription` return an `approve_url`
   plus a `claim_secret`, and `order_result` / `subscription_result` poll with
-  that secret until the server hands back a redeem code (one-time) or a key
-  (subscription). Prices are server-owned — only the product id crosses the
-  wire, and no client secret is embedded in the binary. Stateless like `api`;
-  the polling state machine lives in the frontend's purchase store, driven
-  through the `native_api_*` IPC commands.
+  that secret until the server hands back a key. `create_order` takes a
+  `redeem` flag: with `true` the server redeems the prepaid code into a key
+  itself, so the poll — and the buyer's backup email — carry the key rather
+  than a one-time code the app has already spent. Pass `false` only to renew
+  an existing key, the one case that needs the raw code, since `renew_key`
+  exists only on `/v3/redeem`; the caller branches on whichever of
+  `OrderResult`'s `key` / `code` is set, not on the flag it sent, so an older
+  server that ignores `redeem` still degrades to the classic flow. Prices are
+  server-owned — only the product id crosses the wire, and no client secret is
+  embedded in the binary. Stateless like `api`; the polling state machine lives
+  in the frontend's purchase store, driven through the `native_api_*` IPC
+  commands.
 - `supervisor` — `run_bot_manager`: constructs the `BotManager` and drives
   its run loop off the `MjaiBus`. Tolerates a missing Python runtime — the
   built-in `native` bots need none.

--- a/src/bot/purchase.rs
+++ b/src/bot/purchase.rs
@@ -6,8 +6,21 @@
 //! `approve_url` (opened in the buyer's browser) plus a one-time
 //! `claim_secret`. While the buyer approves on PayPal, the app polls
 //! [`order_result`] / [`subscription_result`] with `{id, claim}` until the
-//! status flips from `pending` to `ready` — which carries the redeem code
-//! (one-time purchase) or the API key itself (subscription).
+//! status flips from `pending` to `ready` — which carries either an API key
+//! or a redeem code, depending on the purchase (see below).
+//!
+//! A subscription always resolves straight to a key. A one-time order can go
+//! either way, selected by [`create_order`]'s `redeem` flag:
+//!
+//! - `redeem: true` — the server redeems the prepaid code into a key itself,
+//!   so [`OrderResult::key`] is set and the buyer's email holds the **key**.
+//!   This is what the app wants by default: a buyer who is emailed a one-time
+//!   *code* that the app already spent behind their back reasonably mistakes
+//!   that code for their credential.
+//! - `redeem: false` — the classic flow: [`OrderResult::code`] is set and the
+//!   caller exchanges it via `POST /v3/redeem`. Required to stack the bought
+//!   time onto a key the buyer already holds, because only `/v3/redeem` takes
+//!   a `renew_key` target — the server-side redeem always mints a fresh key.
 //!
 //! All of these endpoints are **unauthenticated** (the buyer is acquiring a
 //! key, so they don't hold one yet) but per-IP rate limited. Amounts are
@@ -52,16 +65,24 @@ pub struct CreatedSubscription {
 
 /// One poll of `POST /paypal/order-result`.
 ///
-/// `status`: `pending` (keep polling) / `ready` (`code`, `plan`, `days` set)
-/// / `delivered` (retrieval window passed — the code was emailed) /
-/// `refunded`.
+/// `status`: `pending` (keep polling) / `ready` (`plan`, `days` and exactly
+/// one of `key` / `code` set) / `delivered` (retrieval window passed — the
+/// credential was emailed) / `refunded`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderResult {
     pub status: String,
-    /// The prepaid redeem code, present only on `ready`. Feed it to
-    /// `POST /v3/redeem` to turn it into an API key.
+    /// The prepaid redeem code, present on `ready` for an order created with
+    /// `redeem: false`. Feed it to `POST /v3/redeem` to turn it into a key.
     #[serde(default)]
     pub code: Option<String>,
+    /// The API key itself, present on `ready` for an order created with
+    /// `redeem: true` — the server already spent the code, so there is no
+    /// redeem step and the code must never be re-redeemed. Branch on
+    /// whichever of `key` / `code` is present rather than on the flag you
+    /// sent, so an older server that ignores `redeem` still degrades to the
+    /// classic flow.
+    #[serde(default)]
+    pub key: Option<String>,
     #[serde(default)]
     pub plan: Option<String>,
     #[serde(default)]
@@ -85,7 +106,16 @@ pub struct SubscriptionResult {
 }
 
 #[derive(Serialize)]
-struct CreateRequest<'a> {
+struct CreateOrderRequest<'a> {
+    product: &'a str,
+    /// Redeem the code into a key server-side. Serialized as a real JSON
+    /// bool on purpose — the server rejects `1` / `"true"` with a `400`.
+    redeem: bool,
+}
+
+/// Subscriptions always hand back a key, so there is no `redeem` knob here.
+#[derive(Serialize)]
+struct CreateSubscriptionRequest<'a> {
     product: &'a str,
 }
 
@@ -105,13 +135,19 @@ struct SubscriptionResultRequest<'a> {
 /// `product` (an operator-defined id, e.g. `pro-30`). **Not idempotent**:
 /// each call opens a new PayPal order, so call once per purchase and reuse
 /// the returned ids.
-pub async fn create_order(base_url: &str, product: &str) -> Result<CreatedOrder> {
+///
+/// `redeem` decides what the later [`order_result`] poll — and the buyer's
+/// email — carries: `true` for the API key itself, `false` for a redeem code
+/// the caller must exchange. Pass `false` only when the code is needed as a
+/// code, i.e. to renew an existing key through `/v3/redeem`'s `renew_key`.
+pub async fn create_order(base_url: &str, product: &str, redeem: bool) -> Result<CreatedOrder> {
     let base = normalize_base(base_url);
     let url = format!("{base}/paypal/create-order");
     let resp = build_http()?
         .post(&url)
-        .json(&CreateRequest {
+        .json(&CreateOrderRequest {
             product: product.trim(),
+            redeem,
         })
         .send()
         .await
@@ -122,7 +158,10 @@ pub async fn create_order(base_url: &str, product: &str) -> Result<CreatedOrder>
         .context("parse /paypal/create-order response")
 }
 
-/// `POST /paypal/order-result` (no auth) — poll a one-time purchase.
+/// `POST /paypal/order-result` (no auth) — poll a one-time purchase. On
+/// `ready` the response carries the API key (`redeem: true` order) or the
+/// redeem code (`redeem: false`); see [`OrderResult`].
+///
 /// Idempotent and safe to repeat every few seconds until a terminal status.
 /// A wrong `claim` is a `404` and counts toward the per-IP failure guard, so
 /// never retry with guessed secrets.
@@ -149,7 +188,7 @@ pub async fn create_subscription(base_url: &str, product: &str) -> Result<Create
     let url = format!("{base}/paypal/create-subscription");
     let resp = build_http()?
         .post(&url)
-        .json(&CreateRequest {
+        .json(&CreateSubscriptionRequest {
             product: product.trim(),
         })
         .send()
@@ -215,6 +254,7 @@ mod tests {
         let r: OrderResult = serde_json::from_str(r#"{"status":"pending"}"#).unwrap();
         assert_eq!(r.status, "pending");
         assert!(r.code.is_none());
+        assert!(r.key.is_none());
         assert!(r.plan.is_none());
         assert!(r.days.is_none());
     }
@@ -225,6 +265,23 @@ mod tests {
         let r: OrderResult = serde_json::from_str(raw).unwrap();
         assert_eq!(r.status, "ready");
         assert_eq!(r.code.as_deref(), Some("ab12cd34ef56gh78"));
+        assert_eq!(r.plan.as_deref(), Some("pro"));
+        assert_eq!(r.days, Some(30));
+        // The classic flow never pre-redeems; the caller must exchange it.
+        assert!(r.key.is_none());
+    }
+
+    /// A `redeem: true` order resolves server-side: `ready` carries the key
+    /// instead of the code. The caller must not look for `code` there — the
+    /// code is already spent, and re-redeeming it would fail.
+    #[test]
+    fn order_result_ready_carries_key_when_server_redeemed() {
+        let raw = r#"{"status":"ready","key":"k0000000000000000000000000000003",
+                      "plan":"pro","days":30}"#;
+        let r: OrderResult = serde_json::from_str(raw).unwrap();
+        assert_eq!(r.status, "ready");
+        assert_eq!(r.key.as_deref(), Some("k0000000000000000000000000000003"));
+        assert!(r.code.is_none());
         assert_eq!(r.plan.as_deref(), Some("pro"));
         assert_eq!(r.days, Some(30));
     }
@@ -252,8 +309,23 @@ mod tests {
 
     #[test]
     fn request_bodies_have_expected_shape() {
-        let v = serde_json::to_value(CreateRequest { product: "pro-30" }).unwrap();
-        assert_eq!(v, serde_json::json!({"product": "pro-30"}));
+        let v = serde_json::to_value(CreateOrderRequest {
+            product: "pro-30",
+            redeem: true,
+        })
+        .unwrap();
+        assert_eq!(v, serde_json::json!({"product": "pro-30", "redeem": true}));
+        // `redeem` must be a JSON bool — the server rejects `1` / `"true"`.
+        assert!(v["redeem"].is_boolean());
+
+        // Subscriptions always yield a key; they take no `redeem` knob, and
+        // sending one would be a malformed body.
+        let v = serde_json::to_value(CreateSubscriptionRequest {
+            product: "pro-monthly",
+        })
+        .unwrap();
+        assert_eq!(v, serde_json::json!({"product": "pro-monthly"}));
+
         let v = serde_json::to_value(OrderResultRequest {
             order_id: "OID",
             claim: "SECRET",
@@ -273,6 +345,8 @@ mod tests {
 
     // ---- end-to-end against a local mock server (see `crate::bot::test_http`) ----
 
+    /// `redeem: false` — the classic flow a renewal needs: `ready` hands back
+    /// a code the caller exchanges itself (with a `renew_key` target).
     #[tokio::test]
     async fn create_then_poll_order_roundtrip() {
         let (base, served) = mock_http(vec![
@@ -287,7 +361,9 @@ mod tests {
             ),
         ]);
 
-        let created = create_order(&format!("{base}/"), "pro-30").await.unwrap();
+        let created = create_order(&format!("{base}/"), "pro-30", false)
+            .await
+            .unwrap();
         assert_eq!(created.order_id, "OID1");
         assert_eq!(created.claim_secret, "S1");
 
@@ -301,13 +377,70 @@ mod tests {
             .unwrap();
         assert_eq!(ready.status, "ready");
         assert_eq!(ready.code.as_deref(), Some("code1234code5678"));
+        assert!(ready.key.is_none());
 
         let reqs = served.join().unwrap();
         assert!(reqs[0].starts_with("POST /paypal/create-order HTTP/1.1"));
-        assert!(reqs[0].contains(r#"{"product":"pro-30"}"#));
+        assert!(reqs[0].contains(r#"{"product":"pro-30","redeem":false}"#));
         assert!(reqs[1].starts_with("POST /paypal/order-result HTTP/1.1"));
         assert!(reqs[1].contains(r#""order_id":"OID1""#));
         assert!(reqs[1].contains(r#""claim":"S1""#));
+    }
+
+    /// Regression: `redeem: true` must reach the wire as a real JSON bool
+    /// (the server 400s on `1` / `"true"`), and the resulting `ready` poll
+    /// must surface the API key directly — no `/v3/redeem` step, so the
+    /// buyer's emailed credential is the key they actually use.
+    #[tokio::test]
+    async fn redeem_true_order_roundtrip_returns_key_directly() {
+        let (base, served) = mock_http(vec![
+            (
+                "200 OK",
+                r#"{"order_id":"OID2","approve_url":"https://paypal.example/approve","claim_secret":"S3"}"#.into(),
+            ),
+            (
+                "200 OK",
+                r#"{"status":"ready","key":"k0000000000000000000000000000004","plan":"pro","days":30}"#.into(),
+            ),
+        ]);
+
+        let created = create_order(&base, "pro-30", true).await.unwrap();
+        assert_eq!(created.order_id, "OID2");
+
+        let ready = order_result(&base, &created.order_id, &created.claim_secret)
+            .await
+            .unwrap();
+        assert_eq!(ready.status, "ready");
+        assert_eq!(
+            ready.key.as_deref(),
+            Some("k0000000000000000000000000000004")
+        );
+        assert!(ready.code.is_none(), "a redeemed order exposes no code");
+
+        let reqs = served.join().unwrap();
+        assert!(reqs[0].starts_with("POST /paypal/create-order HTTP/1.1"));
+        assert!(reqs[0].contains(r#"{"product":"pro-30","redeem":true}"#));
+        assert!(
+            !reqs[0].contains(r#""redeem":"true""#) && !reqs[0].contains(r#""redeem":1"#),
+            "redeem must be a JSON bool, got: {}",
+            reqs[0]
+        );
+    }
+
+    /// `create-subscription` must never carry `redeem` — subscriptions always
+    /// mint a key, and an unexpected field risks a `400 bad request`.
+    #[tokio::test]
+    async fn create_subscription_omits_the_redeem_flag() {
+        let (base, served) = mock_http(vec![(
+            "200 OK",
+            r#"{"subscription_id":"I-2","approve_url":"https://paypal.example/sub","claim_secret":"S4"}"#.into(),
+        )]);
+
+        create_subscription(&base, "pro-monthly").await.unwrap();
+
+        let reqs = served.join().unwrap();
+        assert!(reqs[0].contains(r#"{"product":"pro-monthly"}"#));
+        assert!(!reqs[0].contains("redeem"), "got: {}", reqs[0]);
     }
 
     #[tokio::test]
@@ -349,7 +482,7 @@ mod tests {
             "400 Bad Request",
             r#"{"error":"unknown product"}"#.into(),
         )]);
-        let err = create_order(&base, "nope-99").await.unwrap_err();
+        let err = create_order(&base, "nope-99", true).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("create order failed"), "got: {msg}");
         assert!(msg.contains("HTTP 400"), "got: {msg}");

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -1378,18 +1378,25 @@ pub async fn native_api_health(base_url: String) -> CmdResult<crate::bot::api::H
 
 /// Start a one-time purchase (`POST /paypal/create-order`, no auth). Not
 /// idempotent — each call opens a fresh PayPal order.
+///
+/// `redeem: true` has the server turn the prepaid code into an API key
+/// itself, so the poll and the buyer's email both carry the key. Pass `false`
+/// only to renew an existing key, which needs the raw code for
+/// `/v3/redeem`'s `renew_key`.
 #[tauri::command]
 pub async fn native_api_create_order(
     base_url: String,
     product: String,
+    redeem: bool,
 ) -> CmdResult<crate::bot::purchase::CreatedOrder> {
-    crate::bot::purchase::create_order(&base_url, &product)
+    crate::bot::purchase::create_order(&base_url, &product, redeem)
         .await
         .map_err(|e| format!("{e:#}"))
 }
 
 /// Poll a one-time purchase (`POST /paypal/order-result`, no auth).
-/// Idempotent; returns `pending` until paid, then `ready` with the code.
+/// Idempotent; returns `pending` until paid, then `ready` with the API key
+/// (`redeem: true` order) or the redeem code (`redeem: false`).
 #[tauri::command]
 pub async fn native_api_order_result(
     base_url: String,


### PR DESCRIPTION
Closes #177.

## Problem

Buying a key ran the inference server's classic one-time flow: the `order-result`
poll returned a prepaid **redeem code**, and Akagi spent it on `POST /v3/redeem`
immediately. The server's backup email therefore carried the *code* — a one-time
string, already consumed, and indistinguishable at a glance from the 32-char API
key the app had just saved.

Buyers pasted the emailed code into the **API key** field and got `401`s. Worse,
that email exists precisely to rescue a purchase when in-app delivery fails, and
on this path it could not: the code it carried was already spent.

## Fix

`POST /paypal/create-order` now accepts a `redeem` boolean. With `redeem: true`
the server redeems the code into an API key itself — the poll returns `key`, and
the email delivers the **key**. One credential, and it is the one that
authenticates.

## Renewals keep the classic flow

`redeem: true` always mints a *fresh* key, so it cannot serve the dialog's
**Add the time to my current key** option: `renew_key` is a parameter of
`/v3/redeem`, not of `create-order`, so a renewal genuinely needs the raw code.

Hence the flag is exactly `redeem: renewKey === null`. Renewals are the only path
that still redeems client-side, which is also the only path that can still reach
the `redeem_failed` retry screen.

## Defensive branching

The poll handler branches on **whichever of `key` / `code` the server returned**,
not on the flag it sent:

- an older server that ignores `redeem` still returns a code, and the app
  degrades to the classic client-side redeem;
- `key` is checked first, so a response carrying both can never make us re-redeem
  a spent code on top of a key we already hold.

## Expiry back-fill

A server-side redeem never reports `expires_at` (only `/v3/redeem` does), so the
one-time "Valid until: …" line would have regressed to blank. The store now
back-fills it from `GET /v3/key` *after* the key is delivered and persisted —
strictly best-effort, so a failure there costs the date line and nothing else. A
paid key is never gated behind a cosmetic request.

## Changes

| File | What |
|---|---|
| `src/bot/purchase.rs` | `create_order(.., redeem: bool)`; `OrderResult.key`; split `CreateOrderRequest` / `CreateSubscriptionRequest` so subscriptions never carry `redeem` |
| `src/ipc/commands.rs` | thread `redeem` through `native_api_create_order` |
| `frontend/src/stores/purchaseStore.ts` | send `redeem: renewKey === null`; take `key` when present; best-effort `fillExpiry` |
| `frontend/src/types.ts` | `OrderResult.key` |
| `src/bot/README.md`, `README.md` | document the flag and the renewal caveat |

## Tests

Three new regression tests in `src/bot/purchase.rs`, all against the local mock
HTTP server with fake data:

- `redeem_true_order_roundtrip_returns_key_directly` — `redeem` reaches the wire
  as a real JSON bool (the server `400`s on `1` / `"true"`), and `ready` surfaces
  the key with no code.
- `order_result_ready_carries_key_when_server_redeemed` — the `ready`-with-`key`
  shape parses, and exposes no code to re-redeem.
- `create_subscription_omits_the_redeem_flag` — subscriptions always mint a key
  and must not send an unexpected field.

Verified locally: `cargo test --lib bot::purchase` 13/13 pass; `cargo fmt --check`
and `cargo clippy --lib` clean; frontend `tsc -b` and `eslint` clean.