### PR TITLE
fix(bot): a key is the request — adopt it on entry

### DIFF
--- a/frontend/src/components/NativeApiFields.test.tsx
+++ b/frontend/src/components/NativeApiFields.test.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { NativeApiFields } from './NativeApiFields'
+import type { NativeApiConfig } from '@/types'
+
+// Regression cover for #221: pasting an API key stored the key and nothing
+// else, so the bot kept answering from the local model with a config that
+// looked configured. A complete key must now enable cloud inference itself.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+const invoke = vi.fn()
+vi.mock('@/lib/tauri', () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) => invoke(cmd, args),
+  HAS_TAURI: false,
+  listen: () => Promise.resolve(() => {}),
+}))
+
+// The purchase flow is a whole handshake of its own and none of it is under
+// test here; the dialog only ever renders after a button press we never make.
+vi.mock('@/components/PurchaseDialog', () => ({ PurchaseDialog: () => null }))
+vi.mock('@/components/ui/sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+/** A key of the shape the server issues: 32 letters and digits. */
+const FULL_KEY = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6'
+
+const base = (patch: Partial<NativeApiConfig> = {}): NativeApiConfig => ({
+  enabled: false,
+  base_url: 'https://mjapi.example.test',
+  key: '',
+  model_4p: '',
+  model_3p: '',
+  proxy_enabled: false,
+  proxy: '',
+  ...patch,
+})
+
+/**
+ * Render the (fully controlled) component behind a state holder, the way the
+ * Bots page and the Setup wizard both drive it. `latest()` reads back what the
+ * component asked its owner to store.
+ */
+function renderFields(initial: NativeApiConfig) {
+  let current = initial
+  function Host() {
+    const [api, setApi] = useState(initial)
+    current = api
+    return <NativeApiFields value={api} onChange={setApi} />
+  }
+  render(<Host />)
+  const keyInput = screen.getByPlaceholderText('••••••••••••••••••••••••••••••••')
+  return { keyInput, latest: () => current }
+}
+
+describe('NativeApiFields — entering a key', () => {
+  beforeEach(() => {
+    invoke.mockReset()
+  })
+
+  it('enables cloud inference and fills empty model slots on a complete key', async () => {
+    invoke.mockResolvedValueOnce([
+      { id: 'mortal-4p', game: '4p', desc: '' },
+      { id: 'mortal-3p', game: '3p', desc: '' },
+    ])
+    const { keyInput, latest } = renderFields(base())
+
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+
+    await waitFor(() => expect(latest().enabled).toBe(true))
+    expect(latest().key).toBe(FULL_KEY)
+    expect(latest().model_4p).toBe('mortal-4p')
+    expect(latest().model_3p).toBe('mortal-3p')
+    expect(invoke).toHaveBeenCalledWith('native_api_models', {
+      baseUrl: 'https://mjapi.example.test',
+      proxy: '',
+      key: FULL_KEY,
+    })
+  })
+
+  it('never clobbers a model the user already chose', async () => {
+    invoke.mockResolvedValueOnce([
+      { id: 'mortal-4p', game: '4p', desc: '' },
+      { id: 'mortal-3p', game: '3p', desc: '' },
+    ])
+    const { keyInput, latest } = renderFields(base({ model_4p: 'my-pick' }))
+
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+
+    await waitFor(() => expect(latest().enabled).toBe(true))
+    expect(latest().model_4p).toBe('my-pick')
+    expect(latest().model_3p).toBe('mortal-3p')
+  })
+
+  it('stores a partial key without enabling or calling the server', () => {
+    const { keyInput, latest } = renderFields(base())
+
+    fireEvent.change(keyInput, { target: { value: FULL_KEY.slice(0, 20) } })
+
+    expect(latest().key).toBe(FULL_KEY.slice(0, 20))
+    expect(latest().enabled).toBe(false)
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('enables nothing and surfaces the reason when the server rejects the key', async () => {
+    invoke.mockRejectedValueOnce('401 Unauthorized: unknown key')
+    const { keyInput, latest } = renderFields(base())
+
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+
+    await waitFor(() => screen.getByText(/401 Unauthorized: unknown key/))
+    expect(latest().enabled).toBe(false)
+    expect(latest().key).toBe(FULL_KEY)
+  })
+
+  it('retries a rejected key on the next edit, but adopts a good one only once', async () => {
+    invoke
+      .mockRejectedValueOnce('401 Unauthorized: unknown key')
+      .mockResolvedValueOnce([{ id: 'mortal-4p', game: '4p', desc: '' }])
+    const { keyInput, latest } = renderFields(base())
+
+    // A key the server rejects must not stay silently disabled forever: fixing
+    // the field (here, retyping the last character) has to ask again.
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+    await waitFor(() => screen.getByText(/401 Unauthorized/))
+    fireEvent.change(keyInput, { target: { value: FULL_KEY.slice(0, -1) } })
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+    await waitFor(() => expect(latest().enabled).toBe(true))
+    expect(invoke).toHaveBeenCalledTimes(2)
+
+    // Once adopted, editing away and back does not re-query the same key.
+    fireEvent.change(keyInput, { target: { value: FULL_KEY.slice(0, -1) } })
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+    expect(invoke).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not query the server when no base URL is set', () => {
+    const { keyInput, latest } = renderFields(base({ base_url: '' }))
+
+    fireEvent.change(keyInput, { target: { value: FULL_KEY } })
+
+    expect(latest().key).toBe(FULL_KEY)
+    expect(latest().enabled).toBe(false)
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/NativeApiFields.tsx
+++ b/frontend/src/components/NativeApiFields.tsx
@@ -39,6 +39,9 @@ import { usePurchaseStore, type PurchasePhase } from '@/stores/purchaseStore'
 import { effectiveProxy, isValidProxyUrl } from '@/lib/proxy'
 import type { KeyStatus, ModelInfo, NativeApiConfig, RedeemResponse } from '@/types'
 
+/** Shape of a key the server issues: 32 letters and digits, nothing else. */
+const KEY_PATTERN = /^[A-Za-z0-9]{32}$/
+
 /**
  * Controlled editor for the built-in bot's cloud-inference settings
  * (`bot.api`). Fully controlled via `value` / `onChange` so it can bind to the
@@ -89,10 +92,13 @@ export function NativeApiFields({
   // never part of the same unsaved edit that changes the URL.
   const devMode = useConfigStore((s) => s.config?.general.developer_mode ?? false)
 
+  /** Key we have already adopted, so re-renders don't re-query the server. */
+  const adoptedKeyRef = useRef<string | null>(null)
+
   // Latest `value` as of the last committed render. Async handlers (the model
-  // auto-fill in `toggleEnabled`) resolve against this instead of the snapshot
-  // captured when the request started, so a slow request never clobbers what
-  // the user typed while it was in flight.
+  // auto-fill in `toggleEnabled` / `adoptKey`) resolve against this instead of
+  // the snapshot captured when the request started, so a slow request never
+  // clobbers what the user typed while it was in flight.
   const valueRef = useRef(value)
   useEffect(() => {
     valueRef.current = value
@@ -106,6 +112,44 @@ export function NativeApiFields({
     })
     setModels(list)
     return list
+  }
+
+  /**
+   * A complete key was typed or pasted. Take it from there: ask the server what
+   * models it grants, pick a default for each mode, and switch cloud inference
+   * on.
+   *
+   * Entering a key is the user saying they want the cloud model — making them
+   * then find a toggle (which sits above the field they just filled) and a model
+   * dropdown only invites the state where a key is set and nothing uses it.
+   *
+   * A key the server rejects enables nothing: the error surfaces and the bot
+   * stays local, which beats a config that claims cloud inference it cannot do.
+   */
+  const adoptKey = async (key: string) => {
+    const next = { ...valueRef.current, key }
+    if (!KEY_PATTERN.test(key) || !next.base_url.trim() || adoptedKeyRef.current === key) {
+      onChange(next)
+      return
+    }
+    adoptedKeyRef.current = key
+    onChange(next)
+    setEnabling(true)
+    setErr(null)
+    try {
+      const list = await queryModels(next)
+      const cur = valueRef.current
+      const filled = { ...cur, enabled: true }
+      if (!filled.model_4p) filled.model_4p = list.find((m) => m.game === '4p')?.id ?? ''
+      if (!filled.model_3p) filled.model_3p = list.find((m) => m.game === '3p')?.id ?? ''
+      onChange(filled)
+    } catch (e) {
+      // Let the next edit try again — a rejected key is often a half-pasted one.
+      adoptedKeyRef.current = null
+      setErr(String(e))
+    } finally {
+      setEnabling(false)
+    }
   }
 
   // Turning the API on: flip immediately for a responsive switch, then query
@@ -331,7 +375,7 @@ export function NativeApiFields({
           <Input
             type={showKey ? 'text' : 'password'}
             value={value.key}
-            onChange={(e) => set({ key: e.target.value })}
+            onChange={(e) => void adoptKey(e.target.value.trim())}
             placeholder="••••••••••••••••••••••••••••••••"
             autoComplete="off"
             spellCheck={false}


### PR DESCRIPTION
Fixes #221.

## The problem

Pasting an API key into *Bots → Cloud inference* stored the key and did
nothing else. Turning cloud inference on required also finding the **Enable**
switch, which sits *above* the field just filled, so the usual outcome was a
key set, `bot.api.enabled` still `false`, and the built-in bot quietly
answering from the local model. Nothing on screen said so.

`NativeApiConfig::is_active()` needs `enabled && base_url && key`, but the
model auto-fill and the "on" state were only reachable through
`toggleEnabled`, wired exclusively to the switch. Meanwhile the redeem and
purchase paths already did the right thing via `adoptNewKey`, so the same key
behaved differently depending on whether it arrived by purchase or by hand.

## The fix

Treat a complete key as the user asking for cloud inference, the way a
redeemed one already is. `frontend/src/components/NativeApiFields.tsx`: the
key field's `onChange` now goes through a new `adoptKey()` rather than a plain
`set({ key })`.

- A key the server issues is 32 characters of `[A-Za-z0-9]`, so a complete one
  is recognisable as it is typed or pasted.
- On a complete key: query `native_api_models`, fill any **empty** 4p/3p model
  slot with the first model the plan grants for that mode, and set
  `enabled: true`. A model the user already chose is never clobbered.
- A key the server rejects enables nothing — the error surfaces and the bot
  stays local. A config claiming inference it cannot perform is worse than an
  obvious "off".
- `adoptedKeyRef` keeps re-renders from re-querying an already-adopted key,
  and is cleared on failure so the next edit retries (a rejected key is often
  a half-pasted one).

The async fill resolves against `valueRef`, not the pre-request snapshot, so a
slow request cannot clobber what the user typed while it was in flight — the
same discipline `toggleEnabled` already used.

This also covers the first-run wizard's bot-configuration step, which renders
the same component.

## Tests

New `frontend/src/components/NativeApiFields.test.tsx`, 6 cases:

- a complete key enables cloud inference and fills both empty model slots;
- a model the user already chose survives the auto-fill;
- a partial key is stored but neither calls the server nor enables;
- a rejected key leaves it disabled and shows the reason;
- a rejected key retries on the next edit, while a good one is adopted once;
- no server URL means no query.

Reverting just the `onChange` handler makes 4 of the 6 fail, so they pin the
regression. `tsc --noEmit` and `eslint` are clean. The 16 failing
sidebar/`NarrowTopBar` tests in the full frontend suite pre-date this branch
(verified by stashing the change and re-running).

## Not included

The issue also suggests stating the effective on/off condition next to the
save button, and having the bot-status display report which model actually
served the last decision instead of re-deriving it from config. Both are
worthwhile but separate from the reported bug; left for follow-ups.
