### PR TITLE
Avoid rewriting resolved bot settings

### DIFF
--- a/src/bot/manifest.rs
+++ b/src/bot/manifest.rs
@@ -283,6 +283,13 @@ pub fn write_resolved(
     std::fs::create_dir_all(&dir).with_context(|| format!("mkdir {}", dir.display()))?;
     let path = dir.join(RESOLVED_FILE);
     let body = serde_json::to_vec_pretty(values).context("serialize resolved settings")?;
+    if std::fs::read(&path)
+        .map(|existing| existing == body)
+        .unwrap_or(false)
+    {
+        return std::fs::canonicalize(&path)
+            .with_context(|| format!("canonicalize {}", path.display()));
+    }
     std::fs::write(&path, body).with_context(|| format!("write {}", path.display()))?;
     // Canonicalize so the env var survives the child's `current_dir(bot_dir)`
     // — a relative path would otherwise be resolved against the bot's cwd
@@ -580,6 +587,26 @@ mystery = "ignored"
         let body = std::fs::read_to_string(&path).unwrap();
         let back: BTreeMap<String, serde_json::Value> = serde_json::from_str(&body).unwrap();
         assert_eq!(back["k"], json!("v"));
+    }
+
+    #[test]
+    fn write_resolved_leaves_identical_file_untouched() {
+        let tmp = TempDir::new().unwrap();
+        let mut values: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        values.insert("k".into(), json!("v"));
+
+        let path = write_resolved(tmp.path(), &values).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        let result = write_resolved(tmp.path(), &values);
+
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_readonly(false);
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        result.unwrap();
     }
 
     /// Regression: the resolved-settings path must be absolute. The bot

--- a/src/bot/manifest.rs
+++ b/src/bot/manifest.rs
@@ -596,15 +596,14 @@ mystery = "ignored"
         values.insert("k".into(), json!("v"));
 
         let path = write_resolved(tmp.path(), &values).unwrap();
-        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        let original_perms = std::fs::metadata(&path).unwrap().permissions();
+        let mut perms = original_perms.clone();
         perms.set_readonly(true);
         std::fs::set_permissions(&path, perms).unwrap();
 
         let result = write_resolved(tmp.path(), &values);
 
-        let mut perms = std::fs::metadata(&path).unwrap().permissions();
-        perms.set_readonly(false);
-        std::fs::set_permissions(&path, perms).unwrap();
+        std::fs::set_permissions(&path, original_perms).unwrap();
 
         result.unwrap();
     }


### PR DESCRIPTION
## Summary
- Avoid rewriting `.akagi/resolved_settings.json` when the resolved bot settings are unchanged.
- Keep returning the canonical path for `AKAGI_BOT_CONFIG` so subprocess bots continue to receive an absolute config path.
- Add a regression test that verifies identical resolved settings do not require writing the file again.

## Root Cause
When a manifest-backed bot is spawned, Akagi resolves the bot settings and writes them to `<bot>/.akagi/resolved_settings.json`. During `tauri dev`, the Tauri file watcher observes that runtime file update and rebuilds/restarts the app, which also terminates the managed Chromium capture browser. This can look like Akagi and the browser both crash as soon as a Mahjong Soul table starts.

The issue is not specific to Mortal 298k; that bot made it easy to reproduce because it has a manifest and is spawned at game start.

## Impact
In development mode, starting a table with a manifest-backed bot no longer triggers an unnecessary Tauri rebuild when the resolved settings have not changed. Runtime file churn is also reduced in normal use.

## Validation
- `cargo test -q bot::manifest::tests::write_resolved`
- Reproduced the original behavior with `tauri dev`: table start updated `mjai_bot/mortal-298k-4p/.akagi/resolved_settings.json`, causing `Rebuilding application...` and restarting Akagi/Chromium.
- Retested after the change: table start no longer triggered a Tauri rebuild; Mortal 298k loaded on CUDA and continued returning actions.
