### PR TITLE
docs(readme): lead with the built-in bot, demote mjai bots to a dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@
 Akagi watches your Mahjong Soul / Tenhou game over a local proxy or a
 built-in browser, mirrors the game state, and shows **shanten**, **waits**,
 **agari rate**, **tenpai rate**, **per-opponent deal-in risk**, and a
-**recommended discard** in a draggable HUD. Drop in an mjai-protocol bot
-like Mortal and the HUD also shows the bot's recommendation each turn.
+**recommended discard** in a draggable HUD. A **built-in bot** ships inside
+the binary — nothing to install — and its suggestion appears each turn; point
+it at the **cloud inference API** when you want a stronger, hosted model.
 
 ## Screenshots
 
@@ -100,6 +101,7 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
 - [Architecture](#architecture)
 - [Tech Stack](#tech-stack)
 - [Project Layout](#project-layout)
+- [mjai Bots (plugin interface)](#mjai-bots-plugin-interface)
 - [Build From Source](#build-from-source)
 - [Testing](#testing)
 - [Releases &amp; CI](#releases--ci)
@@ -119,10 +121,17 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
   - **Chromium** — Akagi launches a controlled Chromium-family browser
     and intercepts WebSocket frames via the Chrome DevTools Protocol.
     Zero proxy/CA setup; just play in the launched window.
-- **Pluggable mjai bots** — install Mortal in one click from the Setup
-  wizard, or drop any `bot.py` under `mjai_bot/<name>/`. Per-mode
-  routing: `bot.active_4p` and `bot.active_3p` swap automatically based
-  on the table's player count.
+- **Two bot backends**
+  - **Built-in bot** (default) — a pure-Rust neural net embedded in the
+    binary. No Python, no download, no setup; it just plays, in both
+    4-player and 3-player.
+  - **Cloud inference** (optional) — hand each decision to a hosted,
+    stronger model over HTTP. The built-in model stays loaded as an
+    automatic fallback, so an unreachable server never stalls a live
+    game. Keys are bought or redeemed from inside the app.
+
+  Per-mode routing throughout: `bot.active_4p` and `bot.active_3p` swap
+  automatically based on the table's player count.
 - **Game history** — every completed match is auto-recorded. The
   History tab shows a rank pie chart, a cumulative PT line chart with
   selectable scoring rules (Mahjong Soul tiers / Tenhou ranks /
@@ -134,7 +143,8 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
   WebSocket frames → mjai events → bot reactions, with frame counts
   and meta inspection.
 - **First-run Setup wizard** — language → platform → capture mode →
-  CA trust / Chromium pick → bot install → done.
+  CA trust / Chromium pick → bot settings → done. Nothing to install: the
+  built-in bot is already there.
 - **Internationalization** — English, 日本語, 繁體中文, 简体中文.
   Live switch from Setup or the Sidebar. Full coverage across the UI.
 - **Sanma (3-player)** — full pipeline: bridge, tracker, snapshot,
@@ -177,12 +187,13 @@ copying / deleting the folder.
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon. Unsigned: run `xattr -cr <unzipped folder>` once, or right-click → *Open* the first time. |
 | Linux | `akagi-<version>-linux-x64.zip` | Built on `ubuntu-22.04` (glibc 2.35+). Requires WebKit2GTK 4.1 (`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`). |
 
-Each zip bundles `python-build-standalone` 3.12 + `uv` next to the
-binary, so bots run out of the box without any system Python install.
+The built-in bot needs no runtime at all. Each zip also bundles
+`python-build-standalone` 3.12 + `uv` next to the binary, so the optional
+[mjai bots](#mjai-bots-plugin-interface) run without any system Python install.
 
 On first launch the **Setup wizard** walks you through language,
-platform, capture mode, optional bot install (Mortal), and CA trust
-(only if you choose MITM mode).
+platform, capture mode, bot settings, and CA trust (only if you choose
+MITM mode). There is no bot to install — the built-in one is already there.
 
 ### B. Chromium mode (no CA trust needed)
 
@@ -339,37 +350,6 @@ Three ways, all from the **Cloud inference** card:
   already hold.
 - Ask in the [Discord server](https://discord.gg/Z2wjXUK8bN).
 
-### Install a bot
-
-The Setup wizard or the **Bots** tab can install bots straight from a
-GitHub release:
-
-- Repo: `shinkuan/Akagi-MjaiBot-Mortal`
-- Asset (4P): `release4p.zip`
-- Asset (3P): `release3p.zip`
-
-The IPC command `install_bot_from_github(repo, asset_glob?, name?)`
-fetches the latest release zip, extracts it under `mjai_bot/<name>/`,
-validates `bot.py`, and runs `uv sync` once. Subsequent launches are
-fast — the sync is gated by a stamp at
-`mjai_bot/<name>/.akagi/synced.stamp`.
-
-You can also install from a **local ZIP** — useful for offline installs
-or a locally-built bot. On the **Bots** tab, click **Install from ZIP**,
-**Browse…** to pick a `.zip` (or paste its path), and install. This runs
-the exact same extract / validate / `uv sync` pipeline as the GitHub
-install; your source `.zip` is left untouched.
-
-> [!IMPORTANT]
-> Because of GitHub's file-size limit, the Mortal weights bundled in
-> the release zip are a small, weak **placeholder model** — useful to
-> verify the install works, **not recommended for real play**.
-> **Stronger Mortal model weights** and an **online API-server model**
-> (a hosted, even stronger model — point your bot at the server and
-> an API key; no local NN needed) are both distributed through the
-> [Discord server](https://discord.gg/Z2wjXUK8bN). Ask there for
-> access; both 4P and 3P versions are available.
-
 ### Per-mode bots
 
 `bot.active_4p` and `bot.active_3p` are independent. Akagi picks the
@@ -377,29 +357,9 @@ right one when the game starts, based on the table's player count.
 Leave a slot empty to play that mode with **analysis only** (no bot
 suggestion).
 
-### Write your own
-
-A bot is a standalone subprocess that talks JSONL over stdin/stdout — Akagi
-feeds it the game as mjai events and it replies with an action plus optional
-HUD data. The full developer guide lives in
-**[`mjai_bot/README.md`](./mjai_bot/README.md)**: the I/O protocol, the mjai
-event stream, the reaction and `meta` HUD format, toast notifications, and
-`manifest.toml` settings. [`mjai_bot/example/`](./mjai_bot/example/) is a
-working rule-based bot you can copy.
-
-For local development, drop your bot folder under `mjai_bot/<name>/` and click
-**Install environment** on its row in the **Bots** tab to build its venv — no
-need to repackage and reinstall on every change. The activation toggle stays
-disabled until the environment is ready.
-
-### AGPL boundary
-
-Bots run as a **separate OS subprocess** spawned by Akagi. Communication
-is strictly JSONL over stdin / stdout — no in-process linking, no
-shared address space, no FFI. This is an intentional license boundary:
-an AGPL-licensed bot (e.g. Mortal, which links libriichi) stays inside
-its own process, so dropping it under `mjai_bot/<name>/` does **not**
-make Akagi a derived work of the bot.
+Beyond these two backends, Akagi can also run **external mjai bots** as
+subprocesses. That's an extension point for developers rather than a step
+anyone needs — see [mjai Bots (plugin interface)](#mjai-bots-plugin-interface).
 
 ---
 
@@ -641,6 +601,51 @@ of pull commands documented in [`src/ipc/README.md`](./src/ipc/README.md).
 ```
 
 Per-module developer guides live in each `src/*/README.md`.
+
+## mjai Bots (plugin interface)
+
+> Optional, and aimed at developers. The [built-in bot](#built-in-bot-no-install)
+> is the default and needs none of this — you only come here to run a *different*
+> engine under Akagi.
+
+Besides its own bot, Akagi can drive any engine that speaks the **mjai**
+protocol. Such a bot is a standalone subprocess talking JSONL over stdin/stdout:
+Akagi feeds it the game as mjai events, and it replies with an action plus
+optional HUD data.
+
+### Write one
+
+The full guide lives in **[`mjai_bot/README.md`](./mjai_bot/README.md)**: the
+I/O protocol, the mjai event stream, the reaction and `meta` HUD format, toast
+notifications, and `manifest.toml` settings.
+[`mjai_bot/example/`](./mjai_bot/example/) is a working rule-based bot you can
+copy.
+
+For local development, drop your bot folder under `mjai_bot/<name>/` and click
+**Install environment** on its row in the **Bots** tab to build its venv — no
+need to repackage and reinstall on every change. The activation toggle stays
+disabled until the environment is ready.
+
+### Install one
+
+The **Bots** tab installs a bot from a GitHub release or a local ZIP.
+
+The IPC command `install_bot_from_github(repo, asset_glob?, name?)` fetches the
+latest release zip, extracts it under `mjai_bot/<name>/`, validates `bot.py`,
+and runs `uv sync` once. Subsequent launches are fast — the sync is gated by a
+stamp at `mjai_bot/<name>/.akagi/synced.stamp`.
+
+**Install from ZIP** is the offline equivalent: click **Browse…** to pick a
+`.zip` (or paste its path). It runs the exact same extract / validate /
+`uv sync` pipeline; your source `.zip` is left untouched.
+
+### AGPL boundary
+
+Bots run as a **separate OS subprocess** spawned by Akagi. Communication is
+strictly JSONL over stdin / stdout — no in-process linking, no shared address
+space, no FFI. This is an intentional license boundary: an AGPL-licensed bot
+(e.g. Mortal, which links libriichi) stays inside its own process, so dropping
+it under `mjai_bot/<name>/` does **not** make Akagi a derived work of the bot.
 
 ## Build From Source
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@
 Akagi watches your Mahjong Soul / Tenhou game over a local proxy or a
 built-in browser, mirrors the game state, and shows **shanten**, **waits**,
 **agari rate**, **tenpai rate**, **per-opponent deal-in risk**, and a
-**recommended discard** in a draggable HUD. A **built-in bot** ships inside
-the binary — nothing to install — and its suggestion appears each turn; point
-it at the **cloud inference API** when you want a stronger, hosted model.
+**recommended discard** in a draggable HUD. A built-in AI model ships inside
+the app — nothing to install — and its suggestion appears each turn; point
+it at the cloud inference API when you want a stronger, hosted model.
 
 ## Screenshots
 
@@ -90,7 +90,6 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
 - [Features](#features)
 - [Supported Platforms](#supported-platforms)
 - [Quick Start](#quick-start)
-- [Configuration](#configuration)
 - [Bots](#bots)
 - [Game History](#game-history)
 - [Logs &amp; Diagnostics](#logs--diagnostics)
@@ -115,7 +114,7 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
 
 - **Live HUD** — shanten, waits, agari rate, tenpai rate, per-opponent
   deal-in risk, suggested attack/defence discard. Draggable, resizable
-  tile grid persisted to local storage.
+  UI layout.
 - **Two capture modes**
   - **MITM proxy** (default) — system-wide; needs a one-time CA trust.
   - **Chromium** — Akagi launches a controlled Chromium-family browser
@@ -125,8 +124,8 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
   - **Built-in bot** (default) — a pure-Rust neural net embedded in the
     binary. No Python, no download, no setup; it just plays, in both
     4-player and 3-player.
-  - **Cloud inference** (optional) — hand each decision to a hosted,
-    stronger model over HTTP. The built-in model stays loaded as an
+  - **Cloud inference** (optional) — hand each decision to a
+    **hosted, stronger model**. The built-in model stays loaded as an
     automatic fallback, so an unreachable server never stalls a live
     game. Keys are bought or redeemed from inside the app.
 
@@ -138,25 +137,16 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
   Custom uma), and detailed stats (win rate, deal-in rate, riichi rate,
   fuuro rate, ryukyoku rate, average winning / deal-in points, average
   winning turn, yakuman / nagashi-mangan counts).
-- **Logs viewer** — **Diagnostic** tab for the application log with
-  live tail and per-module filtering; **Inspector** tab for raw
-  WebSocket frames → mjai events → bot reactions, with frame counts
-  and meta inspection.
-- **First-run Setup wizard** — language → platform → capture mode →
-  CA trust / Chromium pick → bot settings → done. Nothing to install: the
-  built-in bot is already there.
+- **Simple first-run setup** — language → platform → capture mode →
+  CA trust / Chromium pick → bot settings → done.
 - **Internationalization** — English, 日本語, 繁體中文, 简体中文.
-  Live switch from Setup or the Sidebar. Full coverage across the UI.
-- **Sanma (3-player)** — full pipeline: bridge, tracker, snapshot,
-  analysis, per-mode bot routing, history stats, 3p uma tables.
-- **In-app updates** — checks the GitHub releases endpoint on launch
-  (cached for 6 hours) and on demand from *Settings → Updates*. A
-  bounded toast plus a red dot next to the sidebar version surface a
-  new release; the dialog offers *Update now* (downloads the matching
-  zip, SHA-256-verifies it, swaps the binary in place via
-  `self_replace`, then restarts), *Skip this version*, *Later*, or
-  *Open release page*. Read-only installs (e.g. AppImage) fall back to
-  the release page automatically.
+  Live switch from Setup or Settings.
+- **Sanma (3-player)** — fully supported: AI analysis, per-mode bot
+  routing, history stats, 3p uma tables.
+- **In-app updates** — checks for new releases on launch and on demand
+  from *Settings → Updates*; one click downloads the update, applies it
+  in place, and restarts. Read-only installs (e.g. AppImage) fall back
+  to the release page.
 
 ## Supported Platforms
 
@@ -176,10 +166,10 @@ https://github.com/user-attachments/assets/d5bc6ff6-6560-4365-ae55-660c9a522790
 Akagi ships as a portable zip — one self-contained folder per platform.
 Download the file for your OS from
 [Releases](https://github.com/shinkuan/Akagi/releases), unzip anywhere
-you have write permission (e.g. `~/Apps/`, Desktop), and run the binary.
-Configuration, logs, history, the CA cert, and bots all live next to
-the binary, so moving / backing up / uninstalling is just moving /
-copying / deleting the folder.
+you have write permission (e.g. `~/Apps/`, Desktop), and run `akagi`
+inside. Configuration, logs, history, the CA cert, and bots are all
+created right next to it, so moving / backing up / uninstalling is just
+moving / copying / deleting the folder.
 
 | OS | File | Notes |
 |---|---|---|
@@ -187,23 +177,15 @@ copying / deleting the folder.
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon. Unsigned: run `xattr -cr <unzipped folder>` once, or right-click → *Open* the first time. |
 | Linux | `akagi-<version>-linux-x64.zip` | Built on `ubuntu-22.04` (glibc 2.35+). Requires WebKit2GTK 4.1 (`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`). |
 
-The built-in bot needs no runtime at all. Each zip also bundles
-`python-build-standalone` 3.12 + `uv` next to the binary, so the optional
-[mjai bots](#mjai-bots-plugin-interface) run without any system Python install.
-
 On first launch the **Setup wizard** walks you through language,
 platform, capture mode, bot settings, and CA trust (only if you choose
 MITM mode). There is no bot to install — the built-in one is already there.
 
 ### B. Chromium mode (no CA trust needed)
 
-The simplest path. After Setup:
-
-1. Settings → **Capture** → set Mode to **Chromium**.
-2. Click **Detect** to auto-find Chrome / Edge / Brave / Chromium, or
-   set `capture.chromium.executable` manually.
-3. Akagi launches the browser with an isolated profile under
-   `<config_root>/chrome-profile`. Log in to Mahjong Soul and play.
+The simplest path. After Setup, Akagi finds Chrome / Edge / Brave /
+Chromium automatically and launches it with its own separate profile;
+log in to Mahjong Soul and play.
 
 Frames are intercepted via the Chrome DevTools Protocol — no system
 proxy, no certificate.
@@ -212,8 +194,8 @@ proxy, no certificate.
 
 System-wide proxy with a self-signed root CA at `./ca/`:
 
-1. Trust `./ca/akagi-ca.crt` (or `.cer` / `.pem` / `.der`) in your
-   OS / browser certificate store.
+1. Trust the certificate `./ca/akagi-ca.crt` (or `.cer` / `.pem` /
+   `.der`).
 2. Route the game client through `127.0.0.1:23410`.
    Health probe: `GET /ping` → `pong`.
 3. On Windows, [Proxifier](https://www.proxifier.com/) is the usual
@@ -221,131 +203,31 @@ System-wide proxy with a self-signed root CA at `./ca/`:
 
 ---
 
-## Configuration
-
-Configuration lives in `config.toml` next to the binary (or wherever
-you point `--config`). Edits saved through the Settings UI hot-reload
-the affected subsystem — capture / proxy / bot active slots restart
-without an app relaunch.
-
-```toml
-[general]
-language = "en"
-
-[logging]
-dir       = "./logs"
-level     = "info"
-all_level = "warn"
-
-[platform]
-kind = "Majsoul"
-
-[proxy]
-enabled = true
-addr    = "127.0.0.1:23410"
-ca_dir  = "./ca"
-
-[capture]
-mode = "mitm"               # or "chromium"
-
-[capture.chromium]
-executable    = ""          # blank = auto-detect
-user_data_dir = ""          # blank = <config_root>/chrome-profile
-start_url     = "https://game.maj-soul.com/1/"
-cft_channel   = "stable"
-force_cft     = false
-extra_args    = []
-
-[bot]
-enabled   = true
-active_4p = "mortal"        # used in 4-player (yonma) games
-active_3p = "mortal3p"      # used in 3-player (sanma); empty = none
-auto_sync = true
-dir       = "./mjai_bot"
-```
-
-<details>
-<summary>Where the config file lives (resolution order)</summary>
-
-1. `--config <path>` CLI flag.
-2. `<exe_dir>/configs/config.toml`.
-3. `./configs.toml` in the current working directory.
-4. If none of the above exist, defaults are auto-written to
-   `<exe_dir>/configs/config.toml` on first launch.
-
-Pre-3p configs that still use a single `active = "..."` key are
-auto-migrated into `active_4p` on load.
-</details>
-
----
-
 ## Bots
 
 ### Built-in bot (no install)
 
-Akagi ships a **built-in, pure-Rust bot** that runs entirely in-process — no
-Python, no libriichi, no `uv sync`, nothing to download. It's the out-of-the-box
-default for both modes (`bot.active_4p = "akagi-native"`,
-`bot.active_3p = "akagi-native3p"`) and appears at the top of the **Bots** tab,
-always "ready".
+Akagi ships a **built-in, pure-Rust bot**. It's the default for both modes
+(`bot.active_4p = "akagi-native"`, `bot.active_3p = "akagi-native3p"`) and
+appears at the top of the **Bots** tab, always "ready".
 
-It's a small neural net behavior-cloned from Tenhou logs (weights are embedded
+It's a small neural net trained by behavior cloning (weights are embedded
 in the binary), so its strength is **modest by design** — a sensible default,
 not a top-tier engine.
 
 ### Cloud inference (built-in bot)
 
-The built-in bot can optionally hand each decision to a **remote inference
+The built-in bot can optionally hand its decisions to a **remote inference
 server** instead of running its embedded model — a stronger, hosted model
 reached over the network. The embedded local model stays loaded as an automatic
 **fallback**: if the server is unreachable, rate-limited, or the key is invalid,
-the bot silently plays the local model's move so a live game never stalls.
+the bot plays the local model's move so a live game never stalls.
 
-Configure it on the **Bots** tab, under **Cloud inference (built-in bot)**:
+#### Getting a cloud-inference key
 
-- **Use cloud inference API** — the master toggle. Off (default) ⇒ the fully
-  offline local model.
-- **Server URL** — the inference server. Defaults to `https://mjapi.shinkuan.me`;
-  point it at any host (`http://host:8080`, `https://host`) if you self-host.
-- **API key** — a 32-character key.
-- **4-player / 3-player model** — the model id to request per mode; leave empty to use the server's default. **Fetch models**
-  lists the ids your key may use.
+Three ways:
 
-Buttons let you **Check key** (plan, expiry, today's usage vs. daily quota, rate
-limit), **Redeem code** (turn a prepaid code into a key — mint a new one, or add
-time to your current key), **Buy key** (see below), and **Health check** the
-server. To stay within the server's rate limit, the bot queries only at genuine
-decision points — it decides locally whether a call is even possible — never on
-every opponent discard.
-
-Changes apply **immediately after saving, even mid-game**: the bot re-reads these
-settings at every decision, so you can enable cloud inference during a hanchan,
-correct a mistyped key, or switch models without restarting the game. If the
-server stops responding, the bot falls back to the local model and skips the API
-for a short, growing backoff window rather than timing out on every turn; the
-status bar's **Online API** indicator turns red, and turns green again on
-recovery.
-
-The settings persist under `[bot.api]` in `config.toml` (`enabled`, `base_url`,
-`key`, `model_4p`, `model_3p`).
-
-> **Your API key is stored in plaintext** in `config.toml`, and Akagi sends it as
-> a bearer token to the configured **Server URL**. Treat that file as a secret:
-> don't commit it, and scrub the `key` before sharing it (e.g. in a bug report).
-
-#### Getting a key
-
-Three ways, all from the **Cloud inference** card:
-
-- **Buy key** — an in-app purchase. Pick a plan (one-time top-ups, or a monthly
-  subscription), and Akagi opens PayPal in your browser. Prices are set by the
-  server; the app only sends the product id. Once payment clears, the key is
-  delivered back into the app and saved automatically — you can close the dialog
-  while you pay, and a status chip leads you back. If delivery ever fails, the
-  key is also emailed to your PayPal address, so a purchase is never lost.
-  The one exception is buying with *Add the time to my current key* ticked:
-  that stacks the purchased days onto the key you already hold, so what arrives
-  by email is the prepaid **code** used to top it up, not a new key.
+- **Buy key** — an in-app purchase.
 - **Redeem code** — turn a prepaid code into a key, or add time to the key you
   already hold.
 - Ask in the [Discord server](https://discord.gg/Z2wjXUK8bN).
@@ -354,8 +236,6 @@ Three ways, all from the **Cloud inference** card:
 
 `bot.active_4p` and `bot.active_3p` are independent. Akagi picks the
 right one when the game starts, based on the table's player count.
-Leave a slot empty to play that mode with **analysis only** (no bot
-suggestion).
 
 Beyond these two backends, Akagi can also run **external mjai bots** as
 subprocesses. That's an extension point for developers rather than a step
@@ -468,15 +348,6 @@ Useful when debugging a bot or a bridge issue.
   "couldn't terminate the browser already using profile …" — close it
   manually and click Restart. Running two Akagi instances against the
   same profile is unsupported.
-- **Bot stuck in `Loading{SyncingDeps}`.** First-run `uv sync` is
-  slow — watch the Diagnostic tab for `bot=<name>` lines. If it never
-  finishes, delete `mjai_bot/<name>/.akagi/synced.stamp` and retry.
-- **Activation toggle greyed out / a dropped-in bot won't enable.** Its
-  Python environment isn't built yet. On the **Bots** tab, click the
-  **Install environment** button on that bot's row (it appears whenever the
-  env isn't ready) to run `uv sync`; the toggle enables once it finishes.
-  Editing the bot's `pyproject.toml` marks the env stale and brings the
-  button back.
 - **Bot crashed mid-game.** The Inspector tab shows the last frame the
   bot saw before dying; attach it to the bug report.
 - **Wrong bot picked for a 3-player game.** Check `bot.active_3p` in
@@ -499,15 +370,15 @@ Done in alpha.8:
 - [x] i18n: en / ja / zh-TW / zh-CN, with Setup-wizard language picker
 - [x] Bot install from a GitHub release or a local ZIP file
 - [x] Chromium capture mode (no CA trust needed)
+- [x] **Custom themes** (frontend theming hooks)
 - [x] **AutoPlay** (Mahjong Soul first; the bot drives the table
-      autonomously, like the original Akagi's Windows AutoPlay)
+      autonomously)
 
 Planned:
 
 - [ ] **Amatsuki** platform support
-- [ ] **Custom themes** (frontend theming hooks)
 - [ ] **Refine Frontend** — tile layout, animations, accessibility
-- [ ] **Tenhou autoplay** (currently observe-only)
+- [ ] **Tenhou autoplay**
 
 Detailed bug tracking lives in
 [GitHub Issues](https://github.com/shinkuan/Akagi/issues).
@@ -535,16 +406,18 @@ truth for channel types.
   game_state::tracker   bot::manager     ipc forwarder
        │                  │                  │
        ▼ PostBus          ▼ BotResponseBus   ▼ app.emit
-  analysis::runner   subprocess (uv)    Tauri webview
-       │
-       ▼ AnalysisBus
+  analysis::runner   built-in NN (in-proc) Tauri webview
+       │             | cloud API
+       ▼ AnalysisBus  | mjai subprocess
        └──► ipc forwarder ──► app.emit
 ```
 
 [`src/lib.rs`](./src/lib.rs) wires the buses on boot. The frontend
-talks to the backend over six push events (`mjai-event`, `bot-response`,
-`bot-status`, `proxy-status`, `notify`, `history-recorded`) and a set
-of pull commands documented in [`src/ipc/README.md`](./src/ipc/README.md).
+talks to the backend over push events (`mjai-event`, `bot-response`,
+`bot-status`, …) and a set of pull commands, both documented in
+[`src/ipc/README.md`](./src/ipc/README.md). With AutoPlay on, the
+`autoplay` manager consumes the bot's decisions and clicks the table
+through the Chromium capture backend (CDP).
 
 ## Tech Stack
 
@@ -555,6 +428,8 @@ of pull commands documented in [`src/ipc/README.md`](./src/ipc/README.md).
 | MITM | [`hudsucker`](https://crates.io/crates/hudsucker) 0.24 (`rcgen-ca`, `rustls-client`) |
 | CDP capture | [`chromiumoxide`](https://crates.io/crates/chromiumoxide) 0.9 |
 | Mahjong engine | [`riichienv-core`](https://github.com/smly/RiichiEnv) 0.4 |
+| Built-in bot | [`candle`](https://github.com/huggingface/candle) 0.9 (pure-Rust NN inference; weights embedded) |
+| Cloud inference | [`reqwest`](https://crates.io/crates/reqwest) 0.13 (rustls) |
 | Protobuf | `prost` 0.14 + `prost-reflect` 0.16 |
 | Frontend | [React](https://react.dev) 19, TypeScript, [Vite](https://vitejs.dev) 8 |
 | Styling | [Tailwind CSS](https://tailwindcss.com) v4, [shadcn/ui](https://ui.shadcn.com) (Radix Nova preset) |
@@ -562,7 +437,7 @@ of pull commands documented in [`src/ipc/README.md`](./src/ipc/README.md).
 | Charts | [Recharts](https://recharts.org) |
 | Tile rendering | [`<mah-gen>`](https://github.com/eric200203/mahgen) Web Component |
 | i18n | [react-i18next](https://react.i18next.com) |
-| Bot runtime | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv) (bundled per platform) |
+| mjai bot runtime | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv) (bundled per platform; plugin bots only — the built-in bot needs none of it) |
 
 ## Project Layout
 
@@ -570,28 +445,33 @@ of pull commands documented in [`src/ipc/README.md`](./src/ipc/README.md).
 .
 ├── src/
 │   ├── analysis/      Shanten / waits / agari-rate / risk / discard search
-│   ├── bot/           Registry, Python runtime, JSONL subprocess runner
+│   ├── autoplay/      Bot decisions → table clicks via CDP (AutoPlay)
+│   ├── bot/           Bot manager: built-in bot, cloud API client, mjai subprocess runner
 │   ├── bridge/        Per-platform protocol → MjaiEvent
 │   │   ├── majsoul/   Mahjong Soul (liqi protobuf)
+│   │   ├── riichi_city/  Riichi City (MITM only)
 │   │   └── tenhou/    Tenhou (JSON tag stream, observe-only)
 │   ├── capture/       Capture backends abstraction (mitm | chromium)
 │   ├── config/        AppConfig (TOML) sections + resolution
 │   ├── event_bus.rs   Broadcast channels between subsystems
 │   ├── game_state/    riichienv-driven mirror, snapshot, mahgen view
+│   ├── github/        GitHub Releases client (bot install, self-update)
 │   ├── history/       Game replay storage + index
 │   ├── inspector/     Frame / event / bot-reaction broadcaster
 │   ├── ipc/           Tauri commands, app state, capture supervisor
 │   ├── logger/        Per-session log dir + per-target file appenders
 │   ├── proxy/         MITM HTTP/HTTPS/WS via hudsucker; CA at ./ca
 │   ├── schema/        MjaiEvent enum + IPC payload types
+│   ├── updater/       In-app self-update (check + apply)
 │   └── lib.rs         Boot / wiring
+├── native_bot/        Built-in bot crate: obs/action codec, candle CNN, embedded weights
 ├── mjai_bot/
 │   └── example/       Rule-based shanten optimizer (ships in tree)
 ├── frontend/          React + Vite + Tailwind + shadcn UI
 │   └── src/
 │       ├── routes/    Overview / GameDashboard / Bots / History / Logs / Settings / Setup / InspectorView / DiagnosticView
 │       ├── tiles/     Dashboard tiles (header, hands, opponents, analysis, …)
-│       ├── stores/    Zustand slices (game, analysis, bot, proxy, notify, layout, config)
+│       ├── stores/    Zustand stores, one per domain (game, bot, config, theme, …)
 │       └── i18n/      en / ja / zh-TW / zh-CN
 ├── tests/             Integration tests
 ├── capabilities/      Tauri permissions

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,8 +65,9 @@
 Akagi 通过本机 Proxy 或内置浏览器监听你在雀魂 / 天凤的对局，
 镜像游戏状态，并在可拖拽的 HUD 中显示 **向听**、**听牌**、
 **和牌率**、**听牌率**、**对各家放铳风险**，以及
-**推荐切牌**。若加入符合 mjai 协议的 bot（例如 Mortal），
-HUD 在每巡也会显示该 bot 的建议。
+**推荐切牌**。可执行文件本身就内置了一个 **bot** —— 无需安装任何东西 ——
+它的建议会在每巡显示；若想要更强的托管模型，可以把它指向
+**云端推理 API**。
 
 ## 截图
 
@@ -95,6 +96,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 - [架构](#架构)
 - [技术栈](#技术栈)
 - [项目结构](#项目结构)
+- [mjai Bot 插件接口](#mjai-bot-插件接口)
 - [从源码构建](#从源码构建)
 - [测试](#测试)
 - [Releases 与 CI](#releases-与-ci)
@@ -114,9 +116,15 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   - **Chromium** — 由 Akagi 启动受控的 Chromium 系列浏览器，
     通过 Chrome DevTools Protocol 拦截 WebSocket 帧。
     无需配置 proxy 或安装证书；直接在启动的窗口中游玩即可。
-- **可插拔的 mjai bot** — 在设置一键安装 Mortal，或将
-  任意 `bot.py` 放入 `mjai_bot/<name>/`。可按模式切换：
-  `bot.active_4p` 与 `bot.active_3p` 会按牌桌人数自动启用。
+- **两种 bot 后端**
+  - **内置 bot**（默认） — 嵌在可执行文件内的纯 Rust 神经网络。
+    不需要 Python、不需要下载、不需要配置；四麻与三麻都能直接开打。
+  - **云端推理**（可选） — 把每一次决策交给通过 HTTP 访问、
+    更强的托管模型。内置模型仍保持加载作为自动兜底，因此服务器
+    连不上时也不会让对局卡住。密钥可直接在应用内购买或兑换。
+
+  两者皆可按模式切换：`bot.active_4p` 与 `bot.active_3p`
+  会按牌桌人数自动启用。
 - **对局历史** — 每场结束的对局会自动记录。历史标签页显示
   名次饼图、可选计分规则的累计 PT 折线图（雀魂段位 /
   天凤段位 / 自定义 uma），以及详细统计（和牌率、放铳率、
@@ -126,7 +134,8 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   可按模块过滤；**Inspector** 标签页显示原始 WebSocket 帧
   → mjai 事件 → bot 反应，附帧数与 meta 检视。
 - **首次启动设置** — 语言 → 平台 → 抓包模式 →
-  CA 信任 / Chromium 选择 → bot 安装 → 完成。
+  CA 信任 / Chromium 选择 → bot 配置 → 完成。
+  没有东西要安装：内置 bot 本来就在。
 - **多语言** — English、日本語、繁體中文、简体中文。
   可在配置向导或侧栏即时切换，覆盖整个 UI。
 - **三麻** — 完整流程：bridge、tracker、snapshot、
@@ -160,12 +169,13 @@ Akagi 以 portable zip 形式发布 — 每个平台一个自带所需文件的�
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未签名,解压后执行一次 `xattr -cr <解压后目录>`,或第一次右键 → *Open*。 |
 | Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上构建(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-每个 zip 都将 `python-build-standalone` 3.12 + `uv` 一并放在
-binary 旁边,bot 开箱即用,不需要额外安装系统 Python。
+内置 bot 完全不需要任何运行时。每个 zip 也将
+`python-build-standalone` 3.12 + `uv` 一并放在 binary 旁边，
+因此可选的 [mjai bot](#mjai-bot-插件接口) 不需要额外安装系统 Python。
 
-首次启动时,**配置向导** 会引导你完成语言、平台、抓包
-模式、可选的 bot 安装(Mortal)以及 CA 信任(仅 MITM
-模式才需要)。
+首次启动时，**配置向导** 会引导你完成语言、平台、抓包模式、
+bot 配置，以及 CA 信任（仅 MITM 模式才需要）。没有 bot 要安装
+—— 内置的那个本来就在。
 
 ### B. Chromium 模式（无需信任 CA）
 
@@ -252,34 +262,66 @@ dir       = "./mjai_bot"
 
 ## Bots
 
-### 安装 Bot
+### 内置 bot
 
-配置向导或 **Bots** 标签页可直接从 GitHub release 安装 bot：
+Akagi 内置一个 **纯 Rust 的 bot**，完全在进程内运行 —— 不需要
+Python、不需要 libriichi、不需要 `uv sync`，也没有任何东西要下载。
+它是两种模式的默认值（`bot.active_4p = "akagi-native"`、
+`bot.active_3p = "akagi-native3p"`），会出现在 **Bots** 标签页最上方，
+状态永远是「就绪」。
 
-- Repo：`shinkuan/Akagi-MjaiBot-Mortal`
-- 4P 资源：`release4p.zip`
-- 3P 资源：`release3p.zip`
+它是一个以天凤牌谱做行为克隆（behavior cloning）训练出来的小型神经
+网络（权重直接嵌在可执行文件内），因此棋力 **刻意保持在中等水平** ——
+它是个合理的默认值，而不是顶尖引擎。
 
-IPC 命令 `install_bot_from_github(repo, asset_glob?, name?)`
-会拉取最新 release zip，解压到 `mjai_bot/<name>/`，验证
-`bot.py`，并执行一次 `uv sync`。后续启动很快 — sync
-会根据 `mjai_bot/<name>/.akagi/synced.stamp` 戳记决定是否
-跳过。
+### 云端推理
 
-你也可以从**本地 ZIP** 安装 —— 适合离线安装或本地构建的
-bot。在 **Bots** 标签页点击 **从 ZIP 安装**，**浏览…** 选择
-`.zip`（或粘贴其路径）即可安装。它执行与 GitHub 安装完全相同
-的解压 / 验证 / `uv sync` 流程，并且不会改动你的源 `.zip`。
+内置 bot 可以选择把每一次决策交给 **远程推理服务器**，而不是运行内嵌
+的模型 —— 那是一个通过网络访问、更强的托管模型。内嵌的本地模型仍会
+保持加载作为自动 **兜底**：当服务器连不上、被限流，或密钥无效时，bot
+会安静地改用本地模型的着法，让进行中的对局不会卡住。
 
-> [!IMPORTANT]
-> 由于 GitHub 的文件大小限制，release zip 中附带的 Mortal
-> 权重是体积很小、强度很弱的 **占位模型**，仅用于验证安装
-> 是否成功，**不建议实战使用**。
-> **更强的 Mortal 权重** 与 **在线 API 服务器模型**
-> （托管型、强度更高的模型 — 将 bot 指向服务器并提供
-> API 密钥即可，本机不需要 NN）皆通过
-> [Discord 服务器](https://discord.gg/Z2wjXUK8bN) 发放。
-> 请在该处申请访问；4P 与 3P 两个版本都有提供。
+在 **Bots** 标签页的 **云端推理** 卡片中配置：
+
+- **启用云端推理 API** — 总开关。关闭（默认）⇒ 完全离线的本地模型。
+- **服务器地址** — 推理服务器。默认为 `https://mjapi.shinkuan.me`；
+  若你自建，可指向任意主机（`http://host:8080`、`https://host`）。
+- **API 密钥** — 32 字符的密钥。
+- **四麻 / 三麻模型** — 每种模式要请求的 model id；留空则使用服务器的
+  默认值。**获取模型列表** 会列出你的密钥可用的 id。
+
+按钮可以 **检查密钥**（套餐、到期时间、当日用量 vs 每日额度、速率
+限制）、**兑换码**（把预付码换成密钥 —— 新发一组，或给现有密钥
+加时间）、**购买密钥**（见下方），以及对服务器做 **健康检查**。为了
+不超出服务器的速率限制，bot 只在真正需要决策时才发出请求 —— 它会先在
+本地判断这一手是否可能有合法动作 —— 而不是每次对手切牌都问一次。
+
+保存后 **立即生效，即使在对局进行中**：bot 每次决策都会重新读取这些
+配置，因此你可以在半庄中途开启云端推理、修正打错的密钥，或切换模型，
+都不必重开对局。若服务器停止响应，bot 会退回本地模型，并在一段逐渐
+拉长的 backoff 窗口内跳过 API，而不是每一巡都等到超时；状态栏的
+**Online API** 指示灯会转红，恢复后再转绿。
+
+这些配置会保存在 `config.toml` 的 `[bot.api]`（`enabled`、`base_url`、
+`key`、`model_4p`、`model_3p`）。
+
+> **你的 API 密钥以明文存储** 在 `config.toml` 中，且 Akagi 会将它以
+> bearer token 发往配置的 **服务器地址**。请把该文件视为机密：不要提交
+> 到版本库，分享前（例如反馈问题时）也请先把 `key` 抹掉。
+
+#### 获取密钥
+
+三种方式，都在 **云端推理** 卡片上：
+
+- **购买密钥** — 应用内购买。选择套餐（一次性充值，或按月订阅），
+  Akagi 会在浏览器打开 PayPal。价格由服务器决定，应用只发送商品
+  id。付款完成后，密钥会自动回填并保存 —— 付款期间你可以关闭对话框，
+  状态标签会带你回来。万一回填失败，密钥也会发送到你的 PayPal 邮箱，
+  购买永远不会丢失。唯一的例外是勾选 *把时间加到当前密钥* 购买：
+  那会把买到的天数叠加到你已持有的密钥上，因此发到邮箱的是用来充值的
+  预付 **兑换码**，而不是一组新密钥。
+- **兑换码** — 把预付码换成密钥，或给你已持有的密钥加时间。
+- 到 [Discord 服务器](https://discord.gg/Z2wjXUK8bN) 询问。
 
 ### 按模式切换的 bot
 
@@ -287,38 +329,9 @@ bot。在 **Bots** 标签页点击 **从 ZIP 安装**，**浏览…** 选择
 局时按牌桌人数选用对应的 bot。将某个槽位留空即可在该
 模式下仅使用 **分析功能**（不显示 bot 建议）。
 
-### 自行编写 bot
-
-```
-mjai_bot/<name>/
-├── bot.py            # JSONL stdin → JSONL stdout
-├── pyproject.toml    # requires-python = ">=3.12"
-├── manifest.toml     # 可选 — supported_modes、配置 schema
-└── README.md
-```
-
-`bot.py` 从 stdin 每行读取一个 mjai 事件 JSON 数组，并向
-stdout 每行写出一个 mjai 动作对象（无动作时输出
-`{"type":"none"}`）。Akagi 会把 stderr 内容写入应用日志
-中的 `bot=<name>` 条目。
-
-完整协议、manifest schema 以及 secret 字段处理请见
-[`src/bot/README.md`](./src/bot/README.md)。
-[`mjai_bot/example/`](./mjai_bot/example/) 是一个 in-tree、
-可运行的规则型示例 bot。
-
-本地开发时，把 bot 文件夹放到 `mjai_bot/<name>/`，在 **Bots** 标签页该 bot
-行上点击 **安装环境** 即可构建其 venv —— 无需每次改动都重新打包安装。环境
-就绪前启用开关会保持禁用。
-
-### AGPL 边界
-
-Bot 以 Akagi 启动的 **独立 OS 子进程** 运行。通信严格通
-过 stdin / stdout 上的 JSONL 进行 — 没有 in-process 链接、
-没有共享地址空间、没有 FFI。这是有意设计的许可边界：
-AGPL 许可的 bot（例如链接 libriichi 的 Mortal）会留在
-其自己的进程内，因此把它放入 `mjai_bot/<name>/` **不会**
-让 Akagi 成为该 bot 的衍生作品。
+除了这两种后端之外，Akagi 也能以子进程运行 **外部 mjai bot**。
+那是给开发者的扩展点，而不是任何人都得走的步骤 ——
+请见 [mjai Bot 插件接口](#mjai-bot-插件接口)。
 
 ---
 
@@ -553,6 +566,60 @@ alpha.8 已完成：
 ```
 
 各模块的开发者指南位于对应的 `src/*/README.md`。
+
+## mjai Bot 插件接口
+
+> 可选功能，主要面向开发者。[内置 bot](#内置-bot) 才是默认值，完全不需要
+> 这一节的任何步骤 —— 只有当你想让 Akagi 驱动 *另一个* 引擎时才会用到。
+
+除了自家的 bot 之外，Akagi 也能驱动任何遵循 **mjai** 协议的引擎。这种 bot
+是一个独立子进程，通过 stdin/stdout 以 JSONL 通信：Akagi 把对局以 mjai
+事件喂给它，它则回复一个动作，以及可选的 HUD 数据。
+
+### 自行编写
+
+```
+mjai_bot/<name>/
+├── bot.py            # JSONL stdin → JSONL stdout
+├── pyproject.toml    # requires-python = ">=3.12"
+├── manifest.toml     # 可选 — supported_modes、配置 schema
+└── README.md
+```
+
+`bot.py` 从 stdin 每行读取一个 mjai 事件 JSON 数组，并向 stdout 每行写出
+一个 mjai 动作对象（无动作时输出 `{"type":"none"}`）。Akagi 会把 stderr
+内容写入应用日志中的 `bot=<name>` 条目。
+
+完整的 I/O 协议、mjai 事件流、reaction 与 `meta` HUD 格式、toast 通知，
+以及 `manifest.toml` 配置，请见
+**[`mjai_bot/README.md`](./mjai_bot/README.md)**。
+[`mjai_bot/example/`](./mjai_bot/example/) 是一个可直接复制、可运行的
+规则型示例 bot。
+
+本地开发时，把 bot 文件夹放到 `mjai_bot/<name>/`，在 **Bots** 标签页该 bot
+行上点击 **安装环境** 即可构建其 venv —— 无需每次改动都重新打包安装。
+环境就绪前，启用开关会保持禁用。
+
+### 安装
+
+**Bots** 标签页可以从 GitHub release 或本地 ZIP 安装 bot。
+
+IPC 命令 `install_bot_from_github(repo, asset_glob?, name?)` 会拉取最新
+release zip，解压到 `mjai_bot/<name>/`，验证 `bot.py`，并执行一次
+`uv sync`。后续启动很快 —— sync 会根据
+`mjai_bot/<name>/.akagi/synced.stamp` 戳记决定是否跳过。
+
+**从 ZIP 安装** 是离线的等价流程：点击 **浏览…** 选择 `.zip`（或粘贴其
+路径）即可。它执行完全相同的解压 / 验证 / `uv sync` 流程，并且不会改动
+你的源 `.zip`。
+
+### AGPL 边界
+
+Bot 以 Akagi 启动的 **独立 OS 子进程** 运行。通信严格通过 stdin / stdout
+上的 JSONL 进行 —— 没有 in-process 链接、没有共享地址空间、没有 FFI。
+这是有意设计的许可边界：AGPL 许可的 bot（例如链接 libriichi 的 Mortal）
+会留在其自己的进程内，因此把它放入 `mjai_bot/<name>/` **不会** 让 Akagi
+成为该 bot 的衍生作品。
 
 ## 从源码构建
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,9 +65,9 @@
 Akagi 通过本机 Proxy 或内置浏览器监听你在雀魂 / 天凤的对局，
 镜像游戏状态，并在可拖拽的 HUD 中显示 **向听**、**听牌**、
 **和牌率**、**听牌率**、**对各家放铳风险**，以及
-**推荐切牌**。可执行文件本身就内置了一个 **bot** —— 无需安装任何东西 ——
+**推荐切牌**。可执行文件本身就内置了一个AI模型 —— 无需安装任何东西 ——
 它的建议会在每巡显示；若想要更强的托管模型，可以把它指向
-**云端推理 API**。
+云端推理 API。
 
 ## 截图
 
@@ -85,7 +85,6 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 - [功能](#功能)
 - [支持的平台](#支持的平台)
 - [快速开始](#快速开始)
-- [配置文件](#配置文件)
 - [Bots](#bots)
 - [对局历史](#对局历史)
 - [日志与诊断](#日志与诊断)
@@ -109,8 +108,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 ## 功能
 
 - **实时 HUD** — 向听、听牌、和牌率、听牌率、对各家放铳
-  风险、推荐的进攻 / 防守切牌。可拖拽、可缩放的牌格布局
-  会持久化到 local storage。
+  风险、推荐的进攻 / 防守切牌。可拖拽、可缩放的UI布局。
 - **两种抓包模式**
   - **MITM proxy**（默认） — 系统级；需一次性的 CA 信任。
   - **Chromium** — 由 Akagi 启动受控的 Chromium 系列浏览器，
@@ -120,7 +118,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   - **内置 bot**（默认） — 嵌在可执行文件内的纯 Rust 神经网络。
     不需要 Python、不需要下载、不需要配置；四麻与三麻都能直接开打。
   - **云端推理**（可选） — 把每一次决策交给通过 HTTP 访问、
-    更强的托管模型。内置模型仍保持加载作为自动兜底，因此服务器
+    **更强的托管模型**。内置模型仍保持加载作为自动兜底，因此服务器
     连不上时也不会让对局卡住。密钥可直接在应用内购买或兑换。
 
   两者皆可按模式切换：`bot.active_4p` 与 `bot.active_3p`
@@ -130,22 +128,19 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   天凤段位 / 自定义 uma），以及详细统计（和牌率、放铳率、
   立直率、副露率、流局率、平均和牌 / 放铳点数、平均和牌
   巡目、役满 / 流局满贯次数）。
-- **日志查看** — **Diagnostic** 标签页实时 tail 应用日志，
-  可按模块过滤；**Inspector** 标签页显示原始 WebSocket 帧
-  → mjai 事件 → bot 反应，附帧数与 meta 检视。
-- **首次启动设置** — 语言 → 平台 → 抓包模式 →
+- **简单的首次启动设置** — 语言 → 平台 → 抓包模式 →
   CA 信任 / Chromium 选择 → bot 配置 → 完成。
-  没有东西要安装：内置 bot 本来就在。
 - **多语言** — English、日本語、繁體中文、简体中文。
-  可在配置向导或侧栏即时切换，覆盖整个 UI。
-- **三麻** — 完整流程：bridge、tracker、snapshot、
-  分析、按模式 bot 路由、历史统计、3p uma 表。
+  可在配置向导或设置即时切换。
+- **三麻** — 完整支持：AI分析、按模式 bot 路由、历史统计、3p uma 表。
+- **应用内更新** — 启动时自动检查新版本，也可在 *设置 → 更新*
+  手动检查；一键下载、原地更新并重新启动。
 
 ## 支持的平台
 
 | 平台 | 四麻 | 三麻 | AutoPlay |
 |---|:---:|:---:|:---:|
-| **雀魂（Mahjong Soul / Majsoul）** | &check; | &check; | （计划中） |
+| **雀魂（Mahjong Soul / Majsoul）** | &check; | &check; | &check; |
 | **天凤（Tenhou）** | &check; | &check; | &cross; |
 | **Riichi City** | &check; | &check; | &cross; |
 | **Amatsuki** | （计划中） | （计划中） | &cross; |
@@ -159,8 +154,8 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 Akagi 以 portable zip 形式发布 — 每个平台一个自带所需文件的目录。
 从 [Releases](https://github.com/shinkuan/Akagi/releases) 下载
 对应操作系统的 zip,解压到任何你有写入权限的位置(例如
-`~/Apps/`、桌面),然后直接运行里面的 binary 即可。配置文件、
-日志、对局历史、CA 证书以及 bot 都会建立在 binary 旁边,所以
+`~/Apps/`、桌面),然后直接运行里面的`akagi`即可。配置文件、
+日志、对局历史、CA 证书以及 bot 都会建立在旁边,所以
 迁移 / 备份 / 卸载就是迁移 / 复制 / 删除整个目录。
 
 | OS | 文件 | 备注 |
@@ -169,23 +164,13 @@ Akagi 以 portable zip 形式发布 — 每个平台一个自带所需文件的�
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未签名,解压后执行一次 `xattr -cr <解压后目录>`,或第一次右键 → *Open*。 |
 | Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上构建(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-内置 bot 完全不需要任何运行时。每个 zip 也将
-`python-build-standalone` 3.12 + `uv` 一并放在 binary 旁边，
-因此可选的 [mjai bot](#mjai-bot-插件接口) 不需要额外安装系统 Python。
-
 首次启动时，**配置向导** 会引导你完成语言、平台、抓包模式、
 bot 配置，以及 CA 信任（仅 MITM 模式才需要）。没有 bot 要安装
 —— 内置的那个本来就在。
 
 ### B. Chromium 模式（无需信任 CA）
 
-最简单的方式。完成配置向导后：
-
-1. 设置 → **Capture** → 将 Mode 设为 **Chromium**。
-2. 点击 **Detect** 自动查找 Chrome / Edge / Brave / Chromium，
-   或手动设置 `capture.chromium.executable`。
-3. Akagi 会以独立的用户配置启动浏览器，目录位于
-   `<config_root>/chrome-profile`。登录雀魂后即可开始游玩。
+最简单的方式。完成配置向导后Akagi会自动查找 Chrome / Edge / Brave / Chromium 然后以独立的用户配置启动浏览器，登录雀魂后即可开始游玩。
 
 帧通过 Chrome DevTools Protocol 拦截 — 不需要系统 proxy、
 不需要证书。
@@ -194,7 +179,7 @@ bot 配置，以及 CA 信任（仅 MITM 模式才需要）。没有 bot 要安�
 
 系统级的 proxy，搭配位于 `./ca/` 的自签根 CA：
 
-1. 在操作系统 / 浏览器的证书库中信任
+1. 信任证书
    `./ca/akagi-ca.crt`（或 `.cer` / `.pem` / `.der`）。
 2. 将游戏客户端的流量导向 `127.0.0.1:23410`。
    健康检查：`GET /ping` → `pong`。
@@ -203,131 +188,37 @@ bot 配置，以及 CA 信任（仅 MITM 模式才需要）。没有 bot 要安�
 
 ---
 
-## 配置文件
-
-配置文件 `config.toml` 位于可执行文件旁（或你以 `--config`
-指向的位置）。通过设置 UI 保存的修改会热重载对应子系统 —
-capture / proxy / bot active 槽位无需重启整个应用即可生效。
-
-```toml
-[general]
-language = "en"
-
-[logging]
-dir       = "./logs"
-level     = "info"
-all_level = "warn"
-
-[platform]
-kind = "Majsoul"
-
-[proxy]
-enabled = true
-addr    = "127.0.0.1:23410"
-ca_dir  = "./ca"
-
-[capture]
-mode = "mitm"               # 或 "chromium"
-
-[capture.chromium]
-executable    = ""          # 留空 = 自动检测
-user_data_dir = ""          # 留空 = <config_root>/chrome-profile
-start_url     = "https://game.maj-soul.com/1/"
-cft_channel   = "stable"
-force_cft     = false
-extra_args    = []
-
-[bot]
-enabled   = true
-active_4p = "mortal"        # 用于四麻
-active_3p = "mortal3p"      # 用于三麻；留空 = 不启用
-auto_sync = true
-dir       = "./mjai_bot"
-```
-
-<details>
-<summary>配置文件位置（解析顺序）</summary>
-
-1. `--config <path>` CLI 参数。
-2. `<exe_dir>/configs/config.toml`。
-3. 当前工作目录下的 `./configs.toml`。
-4. 以上均不存在时，首次启动会将默认值写入
-   `<exe_dir>/configs/config.toml`。
-
-旧版配置（仍使用单一 `active = "..."` 键）加载时会自动
-迁移为 `active_4p`。
-</details>
-
----
-
 ## Bots
 
 ### 内置 bot
 
-Akagi 内置一个 **纯 Rust 的 bot**，完全在进程内运行 —— 不需要
-Python、不需要 libriichi、不需要 `uv sync`，也没有任何东西要下载。
-它是两种模式的默认值（`bot.active_4p = "akagi-native"`、
+Akagi 内置一个 **纯 Rust 的 bot**，它是两种模式的默认值（`bot.active_4p = "akagi-native"`、
 `bot.active_3p = "akagi-native3p"`），会出现在 **Bots** 标签页最上方，
 状态永远是「就绪」。
 
-它是一个以天凤牌谱做行为克隆（behavior cloning）训练出来的小型神经
+它是一个以行为克隆（behavior cloning）训练出来的小型神经
 网络（权重直接嵌在可执行文件内），因此棋力 **刻意保持在中等水平** ——
 它是个合理的默认值，而不是顶尖引擎。
 
 ### 云端推理
 
-内置 bot 可以选择把每一次决策交给 **远程推理服务器**，而不是运行内嵌
+内置 bot 可以选择把决策交给 **远程推理服务器**，而不是运行内嵌
 的模型 —— 那是一个通过网络访问、更强的托管模型。内嵌的本地模型仍会
 保持加载作为自动 **兜底**：当服务器连不上、被限流，或密钥无效时，bot
-会安静地改用本地模型的着法，让进行中的对局不会卡住。
+会改用本地模型的着法，让进行中的对局不会卡住。
 
-在 **Bots** 标签页的 **云端推理** 卡片中配置：
+#### 获取云端推理密钥
 
-- **启用云端推理 API** — 总开关。关闭（默认）⇒ 完全离线的本地模型。
-- **服务器地址** — 推理服务器。默认为 `https://mjapi.shinkuan.me`；
-  若你自建，可指向任意主机（`http://host:8080`、`https://host`）。
-- **API 密钥** — 32 字符的密钥。
-- **四麻 / 三麻模型** — 每种模式要请求的 model id；留空则使用服务器的
-  默认值。**获取模型列表** 会列出你的密钥可用的 id。
+三种方式：
 
-按钮可以 **检查密钥**（套餐、到期时间、当日用量 vs 每日额度、速率
-限制）、**兑换码**（把预付码换成密钥 —— 新发一组，或给现有密钥
-加时间）、**购买密钥**（见下方），以及对服务器做 **健康检查**。为了
-不超出服务器的速率限制，bot 只在真正需要决策时才发出请求 —— 它会先在
-本地判断这一手是否可能有合法动作 —— 而不是每次对手切牌都问一次。
-
-保存后 **立即生效，即使在对局进行中**：bot 每次决策都会重新读取这些
-配置，因此你可以在半庄中途开启云端推理、修正打错的密钥，或切换模型，
-都不必重开对局。若服务器停止响应，bot 会退回本地模型，并在一段逐渐
-拉长的 backoff 窗口内跳过 API，而不是每一巡都等到超时；状态栏的
-**Online API** 指示灯会转红，恢复后再转绿。
-
-这些配置会保存在 `config.toml` 的 `[bot.api]`（`enabled`、`base_url`、
-`key`、`model_4p`、`model_3p`）。
-
-> **你的 API 密钥以明文存储** 在 `config.toml` 中，且 Akagi 会将它以
-> bearer token 发往配置的 **服务器地址**。请把该文件视为机密：不要提交
-> 到版本库，分享前（例如反馈问题时）也请先把 `key` 抹掉。
-
-#### 获取密钥
-
-三种方式，都在 **云端推理** 卡片上：
-
-- **购买密钥** — 应用内购买。选择套餐（一次性充值，或按月订阅），
-  Akagi 会在浏览器打开 PayPal。价格由服务器决定，应用只发送商品
-  id。付款完成后，密钥会自动回填并保存 —— 付款期间你可以关闭对话框，
-  状态标签会带你回来。万一回填失败，密钥也会发送到你的 PayPal 邮箱，
-  购买永远不会丢失。唯一的例外是勾选 *把时间加到当前密钥* 购买：
-  那会把买到的天数叠加到你已持有的密钥上，因此发到邮箱的是用来充值的
-  预付 **兑换码**，而不是一组新密钥。
+- **购买密钥** — 应用内购买。
 - **兑换码** — 把预付码换成密钥，或给你已持有的密钥加时间。
 - 到 [Discord 服务器](https://discord.gg/Z2wjXUK8bN) 询问。
 
 ### 按模式切换的 bot
 
 `bot.active_4p` 与 `bot.active_3p` 互相独立。Akagi 会在开
-局时按牌桌人数选用对应的 bot。将某个槽位留空即可在该
-模式下仅使用 **分析功能**（不显示 bot 建议）。
+局时按牌桌人数选用对应的 bot。
 
 除了这两种后端之外，Akagi 也能以子进程运行 **外部 mjai bot**。
 那是给开发者的扩展点，而不是任何人都得走的步骤 ——
@@ -431,14 +322,6 @@ session；点击行可看到原始结构化字段与源位置。
   `capture.chromium.executable`。如果浏览器有启动但没
   帧流入，检查 `--remote-debugging-port` 是否被其他
   扩展拦截。
-- **Bot 卡在 `Loading{SyncingDeps}`。** 首次 `uv sync`
-  会很慢 — 在 Diagnostic 标签页观察 `bot=<name>` 的消息。
-  若一直未完成，删除
-  `mjai_bot/<name>/.akagi/synced.stamp` 后重试。
-- **启用开关变灰 / 手动放入的 bot 无法启用。** 它的 Python 环境还没构建。
-  在 **Bots** 标签页该 bot 行上点击 **安装环境** 按钮（环境未就绪时会出现）
-  以运行 `uv sync`；完成后开关即可启用。修改该 bot 的 `pyproject.toml` 会
-  使环境失效，按钮会再次出现。
 - **Bot 对局途中崩溃。** Inspector 标签页可显示 bot 死前
   看到的最后一帧；附在 bug 报告里。
 - **三麻挑了错的 bot。** 检查设置 → Bot 中的
@@ -462,15 +345,14 @@ alpha.8 已完成：
 - [x] i18n：en / ja / zh-TW / zh-CN，含配置向导语言选择
 - [x] 从 GitHub release 或本地 ZIP 文件安装 bot
 - [x] Chromium 抓包模式（无需信任 CA）
+- [x] **自定义主题**（前端 theming hook）
+- [x] **AutoPlay**（先支持雀魂；由 bot 自主控制牌桌）
 
 计划中：
 
 - [ ] **Amatsuki** 平台支持
-- [ ] **自定义主题**（前端 theming hook）
-- [ ] **AutoPlay**（先支持雀魂；由 bot 自主控制牌桌，
-      类似原版 Akagi 在 Windows 的 AutoPlay）
 - [ ] **前端打磨** — 牌型布局、动画、无障碍
-- [ ] **天凤 autoplay**（目前仅观战）
+- [ ] **天凤 autoplay**
 
 详细的 bug 跟踪请到
 [GitHub Issues](https://github.com/shinkuan/Akagi/issues)。
@@ -499,17 +381,18 @@ alpha.8 已完成：
   game_state::tracker   bot::manager     ipc forwarder
        │                  │                  │
        ▼ PostBus          ▼ BotResponseBus   ▼ app.emit
-  analysis::runner   subprocess (uv)    Tauri webview
-       │
-       ▼ AnalysisBus
+  analysis::runner   内置 NN（进程内）     Tauri webview
+       │             | 云端 API
+       ▼ AnalysisBus  | mjai 子进程
        └──► ipc forwarder ──► app.emit
 ```
 
 [`src/lib.rs`](./src/lib.rs) 在启动时把这些 bus 接起来。
-前端通过六个 push 事件（`mjai-event`、`bot-response`、
-`bot-status`、`proxy-status`、`notify`、`history-recorded`）
-与 backend 通信，pull 命令的列表请见
-[`src/ipc/README.md`](./src/ipc/README.md)。
+前端通过 push 事件（`mjai-event`、`bot-response`、
+`bot-status`…）与 pull 命令和 backend 通信，两者的列表
+都在 [`src/ipc/README.md`](./src/ipc/README.md)。开启
+AutoPlay 时，`autoplay` manager 会取用 bot 的决策，并通过
+Chromium 抓包 backend（CDP）点击牌桌。
 
 ## 技术栈
 
@@ -520,6 +403,8 @@ alpha.8 已完成：
 | MITM | [`hudsucker`](https://crates.io/crates/hudsucker) 0.24（`rcgen-ca`、`rustls-client`） |
 | CDP capture | [`chromiumoxide`](https://crates.io/crates/chromiumoxide) 0.9 |
 | 麻将引擎 | [`riichienv-core`](https://github.com/smly/RiichiEnv) 0.4 |
+| 内置 bot | [`candle`](https://github.com/huggingface/candle) 0.9（纯 Rust NN 推理；权重内嵌） |
+| 云端推理 | [`reqwest`](https://crates.io/crates/reqwest) 0.13（rustls） |
 | Protobuf | `prost` 0.14 + `prost-reflect` 0.16 |
 | 前端 | [React](https://react.dev) 19、TypeScript、[Vite](https://vitejs.dev) 8 |
 | 样式 | [Tailwind CSS](https://tailwindcss.com) v4、[shadcn/ui](https://ui.shadcn.com)（Radix Nova preset） |
@@ -527,7 +412,7 @@ alpha.8 已完成：
 | 图表 | [Recharts](https://recharts.org) |
 | 牌型渲染 | [`<mah-gen>`](https://github.com/eric200203/mahgen) Web Component |
 | i18n | [react-i18next](https://react.i18next.com) |
-| Bot 运行环境 | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv)（按平台打包） |
+| mjai bot 运行环境 | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv)（按平台打包；仅插件 bot 需要 —— 内置 bot 完全用不到） |
 
 ## 项目结构
 
@@ -535,28 +420,33 @@ alpha.8 已完成：
 .
 ├── src/
 │   ├── analysis/      向听 / 听牌 / 和牌率 / 风险 / 切牌搜索
-│   ├── bot/           Registry、Python runtime、JSONL 子进程执行器
+│   ├── autoplay/      bot 决策 → 通过 CDP 点击牌桌（AutoPlay）
+│   ├── bot/           Bot manager：内置 bot、云端 API client、mjai 子进程执行器
 │   ├── bridge/        各平台协议 → MjaiEvent
 │   │   ├── majsoul/   雀魂（liqi protobuf）
+│   │   ├── riichi_city/  Riichi City（仅 MITM）
 │   │   └── tenhou/    天凤（JSON tag stream，仅观战）
 │   ├── capture/       抓包 backend 抽象（mitm | chromium）
 │   ├── config/        AppConfig（TOML）分节与解析
 │   ├── event_bus.rs   子系统间的 broadcast channel
 │   ├── game_state/    riichienv 驱动的镜像、snapshot、mahgen view
+│   ├── github/        GitHub Releases client（bot 安装、自我更新）
 │   ├── history/       对局回放存储与索引
 │   ├── inspector/     帧 / 事件 / bot reaction broadcaster
 │   ├── ipc/           Tauri 命令、app state、capture supervisor
 │   ├── logger/        每 session 日志目录与每 target 文件 appender
 │   ├── proxy/         通过 hudsucker 的 MITM HTTP/HTTPS/WS；CA 位于 ./ca
 │   ├── schema/        MjaiEvent enum 与 IPC payload 类型
+│   ├── updater/       应用内自我更新（检查 + 应用）
 │   └── lib.rs         启动与接线
+├── native_bot/        内置 bot crate：obs/action codec、candle CNN、内嵌权重
 ├── mjai_bot/
 │   └── example/       in-tree 规则型向听优化器
 ├── frontend/          React + Vite + Tailwind + shadcn UI
 │   └── src/
 │       ├── routes/    Overview / GameDashboard / Bots / History / Logs / Settings / Setup / InspectorView / DiagnosticView
 │       ├── tiles/     仪表板磁贴（header、hands、opponents、analysis…）
-│       ├── stores/    Zustand slice（game、analysis、bot、proxy、notify、layout、config）
+│       ├── stores/    Zustand store，一个领域一个（game、bot、config、theme…）
 │       └── i18n/      en / ja / zh-TW / zh-CN
 ├── tests/             集成测试
 ├── capabilities/      Tauri 权限

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -65,9 +65,9 @@
 Akagi 透過本機 Proxy 或內建瀏覽器監看你在雀魂 / 天鳳的對局，
 鏡射遊戲狀態，並在可拖曳的 HUD 中顯示 **向聽**、**待牌**、
 **和牌率**、**聽牌率**、**對各家放銃風險**，以及
-**推薦切牌**。執行檔本身就內建一個 **bot** —— 不需要安裝任何東西 ——
+**推薦切牌**。執行檔本身就內建一個AI模型 —— 不需要安裝任何東西 ——
 它的建議會在每巡顯示；若想要更強的託管模型，可以把它指向
-**雲端推論 API**。
+雲端推論 API。
 
 ## 截圖
 
@@ -85,7 +85,6 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 - [功能](#功能)
 - [支援的平台](#支援的平台)
 - [快速開始](#快速開始)
-- [設定檔](#設定檔)
 - [Bots](#bots)
 - [對局歷史](#對局歷史)
 - [紀錄與診斷](#紀錄與診斷)
@@ -109,8 +108,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 ## 功能
 
 - **即時 HUD** — 向聽、待牌、和牌率、聽牌率、對各家放銃
-  風險、推薦的進攻 / 防守切牌。可拖曳、可縮放的牌格佈局
-  會持久化於 local storage。
+  風險、推薦的進攻 / 防守切牌。可拖曳、可縮放的UI佈局。
 - **兩種抓包模式**
   - **MITM proxy**（預設） — 系統層級；需一次性的 CA 信任。
   - **Chromium** — 由 Akagi 啟動受控的 Chromium 系列瀏覽器，
@@ -120,7 +118,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   - **內建 bot**（預設） — 嵌在執行檔內的純 Rust 神經網路。
     不需要 Python、不需要下載、不需要設定；四麻與三麻都能直接開打。
   - **雲端推論**（選用） — 把每一次決策交給透過 HTTP 存取、
-    更強的託管模型。內建模型仍保持載入作為自動後備，因此伺服器
+    **更強的託管模型**。內建模型仍保持載入作為自動後備，因此伺服器
     連不上時也不會讓對局卡住。金鑰可直接在應用程式內購買或兌換。
 
   兩者皆可依模式切換：`bot.active_4p` 與 `bot.active_3p`
@@ -130,22 +128,19 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   天鳳段位 / 自訂 uma），以及細部統計（和牌率、放銃率、
   立直率、副露率、流局率、平均和牌 / 放銃點數、平均和牌
   巡目、役滿 / 流局滿貫次數）。
-- **紀錄檢視** — **Diagnostic** 頁籤即時 tail 應用程式紀錄，
-  可依模組過濾；**Inspector** 頁籤顯示原始 WebSocket 訊框
-  → mjai 事件 → bot 反應，附訊框數量與 meta 檢視。
-- **首次啟動設定** — 語言 → 平台 → 抓包模式 →
+- **簡單的首次啟動設定** — 語言 → 平台 → 抓包模式 →
   CA 信任 / Chromium 選擇 → bot 設定 → 完成。
-  沒有東西要安裝：內建 bot 本來就在。
 - **多語系** — English、日本語、繁體中文、简体中文。
-  可在設定精靈或側邊欄即時切換，覆蓋整個 UI。
-- **三麻** — 完整流程：bridge、tracker、snapshot、
-  分析、依模式 bot 路由、歷史統計、3p uma 表。
+  可在設定精靈或設定即時切換。
+- **三麻** — 完整支援：AI分析、依模式 bot 路由、歷史統計、3p uma 表。
+- **應用程式內更新** — 啟動時自動檢查新版本，也可在 *設定 → 更新*
+  手動檢查；一鍵下載、原地更新並重新啟動。
 
 ## 支援的平台
 
 | 平台 | 四麻 | 三麻 | AutoPlay |
 |---|:---:|:---:|:---:|
-| **雀魂（Mahjong Soul / Majsoul）** | &check; | &check; | （規劃中） |
+| **雀魂（Mahjong Soul / Majsoul）** | &check; | &check; | &check; |
 | **天鳳（Tenhou）** | &check; | &check; | &cross; |
 | **Riichi City** | &check; | &check; | &cross; |
 | **Amatsuki** | （規劃中） | （規劃中） | &cross; |
@@ -159,8 +154,8 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料夾。
 從 [Releases](https://github.com/shinkuan/Akagi/releases) 下載
 對應作業系統的 zip,解壓縮到任何你有寫入權限的位置(例如
-`~/Apps/`、桌面),然後直接執行裡面的 binary 即可。設定檔、紀錄、
-歷史對局、CA 憑證以及 bot 都會建立在 binary 旁邊,所以搬移 /
+`~/Apps/`、桌面),然後直接執行裡面的`akagi`即可。設定檔、紀錄、
+歷史對局、CA 憑證以及 bot 都會建立在旁邊,所以搬移 /
 備份 / 解除安裝就只是搬移 / 複製 / 刪除整個資料夾。
 
 | OS | 檔案 | 備註 |
@@ -169,23 +164,13 @@ Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料�
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未簽章,解壓後執行一次 `xattr -cr <解壓後資料夾>`,或第一次右鍵 → *Open*。 |
 | Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上建置(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-內建 bot 完全不需要任何執行環境。每個 zip 也將
-`python-build-standalone` 3.12 + `uv` 一併放在 binary 旁邊，
-因此選用的 [mjai bot](#mjai-bot-外掛介面) 不需另外安裝系統 Python。
-
 首次啟動時會引導你完成語言、平台、抓包模式、bot 設定，
 以及 CA 信任（僅 MITM 模式才需要）。沒有 bot 要安裝 ——
 內建的那個本來就在。
 
 ### B. Chromium 模式（不需信任 CA）
 
-最簡單的方式。完成設定後：
-
-1. 設定 → **Capture** → 將 Mode 設為 **Chromium**。
-2. 點擊 **Detect** 自動尋找 Chrome / Edge / Brave / Chromium，
-   或手動設定 `capture.chromium.executable`。
-3. Akagi 會以獨立的個人資料啟動瀏覽器，目錄位於
-   `<config_root>/chrome-profile`。登入雀魂後即可開始遊玩。
+最簡單的方式。完成設定後Akagi會自動尋找 Chrome / Edge / Brave / Chromium 然後以獨立的個人資料啟動瀏覽器，登入雀魂後即可開始遊玩。
 
 透過 Chrome DevTools Protocol 攔截 — 不需系統 proxy、
 不需憑證。
@@ -194,7 +179,7 @@ Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料�
 
 系統層級的 proxy，搭配位於 `./ca/` 的自簽根 CA：
 
-1. 在作業系統 / 瀏覽器的憑證儲存區信任
+1. 信任憑證
    `./ca/akagi-ca.crt`（或 `.cer` / `.pem` / `.der`）。
 2. 將遊戲客戶端的流量導向 `127.0.0.1:23410`。
    健康檢查：`GET /ping` → `pong`。
@@ -203,131 +188,37 @@ Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料�
 
 ---
 
-## 設定檔
-
-設定檔 `config.toml` 位於可執行檔旁（或你以 `--config` 指
-向的位置）。透過設定 UI 儲存的修改會熱重載對應子系統 —
-capture / proxy / bot active 槽位無需重啟整個應用即可生效。
-
-```toml
-[general]
-language = "en"
-
-[logging]
-dir       = "./logs"
-level     = "info"
-all_level = "warn"
-
-[platform]
-kind = "Majsoul"
-
-[proxy]
-enabled = true
-addr    = "127.0.0.1:23410"
-ca_dir  = "./ca"
-
-[capture]
-mode = "mitm"               # 或 "chromium"
-
-[capture.chromium]
-executable    = ""          # 留空 = 自動偵測
-user_data_dir = ""          # 留空 = <config_root>/chrome-profile
-start_url     = "https://game.maj-soul.com/1/"
-cft_channel   = "stable"
-force_cft     = false
-extra_args    = []
-
-[bot]
-enabled   = true
-active_4p = "mortal"        # 用於四麻
-active_3p = "mortal3p"      # 用於三麻；留空 = 不啟用
-auto_sync = true
-dir       = "./mjai_bot"
-```
-
-<details>
-<summary>設定檔位置（解析順序）</summary>
-
-1. `--config <path>` CLI 旗標。
-2. `<exe_dir>/configs/config.toml`。
-3. 當前工作目錄下的 `./configs.toml`。
-4. 以上皆不存在時，首次啟動會將預設值寫入
-   `<exe_dir>/configs/config.toml`。
-
-舊版設定（仍使用單一 `active = "..."` 鍵）載入時會自動
-遷移為 `active_4p`。
-</details>
-
----
-
 ## Bots
 
 ### 內建 bot
 
-Akagi 內建一個 **純 Rust 的 bot**，完全在行程內執行 —— 不需要
-Python、不需要 libriichi、不需要 `uv sync`，也沒有任何東西要下載。
-它是兩種模式的預設值（`bot.active_4p = "akagi-native"`、
+Akagi 內建一個 **純 Rust 的 bot**，它是兩種模式的預設值（`bot.active_4p = "akagi-native"`、
 `bot.active_3p = "akagi-native3p"`），會出現在 **Bots** 頁籤最上方，
 狀態永遠是「就緒」。
 
-它是一個以天鳳牌譜做行為複製（behavior cloning）訓練出來的小型神經
+它是一個以行為複製（behavior cloning）訓練出來的小型神經
 網路（權重直接嵌在執行檔內），因此棋力 **刻意保持在中等水準** ——
 它是個合理的預設值，而不是頂尖引擎。
 
 ### 雲端推論
 
-內建 bot 可以選擇把每一次決策交給 **遠端推論伺服器**，而不是執行內嵌
+內建 bot 可以選擇把決策交給 **遠端推論伺服器**，而不是執行內嵌
 的模型 —— 那是一個透過網路存取、更強的託管模型。內嵌的本機模型仍會
 保持載入作為自動 **後備**：當伺服器連不上、被限流，或金鑰無效時，bot
-會安靜地改用本機模型的著手，讓進行中的對局不會卡住。
+會改用本機模型的著手，讓進行中的對局不會卡住。
 
-在 **Bots** 頁籤的 **雲端推論** 卡片中設定：
+#### 取得雲端推論金鑰
 
-- **啟用雲端推論 API** — 總開關。關閉（預設）⇒ 完全離線的本機模型。
-- **伺服器網址** — 推論伺服器。預設為 `https://mjapi.shinkuan.me`；
-  若你自架，可指向任意主機（`http://host:8080`、`https://host`）。
-- **API 金鑰** — 32 字元的金鑰。
-- **四麻 / 三麻模型** — 每種模式要請求的 model id；留空則使用伺服器的
-  預設值。**取得模型清單** 會列出你的金鑰可用的 id。
+三種方式：
 
-按鈕可以 **檢查金鑰**（方案、到期時間、當日用量 vs 每日額度、速率
-限制）、**兌換序號**（把預付序號換成金鑰 —— 新發一組，或替現有金鑰
-加時間）、**購買金鑰**（見下方），以及對伺服器做 **健康檢查**。為了
-不超出伺服器的速率限制，bot 只在真正需要決策時才發出請求 —— 它會先在
-本機判斷這一手是否可能有合法動作 —— 而不是每次對手切牌都問一次。
-
-儲存後 **立即生效，即使在對局進行中**：bot 每次決策都會重新讀取這些
-設定，因此你可以在半莊中途開啟雲端推論、修正打錯的金鑰，或切換模型，
-都不必重開對局。若伺服器停止回應，bot 會退回本機模型，並在一段逐漸
-拉長的 backoff 視窗內跳過 API，而不是每一巡都等到逾時；狀態列的
-**Online API** 指示燈會轉紅，恢復後再轉綠。
-
-這些設定會保存在 `config.toml` 的 `[bot.api]`（`enabled`、`base_url`、
-`key`、`model_4p`、`model_3p`）。
-
-> **你的 API 金鑰以明文儲存** 在 `config.toml` 中，且 Akagi 會將它以
-> bearer token 送往設定的 **伺服器網址**。請把該檔案視為機密：不要提交
-> 到版本庫，分享前（例如回報問題時）也請先把 `key` 塗掉。
-
-#### 取得金鑰
-
-三種方式，都在 **雲端推論** 卡片上：
-
-- **購買金鑰** — 應用程式內購買。選擇方案（一次性加值，或每月訂閱），
-  Akagi 會在瀏覽器開啟 PayPal。價格由伺服器決定，應用程式只送出商品
-  id。付款完成後，金鑰會自動回填並儲存 —— 付款期間你可以關閉對話框，
-  狀態標籤會帶你回來。萬一回填失敗，金鑰也會寄到你的 PayPal 信箱，
-  購買永遠不會遺失。唯一的例外是勾選 *把時間加到目前的金鑰* 購買：
-  那會把買到的天數疊加到你已持有的金鑰上，因此寄到信箱的是用來加值的
-  預付 **序號**，而不是一組新金鑰。
+- **購買金鑰** — 應用程式內購買。
 - **兌換序號** — 把預付序號換成金鑰，或替你已持有的金鑰加時間。
 - 到 [Discord 伺服器](https://discord.gg/Z2wjXUK8bN) 詢問。
 
 ### 依模式切換的 bot
 
 `bot.active_4p` 與 `bot.active_3p` 互相獨立。Akagi 會在開
-局時依牌桌人數選用對應的 bot。將某個槽位留空即可在該
-模式下僅使用 **分析功能**（不顯示 bot 建議）。
+局時依牌桌人數選用對應的 bot。
 
 除了這兩種後端之外，Akagi 也能以子行程執行 **外部 mjai bot**。
 那是給開發者的擴充點，而不是任何人都得走的步驟 ——
@@ -431,14 +322,6 @@ session；點選列可看到原始結構化欄位與來源位置。
   `capture.chromium.executable`。如果瀏覽器有啟動但沒
   訊框流入，檢查 `--remote-debugging-port` 是否被其他
   擴充功能擋下。
-- **Bot 卡在 `Loading{SyncingDeps}`。** 首次 `uv sync`
-  會慢 — 在 Diagnostic 頁籤觀察 `bot=<name>` 的訊息。
-  若一直未完成，刪除
-  `mjai_bot/<name>/.akagi/synced.stamp` 後重試。
-- **啟用開關變灰 / 手動放入的 bot 無法啟用。** 它的 Python 環境還沒建立。
-  在 **Bots** 頁籤該 bot 列上點擊 **安裝環境** 按鈕（環境未就緒時會出現）
-  以執行 `uv sync`；完成後開關即可啟用。修改該 bot 的 `pyproject.toml` 會
-  使環境失效，按鈕會再次出現。
 - **Bot 對局途中崩潰。** Inspector 頁籤可顯示 bot 死前
   看到的最後一個訊框；附在 bug 報告裡。
 - **三麻挑了錯的 bot。** 檢查設定 → Bot 中的
@@ -462,15 +345,14 @@ alpha.8 已完成：
 - [x] i18n：en / ja / zh-TW / zh-CN，含設定精靈語言選擇
 - [x] 從 GitHub release 或本機 ZIP 檔案安裝 bot
 - [x] Chromium 抓包模式（不需信任 CA）
+- [x] **自訂主題**（前端 theming hook）
+- [x] **AutoPlay**（先支援雀魂；由 bot 自主控制牌桌）
 
 規劃中：
 
 - [ ] **Amatsuki** 平台支援
-- [ ] **自訂主題**（前端 theming hook）
-- [ ] **AutoPlay**（先支援雀魂；由 bot 自主控制牌桌，
-      類似原版 Akagi 在 Windows 的 AutoPlay）
 - [ ] **前端打磨** — 牌型佈局、動畫、無障礙
-- [ ] **天鳳 autoplay**（目前僅觀戰）
+- [ ] **天鳳 autoplay**
 
 詳細的 bug 追蹤請至
 [GitHub Issues](https://github.com/shinkuan/Akagi/issues)。
@@ -499,17 +381,18 @@ alpha.8 已完成：
   game_state::tracker   bot::manager     ipc forwarder
        │                  │                  │
        ▼ PostBus          ▼ BotResponseBus   ▼ app.emit
-  analysis::runner   subprocess (uv)    Tauri webview
-       │
-       ▼ AnalysisBus
+  analysis::runner   內建 NN（行程內）    Tauri webview
+       │             | 雲端 API
+       ▼ AnalysisBus  | mjai 子行程
        └──► ipc forwarder ──► app.emit
 ```
 
 [`src/lib.rs`](./src/lib.rs) 在啟動時把這些 bus 接起來。
-前端透過六個 push 事件（`mjai-event`、`bot-response`、
-`bot-status`、`proxy-status`、`notify`、`history-recorded`）
-與 backend 溝通，pull 指令的清單請見
-[`src/ipc/README.md`](./src/ipc/README.md)。
+前端透過 push 事件（`mjai-event`、`bot-response`、
+`bot-status`…）與 pull 指令和 backend 溝通，兩者的清單
+都在 [`src/ipc/README.md`](./src/ipc/README.md)。開啟
+AutoPlay 時，`autoplay` manager 會取用 bot 的決策，並透過
+Chromium 抓包 backend（CDP）點擊牌桌。
 
 ## 技術堆疊
 
@@ -520,6 +403,8 @@ alpha.8 已完成：
 | MITM | [`hudsucker`](https://crates.io/crates/hudsucker) 0.24（`rcgen-ca`、`rustls-client`） |
 | CDP capture | [`chromiumoxide`](https://crates.io/crates/chromiumoxide) 0.9 |
 | 麻將引擎 | [`riichienv-core`](https://github.com/smly/RiichiEnv) 0.4 |
+| 內建 bot | [`candle`](https://github.com/huggingface/candle) 0.9（純 Rust NN 推論；權重內嵌） |
+| 雲端推論 | [`reqwest`](https://crates.io/crates/reqwest) 0.13（rustls） |
 | Protobuf | `prost` 0.14 + `prost-reflect` 0.16 |
 | 前端 | [React](https://react.dev) 19、TypeScript、[Vite](https://vitejs.dev) 8 |
 | 樣式 | [Tailwind CSS](https://tailwindcss.com) v4、[shadcn/ui](https://ui.shadcn.com)（Radix Nova preset） |
@@ -527,7 +412,7 @@ alpha.8 已完成：
 | 圖表 | [Recharts](https://recharts.org) |
 | 牌型渲染 | [`<mah-gen>`](https://github.com/eric200203/mahgen) Web Component |
 | i18n | [react-i18next](https://react.i18next.com) |
-| Bot 執行環境 | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv)（依平台打包） |
+| mjai bot 執行環境 | `python-build-standalone` 3.12 + [`uv`](https://github.com/astral-sh/uv)（依平台打包；僅外掛 bot 需要 —— 內建 bot 完全用不到） |
 
 ## 專案結構
 
@@ -535,28 +420,33 @@ alpha.8 已完成：
 .
 ├── src/
 │   ├── analysis/      向聽 / 待牌 / 和牌率 / 風險 / 切牌搜尋
-│   ├── bot/           Registry、Python runtime、JSONL 子行程執行器
+│   ├── autoplay/      bot 決策 → 透過 CDP 點擊牌桌（AutoPlay）
+│   ├── bot/           Bot manager：內建 bot、雲端 API client、mjai 子行程執行器
 │   ├── bridge/        各平台協定 → MjaiEvent
 │   │   ├── majsoul/   雀魂（liqi protobuf）
+│   │   ├── riichi_city/  Riichi City（僅 MITM）
 │   │   └── tenhou/    天鳳（JSON tag stream，僅觀戰）
 │   ├── capture/       抓包 backend 抽象（mitm | chromium）
 │   ├── config/        AppConfig（TOML）區段與解析
 │   ├── event_bus.rs   子系統間的 broadcast channel
 │   ├── game_state/    riichienv 驅動的鏡射、snapshot、mahgen view
+│   ├── github/        GitHub Releases client（bot 安裝、自我更新）
 │   ├── history/       對局回放儲存與索引
 │   ├── inspector/     訊框 / 事件 / bot reaction broadcaster
 │   ├── ipc/           Tauri 指令、app state、capture supervisor
 │   ├── logger/        每 session 紀錄目錄與每 target 檔案 appender
 │   ├── proxy/         透過 hudsucker 的 MITM HTTP/HTTPS/WS；CA 位於 ./ca
 │   ├── schema/        MjaiEvent enum 與 IPC payload 類型
+│   ├── updater/       應用程式內自我更新（檢查 + 套用）
 │   └── lib.rs         啟動與接線
+├── native_bot/        內建 bot crate：obs/action codec、candle CNN、內嵌權重
 ├── mjai_bot/
 │   └── example/       in-tree 規則型向聽優化器
 ├── frontend/          React + Vite + Tailwind + shadcn UI
 │   └── src/
 │       ├── routes/    Overview / GameDashboard / Bots / History / Logs / Settings / Setup / InspectorView / DiagnosticView
 │       ├── tiles/     儀表板磚塊（header、hands、opponents、analysis…）
-│       ├── stores/    Zustand slice（game、analysis、bot、proxy、notify、layout、config）
+│       ├── stores/    Zustand store，一個領域一個（game、bot、config、theme…）
 │       └── i18n/      en / ja / zh-TW / zh-CN
 ├── tests/             整合測試
 ├── capabilities/      Tauri 權限

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -65,8 +65,9 @@
 Akagi 透過本機 Proxy 或內建瀏覽器監看你在雀魂 / 天鳳的對局，
 鏡射遊戲狀態，並在可拖曳的 HUD 中顯示 **向聽**、**待牌**、
 **和牌率**、**聽牌率**、**對各家放銃風險**，以及
-**推薦切牌**。若放入符合 mjai 協定的 bot（例如 Mortal），
-HUD 在每巡也會顯示該 bot 的建議。
+**推薦切牌**。執行檔本身就內建一個 **bot** —— 不需要安裝任何東西 ——
+它的建議會在每巡顯示；若想要更強的託管模型，可以把它指向
+**雲端推論 API**。
 
 ## 截圖
 
@@ -95,6 +96,7 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
 - [架構](#架構)
 - [技術堆疊](#技術堆疊)
 - [專案結構](#專案結構)
+- [mjai Bot 外掛介面](#mjai-bot-外掛介面)
 - [從原始碼建置](#從原始碼建置)
 - [測試](#測試)
 - [Releases 與 CI](#releases-與-ci)
@@ -114,9 +116,15 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   - **Chromium** — 由 Akagi 啟動受控的 Chromium 系列瀏覽器，
     透過 Chrome DevTools Protocol 攔截 WebSocket 訊框。
     無需設定 proxy 或安裝憑證；直接在啟動的視窗中遊玩即可。
-- **可插拔的 mjai bot** — 在設定一鍵安裝 Mortal，或將
-  任意 `bot.py` 放入 `mjai_bot/<name>/`。可依模式切換：
-  `bot.active_4p` 與 `bot.active_3p` 會依牌桌人數自動套用。
+- **兩種 bot 後端**
+  - **內建 bot**（預設） — 嵌在執行檔內的純 Rust 神經網路。
+    不需要 Python、不需要下載、不需要設定；四麻與三麻都能直接開打。
+  - **雲端推論**（選用） — 把每一次決策交給透過 HTTP 存取、
+    更強的託管模型。內建模型仍保持載入作為自動後備，因此伺服器
+    連不上時也不會讓對局卡住。金鑰可直接在應用程式內購買或兌換。
+
+  兩者皆可依模式切換：`bot.active_4p` 與 `bot.active_3p`
+  會依牌桌人數自動套用。
 - **對局歷史** — 每場結束的對局會自動記錄。歷史頁籤顯示
   名次圓餅圖、可選計分規則的累積 PT 折線圖（雀魂段位 /
   天鳳段位 / 自訂 uma），以及細部統計（和牌率、放銃率、
@@ -126,7 +134,8 @@ https://github.com/user-attachments/assets/2ce7cb71-8b25-4895-a12b-0a638665dcab
   可依模組過濾；**Inspector** 頁籤顯示原始 WebSocket 訊框
   → mjai 事件 → bot 反應，附訊框數量與 meta 檢視。
 - **首次啟動設定** — 語言 → 平台 → 抓包模式 →
-  CA 信任 / Chromium 選擇 → bot 安裝 → 完成。
+  CA 信任 / Chromium 選擇 → bot 設定 → 完成。
+  沒有東西要安裝：內建 bot 本來就在。
 - **多語系** — English、日本語、繁體中文、简体中文。
   可在設定精靈或側邊欄即時切換，覆蓋整個 UI。
 - **三麻** — 完整流程：bridge、tracker、snapshot、
@@ -160,12 +169,13 @@ Akagi 以 portable zip 發佈 — 每個平台一個自帶所需檔案的資料�
 | macOS | `akagi-<version>-macos-arm64.zip` | Apple Silicon。未簽章,解壓後執行一次 `xattr -cr <解壓後資料夾>`,或第一次右鍵 → *Open*。 |
 | Linux | `akagi-<version>-linux-x64.zip` | 在 `ubuntu-22.04` 上建置(glibc 2.35+)。需要 WebKit2GTK 4.1(`apt install libwebkit2gtk-4.1-0` / `dnf install webkit2gtk4.1` / `pacman -S webkit2gtk-4.1`)。 |
 
-每個 zip 都將 `python-build-standalone` 3.12 + `uv` 一併放在
-binary 旁邊,bot 開箱即用,不需另外安裝系統 Python。
+內建 bot 完全不需要任何執行環境。每個 zip 也將
+`python-build-standalone` 3.12 + `uv` 一併放在 binary 旁邊，
+因此選用的 [mjai bot](#mjai-bot-外掛介面) 不需另外安裝系統 Python。
 
-首次啟動時會引導你完成語言、平台、抓包
-模式、選用的 bot 安裝(Mortal)以及 CA 信任(僅 MITM
-模式才需要)。
+首次啟動時會引導你完成語言、平台、抓包模式、bot 設定，
+以及 CA 信任（僅 MITM 模式才需要）。沒有 bot 要安裝 ——
+內建的那個本來就在。
 
 ### B. Chromium 模式（不需信任 CA）
 
@@ -252,26 +262,66 @@ dir       = "./mjai_bot"
 
 ## Bots
 
-### 安裝 Bot
+### 內建 bot
 
-在 **Bots** 頁籤可直接從 GitHub release 安裝 bot：
+Akagi 內建一個 **純 Rust 的 bot**，完全在行程內執行 —— 不需要
+Python、不需要 libriichi、不需要 `uv sync`，也沒有任何東西要下載。
+它是兩種模式的預設值（`bot.active_4p = "akagi-native"`、
+`bot.active_3p = "akagi-native3p"`），會出現在 **Bots** 頁籤最上方，
+狀態永遠是「就緒」。
 
-範例:
+它是一個以天鳳牌譜做行為複製（behavior cloning）訓練出來的小型神經
+網路（權重直接嵌在執行檔內），因此棋力 **刻意保持在中等水準** ——
+它是個合理的預設值，而不是頂尖引擎。
 
-- Repo：`shinkuan/Akagi-MjaiBot-Mortal`
-- 四麻：`release4p.zip`
-- 三麻：`release3p.zip`
+### 雲端推論
 
-IPC 指令 `install_bot_from_github(repo, asset_glob?, name?)`
-會抓取最新 release zip，解壓至 `mjai_bot/<name>/`，驗證
-`bot.py`，並執行一次 `uv sync`。後續啟動很快 — sync
-會根據 `mjai_bot/<name>/.akagi/synced.stamp` 戳記決定是否
-跳過。
+內建 bot 可以選擇把每一次決策交給 **遠端推論伺服器**，而不是執行內嵌
+的模型 —— 那是一個透過網路存取、更強的託管模型。內嵌的本機模型仍會
+保持載入作為自動 **後備**：當伺服器連不上、被限流，或金鑰無效時，bot
+會安靜地改用本機模型的著手，讓進行中的對局不會卡住。
 
-你也可以從**本機 ZIP** 安裝 —— 適合離線安裝或本機建置的
-bot。在 **Bots** 頁籤點擊 **從 ZIP 安裝**，**瀏覽…** 選擇
-`.zip`（或貼上其路徑）即可安裝。它執行與 GitHub 安裝完全相同
-的解壓 / 驗證 / `uv sync` 流程，且不會改動你的來源 `.zip`。
+在 **Bots** 頁籤的 **雲端推論** 卡片中設定：
+
+- **啟用雲端推論 API** — 總開關。關閉（預設）⇒ 完全離線的本機模型。
+- **伺服器網址** — 推論伺服器。預設為 `https://mjapi.shinkuan.me`；
+  若你自架，可指向任意主機（`http://host:8080`、`https://host`）。
+- **API 金鑰** — 32 字元的金鑰。
+- **四麻 / 三麻模型** — 每種模式要請求的 model id；留空則使用伺服器的
+  預設值。**取得模型清單** 會列出你的金鑰可用的 id。
+
+按鈕可以 **檢查金鑰**（方案、到期時間、當日用量 vs 每日額度、速率
+限制）、**兌換序號**（把預付序號換成金鑰 —— 新發一組，或替現有金鑰
+加時間）、**購買金鑰**（見下方），以及對伺服器做 **健康檢查**。為了
+不超出伺服器的速率限制，bot 只在真正需要決策時才發出請求 —— 它會先在
+本機判斷這一手是否可能有合法動作 —— 而不是每次對手切牌都問一次。
+
+儲存後 **立即生效，即使在對局進行中**：bot 每次決策都會重新讀取這些
+設定，因此你可以在半莊中途開啟雲端推論、修正打錯的金鑰，或切換模型，
+都不必重開對局。若伺服器停止回應，bot 會退回本機模型，並在一段逐漸
+拉長的 backoff 視窗內跳過 API，而不是每一巡都等到逾時；狀態列的
+**Online API** 指示燈會轉紅，恢復後再轉綠。
+
+這些設定會保存在 `config.toml` 的 `[bot.api]`（`enabled`、`base_url`、
+`key`、`model_4p`、`model_3p`）。
+
+> **你的 API 金鑰以明文儲存** 在 `config.toml` 中，且 Akagi 會將它以
+> bearer token 送往設定的 **伺服器網址**。請把該檔案視為機密：不要提交
+> 到版本庫，分享前（例如回報問題時）也請先把 `key` 塗掉。
+
+#### 取得金鑰
+
+三種方式，都在 **雲端推論** 卡片上：
+
+- **購買金鑰** — 應用程式內購買。選擇方案（一次性加值，或每月訂閱），
+  Akagi 會在瀏覽器開啟 PayPal。價格由伺服器決定，應用程式只送出商品
+  id。付款完成後，金鑰會自動回填並儲存 —— 付款期間你可以關閉對話框，
+  狀態標籤會帶你回來。萬一回填失敗，金鑰也會寄到你的 PayPal 信箱，
+  購買永遠不會遺失。唯一的例外是勾選 *把時間加到目前的金鑰* 購買：
+  那會把買到的天數疊加到你已持有的金鑰上，因此寄到信箱的是用來加值的
+  預付 **序號**，而不是一組新金鑰。
+- **兌換序號** — 把預付序號換成金鑰，或替你已持有的金鑰加時間。
+- 到 [Discord 伺服器](https://discord.gg/Z2wjXUK8bN) 詢問。
 
 ### 依模式切換的 bot
 
@@ -279,38 +329,9 @@ bot。在 **Bots** 頁籤點擊 **從 ZIP 安裝**，**瀏覽…** 選擇
 局時依牌桌人數選用對應的 bot。將某個槽位留空即可在該
 模式下僅使用 **分析功能**（不顯示 bot 建議）。
 
-### 自行撰寫 bot
-
-```
-mjai_bot/<name>/
-├── bot.py            # JSONL stdin → JSONL stdout
-├── pyproject.toml    # requires-python = ">=3.12"
-├── manifest.toml     # 選填 — supported_modes、設定 schema
-└── README.md
-```
-
-`bot.py` 從 stdin 每行讀取一個 mjai 事件 JSON 陣列，並從
-stdout 每行寫出一個 mjai 動作物件（無動作時輸出
-`{"type":"none"}`）。Akagi 會把 stderr 內容寫入應用程式
-紀錄中的 `bot=<name>` 條目。
-
-完整協定、manifest schema 以及 secret 欄位處理請見
-[`src/bot/README.md`](./src/bot/README.md)。
-[`mjai_bot/example/`](./mjai_bot/example/) 為一個 in-tree、
-可運作的規則型範例 bot。
-
-本機開發時，把 bot 資料夾放到 `mjai_bot/<name>/`，在 **Bots** 頁籤該 bot
-列上點擊 **安裝環境** 即可建立其 venv —— 不必每次改動都重新打包安裝。環境
-就緒前啟用開關會保持停用。
-
-### AGPL 邊界
-
-Bot 以 Akagi 啟動的 **獨立 OS 子行程** 執行。通訊嚴格透
-過 stdin / stdout 上的 JSONL 進行 — 沒有 in-process 連結、
-沒有共享位址空間、沒有 FFI。這是刻意設計的授權邊界：
-AGPL 授權的 bot（例如連結 libriichi 的 Mortal）會留在
-其自己的行程內，因此把它放入 `mjai_bot/<name>/` **不會**
-讓 Akagi 成為該 bot 的衍生作品。
+除了這兩種後端之外，Akagi 也能以子行程執行 **外部 mjai bot**。
+那是給開發者的擴充點，而不是任何人都得走的步驟 ——
+請見 [mjai Bot 外掛介面](#mjai-bot-外掛介面)。
 
 ---
 
@@ -545,6 +566,60 @@ alpha.8 已完成：
 ```
 
 各模組的開發者指南位於對應的 `src/*/README.md`。
+
+## mjai Bot 外掛介面
+
+> 選用功能，主要面向開發者。[內建 bot](#內建-bot) 才是預設值，完全不需要
+> 這一節的任何步驟 —— 只有當你想讓 Akagi 驅動 *另一個* 引擎時才會用到。
+
+除了自家的 bot 之外，Akagi 也能驅動任何遵循 **mjai** 協定的引擎。這種 bot
+是一個獨立子行程，透過 stdin/stdout 以 JSONL 溝通：Akagi 把對局以 mjai
+事件餵給它，它則回覆一個動作，以及選填的 HUD 資料。
+
+### 自行撰寫
+
+```
+mjai_bot/<name>/
+├── bot.py            # JSONL stdin → JSONL stdout
+├── pyproject.toml    # requires-python = ">=3.12"
+├── manifest.toml     # 選填 — supported_modes、設定 schema
+└── README.md
+```
+
+`bot.py` 從 stdin 每行讀取一個 mjai 事件 JSON 陣列，並從 stdout 每行寫出
+一個 mjai 動作物件（無動作時輸出 `{"type":"none"}`）。Akagi 會把 stderr
+內容寫入應用程式紀錄中的 `bot=<name>` 條目。
+
+完整的 I/O 協定、mjai 事件流、reaction 與 `meta` HUD 格式、toast 通知，
+以及 `manifest.toml` 設定，請見
+**[`mjai_bot/README.md`](./mjai_bot/README.md)**。
+[`mjai_bot/example/`](./mjai_bot/example/) 為一個可直接複製、可運作的
+規則型範例 bot。
+
+本機開發時，把 bot 資料夾放到 `mjai_bot/<name>/`，在 **Bots** 頁籤該 bot
+列上點擊 **安裝環境** 即可建立其 venv —— 不必每次改動都重新打包安裝。
+環境就緒前，啟用開關會保持停用。
+
+### 安裝
+
+**Bots** 頁籤可以從 GitHub release 或本機 ZIP 安裝 bot。
+
+IPC 指令 `install_bot_from_github(repo, asset_glob?, name?)` 會抓取最新
+release zip，解壓至 `mjai_bot/<name>/`，驗證 `bot.py`，並執行一次
+`uv sync`。後續啟動很快 —— sync 會根據
+`mjai_bot/<name>/.akagi/synced.stamp` 戳記決定是否跳過。
+
+**從 ZIP 安裝** 是離線的等價流程：點擊 **瀏覽…** 選擇 `.zip`（或貼上其
+路徑）即可。它執行完全相同的解壓 / 驗證 / `uv sync` 流程，且不會改動你的
+來源 `.zip`。
+
+### AGPL 邊界
+
+Bot 以 Akagi 啟動的 **獨立 OS 子行程** 執行。通訊嚴格透過 stdin / stdout
+上的 JSONL 進行 —— 沒有 in-process 連結、沒有共享位址空間、沒有 FFI。
+這是刻意設計的授權邊界：AGPL 授權的 bot（例如連結 libriichi 的 Mortal）
+會留在其自己的行程內，因此把它放入 `mjai_bot/<name>/` **不會** 讓 Akagi
+成為該 bot 的衍生作品。
 
 ## 從原始碼建置
 


### PR DESCRIPTION
## Why

The READMEs still described the app as it shipped *before* the built-in bot.
Features advertised **"pluggable mjai bots — install Mortal in one click from the
Setup wizard"**, and Quick Start promised an **"optional bot install (Mortal)"**.

Neither is true. The wizard has had no bot step since the native bot became the
zero-install default — its step list is `['welcome','platform','mode','config','configure','finish']`,
with `'bots'` deliberately omitted. So a new user's first impression was that
they had to go install a bot before Akagi was useful.

## What changed

**Features now leads with the two backends a user actually gets:**

- **Built-in bot** (default) — pure-Rust, embedded in the binary, nothing to install.
- **Cloud inference** (optional) — a hosted, stronger model over HTTP, with the
  local model kept loaded as an automatic fallback.

`About`, the Setup-wizard bullet and Quick Start are corrected to match.

**mjai bots move to a developer section.** Writing a bot, installing one, and the
AGPL subprocess boundary now live under a new **mjai Bots (plugin interface)**
heading, placed after *Project Layout* where the `mjai_bot/` tree is first
introduced. Nothing was deleted — only relocated, behind a note saying it is
optional and aimed at developers. The user-facing *Bots* section keeps a one-line
pointer to it.

**The `shinkuan/Akagi-MjaiBot-Mortal` pointer is gone**, along with its
`release4p.zip` / `release3p.zip` asset names. Users have no reason to fetch that
bot now. The `[!IMPORTANT]` callout about the release zip's *placeholder* Mortal
weights went with it — it only made sense next to that download, and the
stronger-model story is already told by *Cloud inference* and *Getting a key*.

## The translations were further behind than the English

`README.zh-TW.md` and `README.zh-CN.md` had **never** received the built-in-bot or
cloud-inference sections — a `grep` for cloud-inference content returned zero
hits in both. Their `## Bots` opened straight onto 安裝 Bot / 安装 Bot, so they
still presented the mjai bot as *the* bot, and both carried the repo pointer this
PR removes.

Both are brought fully in sync: the missing sections translated (內建 bot /
內置 bot, 雲端推論 / 云端推理, 取得金鑰 / 获取密钥, including the in-app purchase
flow), and the same restructure applied.

While there, fixed a wrong link in both: *write your own* pointed at the Rust
module guide (`src/bot/README.md`) instead of the bot-author guide
(`mjai_bot/README.md`).

## Verification

Scripted, not eyeballed:

- All three files share **one heading sequence** (39 headings, identical levels).
- **Every internal anchor resolves** (22 links each, 0 broken) under GitHub's
  slug rules — including the CJK anchors `#內建-bot`, `#mjai-bot-外掛介面`,
  `#内置-bot`, `#mjai-bot-插件接口`.
- Every relative file link points at a path that exists, and both
  `mjai_bot/README.md` and `mjai_bot/example/` are tracked.
- Code fences balanced; no remaining reference to `Akagi-MjaiBot-Mortal`,
  `release4p.zip`, or `release3p.zip` in any README.