### PR TITLE
feat(bots): verify cloud-inference key on Save when Online API is enabled

### DIFF
--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -503,6 +503,7 @@
       "topk": "Candidates (top-k)",
       "saved": "Cloud inference settings saved",
       "save_failed": "Failed to save settings",
+      "save_key_check_failed": "Can't save with cloud inference on: the API key check failed. Fix the key or turn the API off.",
       "check_key": "Check key",
       "checking": "Checking…",
       "fetch_models": "Fetch models",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -503,6 +503,7 @@
       "topk": "候補数(top-k)",
       "saved": "クラウド推論の設定を保存しました",
       "save_failed": "設定の保存に失敗しました",
+      "save_key_check_failed": "クラウド推論を有効にしたままでは保存できません：APIキーの確認に失敗しました。キーを修正するか、APIをオフにしてください。",
       "check_key": "キーを確認",
       "checking": "確認中…",
       "fetch_models": "モデルを取得",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -503,6 +503,7 @@
       "topk": "候选数(top-k)",
       "saved": "已保存云端推理设置",
       "save_failed": "保存设置失败",
+      "save_key_check_failed": "无法在启用云端推理的情况下保存：密钥检查未通过。请修正密钥，或关闭 API。",
       "check_key": "查询密钥",
       "checking": "查询中…",
       "fetch_models": "获取模型",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -503,6 +503,7 @@
       "topk": "候選數(top-k)",
       "saved": "已儲存雲端推論設定",
       "save_failed": "儲存設定失敗",
+      "save_key_check_failed": "無法在啟用雲端推論的情況下儲存：金鑰檢查未通過。請修正金鑰，或關閉 API。",
       "check_key": "查詢金鑰",
       "checking": "查詢中…",
       "fetch_models": "取得模型",

