### PR TITLE
fix(overlay): close the overlay with the main window

### DIFF
--- a/src/ipc/README.md
+++ b/src/ipc/README.md
@@ -114,6 +114,20 @@ through `overlay::reconcile`, which is idempotent and called from three places:
 app startup, `update_config`, and `set_overlay_enabled`. The last is what the
 Game page's toolbar toggle and the overlay's own × button both call.
 
+**The overlay must never outlive the app.** Tauri exits when *all* windows
+close, and the overlay counts as one — so `lib.rs` hooks the main window's
+`CloseRequested` and closes the overlay there, letting Tauri exit on its own
+once no windows remain (rather than `exit(0)`, which would skip the
+window-state save and the rest of the shutdown path). Skipping this is not a
+cosmetic bug: the overlay is `skip_taskbar` and undecorated, so a lingering one
+is a card floating over the desktop with no taskbar entry, no title bar, and
+nothing that leads back to the headless process still running behind it (#192).
+
+Note the asymmetry that closing implies: closing the overlay's *window* on
+shutdown must **not** touch `overlay.enabled`, or quitting Akagi would silently
+disable the feature. Only a deliberate × (which routes through
+`set_overlay_enabled`) does that.
+
 ## Adding a new event
 
 1. Define the payload in `crate::schema::ipc` (Serialize + Deserialize).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,31 @@ pub fn run() {
                 // fills in on the first `bot-response`.
                 ipc::overlay::reconcile(app.handle(), &overlay_cfg);
 
+                // The overlay is an accessory window, not a co-equal one. Tauri
+                // exits when *all* windows close, and the overlay counts — so
+                // without this, closing the main window leaves the overlay on
+                // screen holding the process open. It is `skip_taskbar` and
+                // undecorated, which is right while Akagi is running and hostile
+                // the moment it isn't: no taskbar entry, no title bar, nothing
+                // that leads back to the process still alive behind the card.
+                //
+                // Close it with the main window and let Tauri exit on its own
+                // once no windows remain — no `exit(0)`, so the window-state save
+                // and every other shutdown path still runs. This closes the
+                // *window*; it deliberately does not touch `overlay.enabled`, so
+                // the overlay comes back on the next launch. Only a deliberate ×
+                // (or the toggle) turns the feature off.
+                if let Some(main) = app.get_webview_window("main") {
+                    let handle = app.handle().clone();
+                    main.on_window_event(move |event| {
+                        if matches!(event, tauri::WindowEvent::CloseRequested { .. }) {
+                            if let Err(e) = ipc::overlay::close(&handle) {
+                                warn!("overlay: could not close with the main window: {e}");
+                            }
+                        }
+                    });
+                }
+
                 // Spawn tracker + analysis loops inside the Tauri Tokio
                 // runtime — `lib::run` itself is sync.
                 tauri::async_runtime::spawn(game_state::tracker::drive_loop(


### PR DESCRIPTION
Closes #192.

Closing Akagi's main window left the suggestion overlay on screen with `akagi.exe` still running behind it.

## Why

Tauri exits when *all* windows close, and the overlay counts as one. Nothing handled the main window's `CloseRequested`, so destroying it just left the overlay holding the process open.

That is worse than a stray window. The overlay is `skip_taskbar` and undecorated — right while Akagi is running, hostile the moment it isn't. No taskbar entry, no title bar, nothing that leads back to the headless process behind the card. The only way out is the overlay's own **×**, and that persists `overlay.enabled = false`.

So the two things reported are one bug: *"closing Akagi leaves the overlay, and getting rid of the overlay disables it forever."* The user was forced into the one action that turns the feature off.

## Fix

The main window's `CloseRequested` now closes the overlay, and Tauri exits on its own once no windows remain — deliberately **not** `exit(0)`, which would skip the window-state save and the rest of the shutdown path.

It closes the *window* and does not touch `overlay.enabled`: quitting the app must never disable a feature. Only a deliberate × (or the Settings / toolbar toggle) does that, and the toggle brings it back. The asymmetry is now written down in `src/ipc/README.md`, because it is exactly the kind of thing a future "just close the window on shutdown, tidier" refactor would collapse.

## Verification

Window lifetime isn't unit-testable, so this was verified against the built binary. With the overlay open, send the main window a `WM_CLOSE` — precisely what the titlebar × does:

```
BEFORE close: windows = 'Akagi Overlay', 'Akagi'
AFTER close: process still alive? False
  process exited with code 0
--- config.toml [overlay] after quitting ---
enabled = true
```

Process gone, no window left behind, and the overlay still enabled for next launch.