### PR TITLE
fix(overlay): enable macos-private-api so the transparent window compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI
 
-# Fast PR gate: lint + test on Linux only. The full cross-platform build
-# and packaging lives in release.yml (tag-triggered). The goal here is to
-# catch fmt / clippy / compile / test / frontend breakage before merge —
-# `cargo test --lib` alone misses integration-test compile breaks, so we
-# also compile every test target.
+# Fast PR gate: lint + test on Linux, plus a compile-only check on the other
+# two release targets. The full cross-platform build and packaging still lives
+# in release.yml (tag-triggered). The goal here is to catch fmt / clippy /
+# compile / test / frontend breakage before merge — `cargo test --lib` alone
+# misses integration-test compile breaks, so we also compile every test target.
+#
+# The macOS/Windows check exists because Linux alone is not enough to prove the
+# code compiles: an API can be `cfg`'d out on another platform and still build
+# clean here. That is not hypothetical — `WebviewWindowBuilder::transparent` is
+# gated behind Tauri's `macos-private-api` feature on macOS, so the overlay
+# window compiled fine on Linux, passed every PR, and only blew up when the
+# v3.3.2 tag reached release.yml, which is the first thing that ever compiles
+# for macOS.
 
 on:
   pull_request:
@@ -68,6 +76,37 @@ jobs:
       # spawn_with_command arity break in tests/example_bot.rs.
       - name: build all test targets
         run: cargo test --no-run --all-targets
+
+  # Compile-only on the other two release targets. No tests, no packaging — the
+  # point is purely "does this platform's cfg path still build", which is the
+  # one thing the Linux gate above structurally cannot tell us. `macos-14` is
+  # arm64, matching release.yml's `aarch64-apple-darwin`.
+  compile:
+    name: Compile (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # build.rs runs prost-build on liqi.proto and needs protoc on PATH.
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # --all-targets so the bin (and its `generate_context!`) is compiled too,
+      # not just the lib.
+      - name: cargo check
+        run: cargo check --all-targets --locked
 
   frontend:
     name: Frontend (lint + build)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,15 @@ tauri-build = { version = "2", features = [] }
 prost-build = "0.14"
 
 [dependencies]
-tauri = { version = "2", features = [] }
+# `macos-private-api`: the suggestion overlay is a transparent window, and on
+# macOS `WebviewWindowBuilder::transparent` does not exist without this feature
+# — it is `#[cfg(any(not(target_os = "macos"), feature = "macos-private-api"))]`.
+# Must stay in step with `app.macOSPrivateApi` in tauri.conf.json; the feature
+# is what makes the call compile, the config flag is what makes it take effect.
+# The catch is that it uses private Apple APIs, so a build with it cannot be
+# accepted into the Mac App Store. Akagi ships as an unsigned portable zip from
+# GitHub Releases, so that costs us nothing.
+tauri = { version = "2", features = ["macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -15,6 +15,7 @@
   },
   "app": {
     "withGlobalTauri": true,
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "main",


### PR DESCRIPTION
Closes #196. Unblocks the v3.3.2 release.

## The break

The `v3.3.2` release build failed on `aarch64-apple-darwin`. Windows and Linux compiled; macOS didn't, so `Publish GitHub release` was skipped and **no release was produced**.

```
error[E0599]: no method named `transparent` found for struct `WebviewWindowBuilder`
   --> src/ipc/overlay.rs:91:10
 91 |         .transparent(true)
```

The overlay is a transparent window, and on macOS `WebviewWindowBuilder::transparent` **does not exist** unless Tauri's `macos-private-api` feature is on:

```rust
#[cfg(any(not(target_os = "macos"), feature = "macos-private-api"))]
pub fn transparent(mut self, transparent: bool) -> Self
```

So: enable the feature, and set `app.macOSPrivateApi: true` in `tauri.conf.json`. The **feature** is what makes the call compile; the **config flag** is what makes it take effect at runtime. They have to stay in step, which is why both changes carry a comment pointing at the other.

The catch is that it uses private Apple APIs, so such a build can't be accepted into the Mac App Store. Akagi ships as an unsigned portable zip from GitHub Releases, so that costs us nothing.

## The more useful half

**`ci.yml` compiles on Linux only** — it says so in its own header. So an API that is `cfg`'d out on another platform builds clean on every PR and is discovered by `release.yml` instead, *after a tag has been pushed*. That is the worst possible moment to find out, and it is exactly what happened: the overlay went through three PRs and a merge to `v3`, all green, and broke the instant the tag reached the first job that ever compiles for macOS.

That is a structural gap, not a slip in one PR — any macOS- or Windows-gated API walks through the same door.

So this adds a **compile-only** matrix job on `macos-14` (arm64, matching the release target) and `windows-latest`: `cargo check --all-targets`. No tests, no packaging — purely *"does this platform's cfg path still build"*, which is the one thing the Linux gate structurally cannot answer.

It is also the only thing that can prove the fix above. I cannot build for macOS from this machine; **this PR's own macOS job is the verification.**

## Checks

- `cargo check --all-targets --locked` clean on Windows locally, and `Cargo.lock` is **unchanged** by the feature, so CI's `--locked` stays valid.
- The new `Compile (macos-14)` job is the one to watch: it must go green, and it would have gone red on `v3` as it stands.

## The tag

`v3.3.2` is pushed and points at the version-bump commit, but **no GitHub release exists** — the publish step never ran. Once this lands the tag needs re-pointing (or superseding); I'll check with you before touching it.