### PR TITLE
fix(native-bot): rank the pass on the card when a call is declined

### DIFF
--- a/frontend/src/lib/botShow.test.ts
+++ b/frontend/src/lib/botShow.test.ts
@@ -57,6 +57,20 @@ describe('visibleItems', () => {
     ])
   })
 
+  // The bot's "Pass" row (#190) carries a label and a probability but no tiles —
+  // drawing the declined tile there would read as a discard suggestion. If the
+  // empty-row filter dropped it, a declined call would render as *only* the call
+  // it turned down, i.e. as a recommendation to make it.
+  it('keeps a tile-less row that still has a label', () => {
+    const declined: ShowMeta = {
+      items: [
+        { label: 'Pass', value: '87%' },
+        { label: 'Pon', pais: ['2p', '2p'], value: '13%' },
+      ],
+    }
+    expect(visibleItems(declined).map((i) => i.label)).toEqual(['Pass', 'Pon'])
+  })
+
   it('is unbounded when no limit is given, and safe at the edges', () => {
     expect(visibleItems(show)).toHaveLength(4)
     expect(visibleItems(show, 99)).toHaveLength(4)

--- a/src/bot/README.md
+++ b/src/bot/README.md
@@ -91,6 +91,36 @@ bridge to them.
   `purchase` and `native` tests, so they can assert on the raw request
   (path, `Authorization` header, body) and script the response.
 
+## The `meta.show` card (built-in bot)
+
+The built-in bot attaches a `meta.show` card — the ranked candidates with their
+policy probabilities — to its `BotResponse`. The frontend renders it in the Bot
+Show tile and the suggestion overlay. One rule governs it, and everything in
+`native.rs` that touches `meta` exists to keep it true:
+
+> **The card changes exactly when the bot chose something, and never otherwise.**
+
+Both halves matter, and getting either wrong is invisible in tests but obvious in
+a game.
+
+*Never otherwise*: most events reaching the bot are not decisions — an opponent's
+discard we cannot call, a draw that isn't ours. Those reply `MjaiEvent::None` with
+`meta: None`, and the frontend leaves the card up. If they carried a card, the tile
+would flicker through the whole hand.
+
+*Exactly when it chose*: **declining a call is a choice**, and it must refresh the
+card. `is_decision_point` is the gate — a legal set that is empty, or that contains
+nothing but `Pass`, is not a decision. Anything else is, including a call window
+where the bot passes, and there the pass is ranked as a row of its own against the
+pon/chi/kan it turned down ("Pass 87% / Pon 13%"). That comparison is the most
+useful thing on screen at that moment.
+
+This was got wrong once (#190): the local path suppressed the card whenever the
+top candidate was a pass, so declining a call left the *previous turn's* discard
+advice on screen, reading as live advice for a decision that was already over. The
+cloud-inference path had it right. Both now share the `PASS_LABEL` row, so the card
+reads the same whichever one answered.
+
 ## Adding a new bot
 
 Drop a folder under `mjai_bot/`:

--- a/src/bot/native.rs
+++ b/src/bot/native.rs
@@ -496,11 +496,11 @@ impl BotRunner for NativeBot {
             }
         }
 
-        // Local gate: no legal action ⇒ don't spend an API call (and don't
-        // pester the server with the opponent-discard windows we can't act on).
+        // Local gate: nothing to decide ⇒ reply `none`, spend no API call, and
+        // leave whatever card is on screen alone.
         let local = match self.engine.decide()? {
-            Some(d) => d,
-            None => {
+            Some(d) if is_decision_point(&d.candidates) => d,
+            _ => {
                 return Ok(BotResponse {
                     action: MjaiEvent::None,
                     meta: None,
@@ -528,6 +528,29 @@ impl BotRunner for NativeBot {
         self.breaker.reset();
         Ok(())
     }
+}
+
+/// Did the bot actually choose anything here?
+///
+/// This is the precondition for touching the HUD card: it must change when the
+/// bot made a choice, and *only* then. A real decision has something to choose
+/// between — our own turn (a discard, riichi, kan, tsumo…), or a call window
+/// where a pon / chi / kan / ron sits next to the pass.
+///
+/// Two things are not decisions. An empty legal set, obviously. And a legal set
+/// of exactly `[Pass]`: the engine offers `Pass` unconditionally in its response
+/// phase, so a seat standing in someone *else's* call window still gets one
+/// handed back. Rendering that as "Pass 100%" would replace real advice with a
+/// choice the bot never had.
+///
+/// The bare-`[Pass]` case is not reachable in live play today — the bridge feeds
+/// opponents' hands as `?`, so the engine can only ever see *our* claims, and it
+/// only opens a response window when a claim exists, which means the pass always
+/// arrives next to the call it was weighed against. But that is a fact about
+/// what the engine currently knows, not about what the card promises. Encode the
+/// promise.
+fn is_decision_point(candidates: &[(BotAction, f32)]) -> bool {
+    !matches!(candidates, [] | [(BotAction::Pass, _)])
 }
 
 /// Build the reply pair (mjai action + HUD card) from the local model's
@@ -660,6 +683,12 @@ fn with_lead(lead: &str, rest: &[String]) -> Vec<String> {
 /// the local model, so the source can flip mid-game.
 const SHOW_TITLE_LOCAL: &str = "Akagi · Local";
 
+/// Row label for declining a call. Both inference paths use it, so the card
+/// reads the same whichever one answered. "None" — the mjai wire word — is
+/// accurate and useless: on a call window what the player wants to read is
+/// "Pass 87%" against "Pon 13%", not "None 87%".
+const PASS_LABEL: &str = "Pass";
+
 /// Card title for a decision the online API served: name the model. The
 /// server's own report (which model actually answered) wins over the
 /// configured id — the config may be empty, meaning "server default".
@@ -715,7 +744,7 @@ fn label_pais_mjai(ev: &MjaiEvent) -> Option<(&'static str, Vec<String>)> {
         // Passing IS the chosen move on a call window (pon/chi/kan/ron
         // offered, model declines) — show it, or the card would render only
         // the runner-ups and read as recommending the call it just declined.
-        MjaiEvent::None => ("None", vec![]),
+        MjaiEvent::None => (PASS_LABEL, vec![]),
         _ => return None,
     };
     Some(out)
@@ -737,8 +766,8 @@ fn label_pais_candidate(action: &str) -> Option<(&'static str, Vec<String>)> {
         "ryukyoku" => ("Ryukyoku", vec![]),
         "nukidora" => ("Kita", vec!["N".into()]),
         // On a call window the pass option is half the decision (e.g. pon 55%
-        // vs none 45%) — a real ranked row, not noise.
-        "none" => ("None", vec![]),
+        // vs pass 45%) — a real ranked row, not noise.
+        "none" => (PASS_LABEL, vec![]),
         // Unknown future labels are not shown as a row.
         _ => return None,
     };
@@ -779,26 +808,30 @@ fn take_n<const N: usize>(v: Vec<String>) -> [String; N] {
 
 /// Build the HUD "Bot Show" recommendation card (`meta.show`) from the ranked
 /// candidates, so the built-in bot surfaces its **top-N** suggestions (each with
-/// its policy probability) like other bots. `None` when the top choice is a pass
-/// (nothing to recommend — the previous card stays).
+/// its policy probability) like other bots.
+///
+/// Every candidate becomes a row, the pass included. Declining a call *is* the
+/// decision on a call window, and its probability is the most interesting number
+/// on screen at that moment — "Pass 87% / Pon 13%" is the answer to "should I
+/// have ponned?". Suppressing it left the previous turn's discard advice sitting
+/// there, reading as live advice for a decision that was already over.
+///
+/// Callers must have established a decision point first ([`is_decision_point`]);
+/// a lone pass is not one, and must not reach here.
 fn build_show_meta(candidates: &[(BotAction, f32)]) -> Option<serde_json::Value> {
-    // A leading pass means "no action this turn": leave the previous card up.
-    if matches!(candidates.first(), None | Some((BotAction::Pass, _))) {
-        return None;
-    }
     let items: Vec<Value> = candidates
         .iter()
-        .filter_map(|(a, p)| {
-            label_pais_bot_action(a)
-                .map(|(label, pais)| make_show_item(label, &pais, Some(*p as f64)))
+        .map(|(a, p)| {
+            let (label, pais) = label_pais_bot_action(a);
+            make_show_item(label, &pais, Some(*p as f64))
         })
         .collect();
     wrap_show(items, SHOW_TITLE_LOCAL)
 }
 
-/// Label + tiles for one bot action, or `None` for a pass (not shown as a row).
-fn label_pais_bot_action(a: &BotAction) -> Option<(&'static str, Vec<String>)> {
-    let out = match a {
+/// Label + tiles for one bot action.
+fn label_pais_bot_action(a: &BotAction) -> (&'static str, Vec<String>) {
+    match a {
         BotAction::Dahai { pai, .. } => ("Discard", vec![pai.clone()]),
         BotAction::Reach { pai } => (
             "Riichi",
@@ -816,9 +849,10 @@ fn label_pais_bot_action(a: &BotAction) -> Option<(&'static str, Vec<String>)> {
         BotAction::Hora { .. } => ("Hora", vec![]),
         BotAction::Kyushu => ("Ryukyoku", vec![]),
         BotAction::Kita => ("Kita", vec!["N".into()]),
-        BotAction::Pass => return None,
-    };
-    Some(out)
+        // No tiles: the row is about *declining* the discard on the table, and
+        // drawing that tile here would read as a recommendation to play it.
+        BotAction::Pass => (PASS_LABEL, vec![]),
+    }
 }
 
 /// Map a schema-agnostic [`BotAction`] to Akagi's `MjaiEvent` reply.
@@ -966,6 +1000,110 @@ mod tests {
             tehais: vec![hand.clone(), hand.clone(), hand.clone(), hand],
             num_players: 4,
         }
+    }
+
+    /// A `start_kyoku` shaped like the ones the bridge actually emits: our hand
+    /// is known, the opponents' are `?`. It matters. Handing the engine four
+    /// concrete hands (as `start_kyoku_4p` does, for convenience) lets it see
+    /// claims it can never see in a real game, so a test built on that is
+    /// testing a game we never get to play.
+    fn start_kyoku_4p_hidden(our_hand: [&str; 13]) -> MjaiEvent {
+        // The bridge's placeholder for a tile we cannot see (mjai's `?`).
+        let hidden = vec!["?".to_string(); 13];
+        MjaiEvent::StartKyoku {
+            bakaze: "E".into(),
+            dora_marker: "2m".into(),
+            kyoku: 1,
+            honba: 0,
+            kyotaku: 0,
+            oya: 0,
+            scores: vec![25000; 4],
+            tehais: vec![
+                our_hand.iter().map(|s| s.to_string()).collect(),
+                hidden.clone(),
+                hidden.clone(),
+                hidden,
+            ],
+            num_players: 4,
+        }
+    }
+
+    fn seat1_discards(pai: &str) -> [MjaiEvent; 2] {
+        [
+            MjaiEvent::Tsumo {
+                actor: 1,
+                pai: pai.into(),
+            },
+            MjaiEvent::Dahai {
+                actor: 1,
+                pai: pai.into(),
+                tsumogiri: true,
+            },
+        ]
+    }
+
+    /// Regression (#190), end to end. We hold two 9s, seat 1 discards a 9s: a pon
+    /// window. Whatever the model picks, the card must show the pass ranked
+    /// against the pon — that comparison *is* the decision. Before this fix the
+    /// bot emitted no card at all when it declined, so the tile kept displaying
+    /// the previous turn's discard advice as if it were live.
+    #[tokio::test]
+    async fn a_declined_call_still_produces_a_card_ranking_the_pass() {
+        let mut bot = bot_with(cfg_off(), crate::event_bus::notify_bus()).await;
+        let mut events = vec![
+            start_game_4p(0),
+            start_kyoku_4p_hidden([
+                "9s", "9s", "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p",
+            ]),
+        ];
+        events.extend(seat1_discards("9s"));
+
+        let resp = bot.react(&events).await.unwrap();
+
+        let meta = resp
+            .meta
+            .as_ref()
+            .expect("a pon window is a decision — it must refresh the card");
+        let items = meta["show"]["items"].as_array().unwrap();
+        let labels: Vec<&str> = items
+            .iter()
+            .map(|i| i["label"].as_str().unwrap_or_default())
+            .collect();
+        assert!(
+            labels.contains(&"Pass"),
+            "the pass must be a ranked row, got {labels:?}"
+        );
+        assert!(
+            labels.contains(&"Pon"),
+            "…alongside the call it is weighed against, got {labels:?}"
+        );
+        assert!(
+            items.iter().all(|i| i["value"].is_string()),
+            "every row carries the probability the player is here to read"
+        );
+    }
+
+    /// The other half of the contract: an opponent discard we cannot call is not
+    /// a decision, so the card must be left exactly as it was.
+    #[tokio::test]
+    async fn an_uncallable_opponent_discard_leaves_the_card_alone() {
+        let mut bot = bot_with(cfg_off(), crate::event_bus::notify_bus()).await;
+        let mut events = vec![
+            start_game_4p(0),
+            // No 9s in hand, and seat 1 is our shimocha so a chi is impossible.
+            start_kyoku_4p_hidden([
+                "1m", "3m", "5m", "7m", "9m", "2p", "4p", "6p", "8p", "1s", "3s", "5s", "7s",
+            ]),
+        ];
+        events.extend(seat1_discards("9s"));
+
+        let resp = bot.react(&events).await.unwrap();
+
+        assert!(matches!(resp.action, MjaiEvent::None));
+        assert!(
+            resp.meta.is_none(),
+            "nothing was decided, so nothing should replace the card on screen"
+        );
     }
 
     #[tokio::test]
@@ -1486,8 +1624,13 @@ mod tests {
         assert_eq!(items[2]["value"], "10%");
     }
 
+    /// Regression (#190): declining a call used to produce no card at all, so
+    /// the tile kept showing the previous turn's discard advice — live-looking
+    /// advice for a decision that was already over. The pass is the decision
+    /// here, and its probability against the call it turned down is the whole
+    /// point of the card.
     #[test]
-    fn local_show_meta_none_when_top_is_pass() {
+    fn local_show_meta_ranks_the_pass_against_the_call_it_declined() {
         let cands = vec![
             (BotAction::Pass, 0.9f32),
             (
@@ -1499,10 +1642,65 @@ mod tests {
                 0.1f32,
             ),
         ];
+
+        let meta = build_show_meta(&cands).expect("a declined call still has a card to show");
+        let items = meta["show"]["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2, "both the pass and the pon it beat");
+        assert_eq!(items[0]["label"], "Pass");
+        assert_eq!(items[0]["value"], "90%");
         assert!(
-            build_show_meta(&cands).is_none(),
-            "a leading pass must not replace the card"
+            items[0].get("pais").is_none(),
+            "the pass row must draw no tile — it would read as a discard suggestion"
         );
+        assert_eq!(items[1]["label"], "Pon");
+        assert_eq!(items[1]["value"], "10%");
+    }
+
+    /// The other half of #190: a lone pass is *not* a decision. `WaitResponse`
+    /// opens for every seat as soon as any seat can claim, and the engine always
+    /// offers `Pass` there — so a seat with nothing to claim gets `[Pass]` back.
+    /// Showing "Pass 100%" for that would replace the card on every opponent
+    /// discard someone *else* could call.
+    #[test]
+    fn a_lone_pass_is_not_a_decision_point() {
+        assert!(
+            !is_decision_point(&[]),
+            "no legal action at all is not a decision"
+        );
+        assert!(
+            !is_decision_point(&[(BotAction::Pass, 1.0)]),
+            "someone else's call window is not our decision"
+        );
+    }
+
+    #[test]
+    fn a_choice_is_a_decision_point() {
+        let call_window = [
+            (BotAction::Pass, 0.9f32),
+            (
+                BotAction::Pon {
+                    target: 0,
+                    pai: "1m".into(),
+                    consumed: vec!["1m".into(), "1m".into()],
+                },
+                0.1f32,
+            ),
+        ];
+        assert!(
+            is_decision_point(&call_window),
+            "pass vs pon is exactly the decision the card exists to explain"
+        );
+
+        // Our own turn: no pass on offer, and even a single forced discard is a
+        // decision the player wants to see.
+        let forced_discard = [(
+            BotAction::Dahai {
+                pai: "1m".into(),
+                tsumogiri: true,
+            },
+            1.0f32,
+        )];
+        assert!(is_decision_point(&forced_discard));
     }
 
     #[test]
@@ -1541,12 +1739,12 @@ mod tests {
         assert_eq!(items[2]["value"], "10%");
     }
 
-    /// A call window where the model declines (pon 35% vs none 65%): the card
-    /// must show the chosen pass as row 0 AND keep `none` runner-up rows —
+    /// A call window where the model declines (pon 35% vs pass 65%): the card
+    /// must show the chosen pass as row 0 AND keep the pass runner-up rows —
     /// dropping them made the card read as recommending the declined call.
     #[test]
-    fn api_show_meta_renders_pass_and_none_rows() {
-        // Chosen move is pass: row 0 = "None" with candidates[0]'s prob.
+    fn api_show_meta_ranks_the_pass_alongside_the_call() {
+        // Chosen move is the pass: row 0 = "Pass" with candidates[0]'s prob.
         let cands = vec![
             Candidate {
                 action: "none".into(),
@@ -1560,12 +1758,14 @@ mod tests {
         let meta = build_show_meta_mjai(&MjaiEvent::None, &cands, "Akagi · Online").unwrap();
         let items = meta["show"]["items"].as_array().unwrap();
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0]["label"], "None");
+        // Same word as the local path (#190): one card, one vocabulary,
+        // whichever inference path answered.
+        assert_eq!(items[0]["label"], "Pass");
         assert_eq!(items[0]["value"], "65%");
         assert_eq!(items[1]["label"], "Pon");
         assert_eq!(items[1]["value"], "35%");
 
-        // Chosen move is the call: the none runner-up still gets a row.
+        // Chosen move is the call: the pass runner-up still gets a row.
         let ev = MjaiEvent::Pon {
             actor: 0,
             target: 3,
@@ -1587,7 +1787,7 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(items[0]["label"], "Pon");
         assert_eq!(items[0]["value"], "55%");
-        assert_eq!(items[1]["label"], "None");
+        assert_eq!(items[1]["label"], "Pass");
         assert_eq!(items[1]["value"], "45%");
     }
 


### PR DESCRIPTION
Closes #190.

At a call window where the built-in bot decides not to pon, the Bot Show card kept displaying the **previous turn's discard advice**. It read as live advice for a decision that was already over.

## What was wrong

The local path threw the answer away twice:

- `build_show_meta` returned `None` the moment the top-ranked candidate was a pass — the comment even said so: *"leave the previous card up"*.
- `label_pais_bot_action` mapped `BotAction::Pass` to no row at all, so the pass could not appear even as a runner-up.

Meanwhile the number you actually want was already sitting right there. `Decision.candidates` is the legal set ranked by policy probability, softmaxed — and the pass is one of them. **"Pass 87% / Pon 13%" was computed and discarded on every declined call.**

Now every candidate becomes a row, the pass included. The pass draws no tile: rendering the declined tile there would read as a recommendation to play it.

## The two bots disagreed

The cloud-inference path already got this right — `label_pais_mjai` maps `MjaiEvent::None` to a row, with a comment giving exactly the right reasoning. So the same tile behaved differently depending on which bot answered. They now share a `PASS_LABEL` row.

`"Pass"` replaces the old `"None"`. The mjai wire word is accurate and useless: on a call window what you want to read is "Pass 87%" against "Pon 13%", not "None 87%".

## The decision-point rule, made explicit

`is_decision_point` encodes the contract the card depends on — *it changes when the bot chose something, and never otherwise* — and now gates both the card **and the API call**.

An empty legal set is not a decision. Neither is a legal set of nothing but `Pass`, which the engine *can* hand back: it offers `Pass` unconditionally in its response phase, so a seat standing in someone else's call window would get one.

That second case turns out to be **unreachable in live play**, and I checked rather than assumed — I probed the engine with the input the bridge actually produces. Opponents' hands arrive as `?`, so the engine can only ever see *our* claims, and it only opens a response window when a claim exists; the pass therefore always arrives next to the call it was weighed against. An opponent's discard we cannot call, and an opponent's pon, both come back as "no legal action".

It is still guarded. That is a fact about what the engine currently knows, not about what the card promises — and the engine's own tests already feed it concrete opponent hands, where the bare-`[Pass]` window does occur.

## Tests

Two end-to-end cases drive `react()` with the **hidden-hand `start_kyoku` the bridge actually emits** (the existing helper hands the engine four concrete hands, which lets it see claims it can never see in a real game):

- a pon window must refresh the card, with the pass ranked against the pon, every row carrying its probability;
- an uncallable opponent discard must leave the card untouched.

Plus unit coverage for `is_decision_point`, for the local card, and — on the frontend — for the empty-row filter keeping a tile-less `"Pass"` row. If that filter dropped it, a declined call would render as *only* the call it turned down, i.e. as a recommendation to make it.

## Verified in the built app

Not just green tests — the card renders as intended:

```
Akagi · Local
  Pass                     87%
  [🀝][🀝] Pon             13%
```

`cargo test --lib` 603 passed, `cargo clippy --all-targets -- -D warnings` clean on the touched files, `npm test` 29 passed, eslint + `tsc -b` clean.