### PR TITLE
Answer forced moves locally instead of spending an online API call

### DIFF
--- a/native_bot/src/engine.rs
+++ b/native_bot/src/engine.rs
@@ -88,6 +88,11 @@ pub struct Decision {
     pub candidates: Vec<(BotAction, f32)>,
     /// Raw action logits (indexed by the mode's action space).
     pub logits: Vec<f32>,
+    /// The full legal set (before the top-N cut in `candidates`) held exactly
+    /// one action, so this "decision" is forced — any policy, local or remote,
+    /// can only play `action`. Callers that pay per query (the online API) use
+    /// this to answer locally instead of spending a call on a foregone move.
+    pub forced: bool,
 }
 
 enum Backend {
@@ -195,7 +200,8 @@ impl Engine {
     /// legal action (not our turn / nothing to respond to).
     pub fn decide(&mut self) -> Result<Option<Decision>> {
         let seat = self.seat;
-        let (mut ranked, logits, last_discarder, drawn, reach_pai) = match &mut self.backend {
+        let (mut ranked, logits, last_discarder, drawn, reach_pai, forced) = match &mut self.backend
+        {
             Backend::Four { state, model } => {
                 // `last_discard` is `(discarder_pid, tile)`.
                 let last_discarder = state.last_discard.map(|(pid, _tile)| pid);
@@ -204,6 +210,9 @@ impl Engine {
                 if legal.is_empty() {
                     return Ok(None);
                 }
+                // Forced ⇔ the *legal* set is a singleton — `ranked` is cut to
+                // SHOW_TOP_N below, so its length can't be used for this.
+                let forced = legal.len() == 1;
                 let logits = model.forward_logits(&obs)?;
                 let ranked = rank_by_logits(&legal, &logits, 4, SHOW_TOP_N);
                 let Some((top, _)) = ranked.first() else {
@@ -214,7 +223,7 @@ impl Engine {
                 } else {
                     None
                 };
-                (ranked, logits, last_discarder, drawn, reach_pai)
+                (ranked, logits, last_discarder, drawn, reach_pai, forced)
             }
             Backend::Three { state, model } => {
                 let last_discarder = state.last_discard.map(|(pid, _tile)| pid);
@@ -223,6 +232,7 @@ impl Engine {
                 if legal.is_empty() {
                     return Ok(None);
                 }
+                let forced = legal.len() == 1;
                 let logits = model.forward_logits(&obs)?;
                 let ranked = rank_by_logits(&legal, &logits, 3, SHOW_TOP_N);
                 let Some((top, _)) = ranked.first() else {
@@ -233,7 +243,7 @@ impl Engine {
                 } else {
                     None
                 };
-                (ranked, logits, last_discarder, drawn, reach_pai)
+                (ranked, logits, last_discarder, drawn, reach_pai, forced)
             }
         };
 
@@ -256,6 +266,7 @@ impl Engine {
             action,
             candidates,
             logits,
+            forced,
         }))
     }
 

--- a/native_bot/tests/engine_replay.rs
+++ b/native_bot/tests/engine_replay.rs
@@ -53,6 +53,11 @@ fn decides_a_legal_discard_after_tsumo() {
         "unexpected action on own turn: {:?}",
         decision.action
     );
+    // A fresh 14-tile hand has many legal discards — nothing forced about it.
+    assert!(
+        !decision.forced,
+        "an opening discard choice must not be flagged forced"
+    );
     assert_eq!(decision.logits.len(), 82);
     assert!(
         decision.logits.iter().all(|v| v.is_finite()),

--- a/src/bot/native.rs
+++ b/src/bot/native.rs
@@ -23,7 +23,10 @@
 //! - **Gating** — the API's rate limits are low, and calling on every opponent
 //!   discard "just in case" roughly triples the request count. So we run the
 //!   local model's cheap legal-action check first and only hit the network when
-//!   our seat genuinely has a move to make.
+//!   our seat genuinely has a move to make. Forced moves — a legal set of
+//!   exactly one action, e.g. every tsumogiri while riichi — are answered
+//!   locally too: the server could not pick anything else, so the call would
+//!   spend quota to learn nothing.
 //! - **Fallback** — if the server is unreachable, rate-limited, or the key is
 //!   invalid, we play the local model's action so a live game never stalls.
 //! - **Circuit breaker** — after a failed call the API is skipped for a growing
@@ -544,7 +547,11 @@ impl BotRunner for NativeBot {
         let cfg = self.config.read().await.bot.api.clone();
         self.apply_api_config(&cfg, Announce::ToUser);
 
-        let (action, meta) = if self.api.is_some() && self.breaker.allows() {
+        // A forced move (the legal set is a singleton — e.g. tsumogiri while
+        // riichi) has only one possible answer, so asking the server would
+        // spend a metered API call to learn nothing. Answer it locally.
+        let use_api = self.api.is_some() && self.breaker.allows() && !local.forced;
+        let (action, meta) = if use_api {
             self.remote_decision(&local).await
         } else {
             local_reply(&local, self.seat)
@@ -1310,6 +1317,94 @@ mod tests {
         );
         // A dead follow-up trips the breaker, so the next decision stays local.
         assert!(!bot.breaker.allows());
+    }
+
+    /// Regression (#227): a forced move — the legal set is a singleton, here
+    /// the tsumogiri after our riichi — must be answered by the local model
+    /// without spending a metered API call: the server could only return the
+    /// same move.
+    ///
+    /// The mock is scripted with zero responses, so its listener is already
+    /// gone when we decide; had the bot tried the network anyway, the refused
+    /// connection would have opened the breaker and toasted a degrade warning.
+    /// Both staying quiet is the proof that no call was even attempted.
+    #[tokio::test]
+    async fn a_forced_move_is_answered_locally_without_an_api_call() {
+        let (base, served) = mock_http(vec![]);
+        let notify = crate::event_bus::notify_bus();
+        let mut rx = notify.subscribe();
+        let mut bot = bot_with(cfg_api(&base), notify).await;
+
+        let mut events = vec![
+            start_game_4p(0),
+            // Closed tenpai: 123m 456m 789m 123p + 4p tanki.
+            start_kyoku_4p_hidden([
+                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p",
+            ]),
+            MjaiEvent::Tsumo {
+                actor: 0,
+                pai: "9s".into(),
+            },
+            // Our riichi, echoed back through the bus as in a live game.
+            MjaiEvent::Reach {
+                actor: 0,
+                pai: None,
+            },
+            MjaiEvent::Dahai {
+                actor: 0,
+                pai: "9s".into(),
+                tsumogiri: true,
+            },
+            MjaiEvent::ReachAccepted { actor: 0 },
+        ];
+        for seat in 1..4u8 {
+            events.push(MjaiEvent::Tsumo {
+                actor: seat,
+                pai: "1z".into(),
+            });
+            events.push(MjaiEvent::Dahai {
+                actor: seat,
+                pai: "1z".into(),
+                tsumogiri: true,
+            });
+        }
+        // Our next draw: not the winning 4p, no kan in sight — discarding the
+        // drawn tile is the only legal action.
+        events.push(MjaiEvent::Tsumo {
+            actor: 0,
+            pai: "9s".into(),
+        });
+
+        let resp = bot.react(&events).await.unwrap();
+        assert_eq!(
+            resp.action,
+            MjaiEvent::Dahai {
+                actor: 0,
+                pai: "9s".into(),
+                tsumogiri: true,
+            },
+            "riichi forces the tsumogiri"
+        );
+        // Answered by the local model…
+        assert_eq!(
+            resp.meta.as_ref().unwrap()["show"]["title"],
+            SHOW_TITLE_LOCAL
+        );
+        // …without touching the network: no request reached the mock, no failed
+        // attempt opened the breaker, no degrade toast reached the user.
+        assert!(
+            bot.breaker.allows(),
+            "a skipped call must not touch the breaker"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a skipped call must not toast the user"
+        );
+        assert_eq!(
+            served.join().unwrap().len(),
+            0,
+            "no API call for a forced move"
+        );
     }
 
     // ---------- circuit breaker ----------


### PR DESCRIPTION
Fixes #227 (the single-legal-action half).

## Problem

With the online API enabled, every decision point went to the server — including positions with exactly **one** legal action, where the server can only return that same move. The most common case is playing out a riichi: every draw after the declaration is a forced tsumogiri (unless tsumo/kan is legal), so each of those turns burned one metered API call and a network round-trip for nothing.

## Fix

- `native_bot`: `Engine::decide()` now sets `Decision::forced` when the legal-action set is a singleton. This is measured on the full legal set **before** the top-N display cut — `candidates.len()` alone cannot distinguish a forced move from a truncated ranking.
- `NativeBot::react()` answers a forced decision with the local reply and skips the request entirely. Skipped calls leave the circuit breaker and health toasts untouched.

Edge cases kept intact:

- Call windows (`[Pon, Pass]` etc.) always have ≥ 2 legal actions and still go to the server.
- If the local riichi-discard prediction fails and riichi is dropped from the local ranking, the legal set still had ≥ 2 actions, so `forced` stays false and the server (which may still answer `reach`) is consulted as before.

## Tests

- Regression `a_forced_move_is_answered_locally_without_an_api_call`: end-to-end riichi → forced tsumogiri against a mock server scripted with zero responses; asserts the tsumogiri is played with the local HUD title, no request is served, the breaker stays closed, and no health toast fires. Mutation-checked: removing the `!local.forced` guard makes it fail.
- `engine_replay`: an opening 14-tile hand asserts `!forced`.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 746 lib tests, and `engine_replay` (with inference weights) all pass locally.