--- a/frontend/src/lib/nativeApi.test.ts
+++ b/frontend/src/lib/nativeApi.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { checkApiBeforeSave } from './nativeApi'
+import type { NativeApiConfig } from '@/types'
+
+// The helper reaches the backend through `@/lib/tauri`'s `invoke`; mock it so
+// the test controls whether the key-status endpoint accepts or rejects the key.
+const invoke = vi.fn()
+vi.mock('@/lib/tauri', () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) => invoke(cmd, args),
+}))
+
+const api = (patch: Partial<NativeApiConfig> = {}): NativeApiConfig => ({
+  enabled: true,
+  base_url: 'https://mjapi.example.test',
+  key: 'sk-test-key',
+  model_4p: '',
+  model_3p: '',
+  proxy_enabled: false,
+  proxy: '',
+  ...patch,
+})
+
+describe('checkApiBeforeSave', () => {
+  beforeEach(() => {
+    invoke.mockReset()
+  })
+
+  it('passes without hitting the server when the API is disabled', async () => {
+    // A disabled API has nothing to verify — Save must proceed even with a
+    // blank/garbage key, and we must not make a network call to check it.
+    const res = await checkApiBeforeSave(api({ enabled: false, key: '' }))
+    expect(res).toEqual({ ok: true })
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('blocks as `missing` when enabled but the URL or key is blank', async () => {
+    // Enabled with an empty key can't possibly work; report it as `missing`
+    // (a distinct, friendlier reason) instead of firing a doomed request.
+    expect(await checkApiBeforeSave(api({ key: '   ' }))).toEqual({
+      ok: false,
+      kind: 'missing',
+    })
+    expect(await checkApiBeforeSave(api({ base_url: '' }))).toEqual({
+      ok: false,
+      kind: 'missing',
+    })
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('passes when the server accepts the key', async () => {
+    invoke.mockResolvedValueOnce({ plan: 'pro' })
+    const cfg = api()
+    expect(await checkApiBeforeSave(cfg)).toEqual({ ok: true })
+    expect(invoke).toHaveBeenCalledWith('native_api_key_status', {
+      baseUrl: cfg.base_url,
+      key: cfg.key,
+    })
+  })
+
+  it('blocks as `error` and forwards the reason when the server rejects the key', async () => {
+    invoke.mockRejectedValueOnce('401 Unauthorized: key expired')
+    expect(await checkApiBeforeSave(api())).toEqual({
+      ok: false,
+      kind: 'error',
+      message: '401 Unauthorized: key expired',
+    })
+  })
+})

--- a/frontend/src/lib/nativeApi.ts
+++ b/frontend/src/lib/nativeApi.ts
@@ -1,6 +1,41 @@
 import { invoke } from '@/lib/tauri'
 import { useConfigStore } from '@/stores/configStore'
-import type { NativeApiConfig } from '@/types'
+import type { KeyStatus, NativeApiConfig } from '@/types'
+
+/**
+ * Result of {@link checkApiBeforeSave}. `ok` gates whether the caller may
+ * persist the config; `kind` distinguishes the two blocking reasons so the
+ * caller can pick the right (localised) message:
+ *  - `missing` — enabled but no server URL / key entered yet.
+ *  - `error`   — the server rejected the key; `message` is the raw reason.
+ */
+export type ApiSaveCheck =
+  | { ok: true }
+  | { ok: false; kind: 'missing' }
+  | { ok: false; kind: 'error'; message: string }
+
+/**
+ * Guard run before persisting `bot.api`: when cloud inference is **enabled**,
+ * confirm the key actually works (via `GET /v3/key`) so a broken key can't be
+ * saved in the enabled state — otherwise the built-in bot would silently fall
+ * back to the local model every turn with no signal to the user. A disabled
+ * API always passes; there is nothing to check.
+ */
+export async function checkApiBeforeSave(api: NativeApiConfig): Promise<ApiSaveCheck> {
+  if (!api.enabled) return { ok: true }
+  if (api.base_url.trim() === '' || api.key.trim() === '') {
+    return { ok: false, kind: 'missing' }
+  }
+  try {
+    await invoke<KeyStatus>('native_api_key_status', {
+      baseUrl: api.base_url,
+      key: api.key,
+    })
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, kind: 'error', message: String(e) }
+  }
+}
 
 /**
  * Persist a `bot.api` change immediately, layered on the *stored* (on-disk)

--- a/frontend/src/routes/Bots.tsx
+++ b/frontend/src/routes/Bots.tsx
@@ -40,7 +40,7 @@ import { useConfigStore } from '@/stores/configStore'
 import type { AppConfig, BotInfo, BotSettings, NativeApiConfig } from '@/types'
 import { ManifestField } from '@/components/ManifestField'
 import { NativeApiFields } from '@/components/NativeApiFields'
-import { persistApiConfig } from '@/lib/nativeApi'
+import { checkApiBeforeSave, persistApiConfig } from '@/lib/nativeApi'
 import { proxyConfigValid } from '@/lib/proxy'
 import { mergeExternal } from '@/lib/merge'
 
@@ -658,6 +658,17 @@ function NativeApiSettings() {
   const save = async (): Promise<boolean> => {
     setSaving(true)
     try {
+      // With cloud inference enabled, refuse to persist a key that doesn't
+      // work: a saved-but-broken key silently falls back to the local model
+      // every turn, so the user would think the API is on when it isn't. Block
+      // the save and surface why — they must fix the key or turn the API off.
+      const check = await checkApiBeforeSave(draft)
+      if (!check.ok) {
+        toast.error(t('bots.api.save_key_check_failed'), {
+          description: check.kind === 'missing' ? t('bots.api.need_url_key') : check.message,
+        })
+        return false
+      }
       const next = { ...config, bot: { ...config.bot, api: draft } }
       await invoke('update_config', { newConfig: next })
       setConfig(next)

--- a/frontend/src/routes/Setup.tsx
+++ b/frontend/src/routes/Setup.tsx
@@ -18,6 +18,7 @@ import { InstallBlockingOverlay } from '@/components/InstallBlockingOverlay'
 import { NativeApiFields } from '@/components/NativeApiFields'
 import { invoke } from '@/lib/tauri'
 import { withInstallBlock } from '@/lib/install'
+import { checkApiBeforeSave } from '@/lib/nativeApi'
 import { mergeExternal } from '@/lib/merge'
 import { useTauriBridge } from '@/hooks/useTauriBridge'
 import { useConfigStore } from '@/stores/configStore'
@@ -126,6 +127,21 @@ export function Setup() {
       setBusy(true)
       setErr(null)
       try {
+        // Same guard as the Bots page Save: if cloud inference is enabled,
+        // the key must work before we let the wizard advance — otherwise Finish
+        // would persist an enabled-but-broken API that silently falls back to
+        // the local model. Checked here (not on Finish) so the error surfaces
+        // right by the API fields; the user must fix the key or turn it off.
+        const check = await checkApiBeforeSave(draft.bot.api)
+        if (!check.ok) {
+          setErr(
+            check.kind === 'missing'
+              ? `${t('bots.api.save_key_check_failed')} ${t('bots.api.need_url_key')}`
+              : `${t('bots.api.save_key_check_failed')} ${check.message}`,
+          )
+          setBusy(false)
+          return
+        }
         await saveBotSettings()
       } catch (e) {
         setErr(String(e))


### PR DESCRIPTION
Closes #203.

## Problem

The **Save** button on the Bots page *Cloud inference (built-in bot)* card — and the first-run **Setup wizard** — persisted `bot.api` unconditionally, never confirming the API key actually works. Enabling the Online API and saving a wrong / expired / empty key succeeded silently, and at game time the built-in bot fell back to the local model on every request with no signal that cloud inference was broken.

## Change

New helper `checkApiBeforeSave(api)` in `frontend/src/lib/nativeApi.ts`:

- API **disabled** → `{ ok: true }` (nothing to check, no network call).
- Enabled but **URL/key blank** → `{ ok: false, kind: 'missing' }`.
- Enabled → calls the existing key-status endpoint (`native_api_key_status`, `GET /v3/key`); on rejection returns `{ ok: false, kind: 'error', message }`.

Applied at **both** persist points:

1. **Bots page** — `NativeApiSettings.save()` runs the guard first; on failure it toasts the reason (new `bots.api.save_key_check_failed` string, all four locales) and returns `false` without persisting. Covers the plain **Save** and the **Save & leave** unsaved-changes path (both funnel through `save()`).
2. **Setup wizard** — the `configure → finish` transition (`next()`) runs the same guard. Since that's the only path to the Finish step, first-run setup can no longer persist an enabled-but-broken API; the error surfaces in the wizard's error strip right beside the API fields.

In both cases the user must fix the key or turn the API off before the enabled state can be saved.

## Notes

- A transient server outage also blocks the save (the check didn't pass), matching the requested behaviour. Retry when reachable, or disable the API.

## Tests

- `frontend/src/lib/nativeApi.test.ts` covers all four helper branches (disabled → no call, missing url/key, accepted key, rejected key forwards the reason).
- `vitest run` — 33/33 pass · `tsc -b` clean · `eslint` clean on changed files · `vite build` succeeds.
- Built and GUI-smoke-tested a standalone binary (window launches healthy, not hung).