### PR TITLE
fix(autoplay): refresh delay.lua when it matches an outdated bundled default

### DIFF
--- a/assets/delay_default_superseded/1893c05.lua
+++ b/assets/delay_default_superseded/1893c05.lua
@@ -1,0 +1,187 @@
+-- Akagi autoplay delay model.
+--
+-- Akagi generated this file next to your config.toml. Edit it freely —
+-- it hot-reloads every time you save. Delete it to get a fresh copy of
+-- the default on the next start. If the script ever errors, Akagi keeps
+-- playing with its built-in model and logs the reason once.
+--
+-- decide_delay(ctx) returns { delay_ms = <number>, allow_bank = <bool> }.
+--
+-- delay_ms is the target TOTAL thinking time for the decision window —
+-- the time the SERVER observes between offering the decision and
+-- receiving the action. It is NOT a sleep length: Akagi subtracts
+-- whatever networking and bot inference already consumed.
+--
+-- Akagi always enforces on top of whatever this script returns:
+--   * a minimum delay (config `min_delay_ms`) — clicks issued before
+--     Mahjong Soul finishes rendering buttons/tiles are silently lost
+--   * the dealing-animation wait on the dealer's opening discard
+--   * the server time budget — autoplay can never run into an
+--     auto-discard; the extra time bank is only spent when this script
+--     returns allow_bank = true
+--
+-- Context passed to decide_delay:
+--   ctx.action          "dahai" | "reach" | "chi" | "pon" | "daiminkan"
+--                       | "ankan" | "kakan" | "hora" | "ryukyoku" | "kita"
+--                       | "none"  (declining a call window)
+--   ctx.tsumogiri       the discard is the just-drawn tile
+--   ctx.post_call       discard following our own chi/pon
+--   ctx.tile_class      "honor" | "terminal" | "middle" for a discard
+--   ctx.first_action    first action of the kyoku
+--   ctx.dealer_opening  dealer's 14-tile opening discard
+--   ctx.can_riichi      riichi is declarable this turn
+--   ctx.is_kan          the action is a kan declaration
+--   ctx.in_riichi       we are in accepted riichi
+--   ctx.opponent_riichi an opponent has declared riichi
+--   ctx.junme           our discard number this kyoku (1 = first)
+--   ctx.legal_count     number of legal actions
+--   ctx.top_prob        bot's top candidate probability (0..1), or nil
+--   ctx.second_prob     second candidate probability, or nil
+--   ctx.margin          top_prob - second_prob, or nil
+--   ctx.budget          { fixed_ms, add_ms, elapsed_ms } or nil
+--   ctx.rng()           uniform random in [0, 1)
+--   ctx.lognormal(mu, sigma)  log-normal sample in SECONDS
+--
+-- Every number below is calibrated against ranked Throne-room game
+-- records (30 games, ~21,500 decisions, think times on the server
+-- clock). Real discards are a MIXTURE: a "routine" cluster (~1s — the
+-- tile was already decided) and a genuine think whose length depends on
+-- what is being discarded, how deep the hand is, and whether someone
+-- has declared riichi.
+
+-- Probability that a discard is routine (no real thought). Measured
+-- fast-fraction (<1.2s): lone honors get flicked away, middle tiles
+-- almost never do.
+local ROUTINE = {
+  tedashi   = { honor = 0.21, terminal = 0.10, middle = 0.04 },
+  tsumogiri = { honor = 0.31, terminal = 0.26, middle = 0.20 },
+}
+
+-- Log-normal { mu, sigma } (ln-seconds) of the *genuine-think* cluster.
+local THINK = {
+  tedashi   = { honor = { 0.77, 0.50 }, terminal = { 0.83, 0.50 },
+                middle = { 1.01, 0.55 }, default = { 0.87, 0.55 } },
+  tsumogiri = { honor = { 0.54, 0.45 }, terminal = { 0.57, 0.45 },
+                middle = { 0.63, 0.48 }, default = { 0.57, 0.47 } },
+}
+
+-- Non-discard decisions (single log-normal fits them well).
+local OTHER = {
+  reach           = { 1.10, 0.55 }, -- riichi declaration   (median ~3.0s)
+  claim           = { 0.26, 0.57 }, -- call window incl pass (median ~1.3s)
+  post_call_dahai = { 0.52, 0.42 }, -- discard after own call (median ~1.7s)
+  hora            = { 0.15, 0.50 }, -- ron / tsumo           (median ~1.2s)
+  in_riichi       = { 0.35, 0.30 }, -- skip while in riichi  (median ~1.4s)
+}
+
+local function routine_probability(ctx, giri)
+  local p = (ROUTINE[giri] or {})[ctx.tile_class or "middle"] or 0.05
+  -- The bot's confidence is a good proxy for "this tile was already
+  -- decided": a dominant top candidate doubles the routine odds, a
+  -- contested one collapses them.
+  if ctx.top_prob ~= nil then
+    if ctx.top_prob > 0.97 then p = p * 1.8 end
+    if ctx.top_prob < 0.60 then p = p * 0.3 end
+  end
+  -- A riichi on the table means every discard gets a safety read.
+  if ctx.opponent_riichi then p = p * 0.4 end
+  if p > 0.6 then p = 0.6 end
+  return p
+end
+
+local function discard_think(ctx)
+  local giri = ctx.tsumogiri and "tsumogiri" or "tedashi"
+  if ctx.rng() < routine_probability(ctx, giri) then
+    -- Routine flick: tight cluster around one second.
+    return ctx.lognormal(0.0, 0.18)
+  end
+  local params = THINK[giri][ctx.tile_class or "default"]
+                 or THINK[giri].default
+  local think = ctx.lognormal(params[1], params[2])
+  -- Deeper hands are read longer — but only tedashi shows this
+  -- (measured tsumogiri medians are junme-flat).
+  if giri == "tedashi" and ctx.junme ~= nil and ctx.junme > 0 then
+    think = think * (1.0 + 0.012 * math.min(ctx.junme, 15))
+  end
+  -- Defence reads against a live riichi: +16% tedashi, +25% tsumogiri,
+  -- with a fatter tail.
+  if ctx.opponent_riichi then
+    think = think * (giri == "tedashi" and 1.16 or 1.25)
+    if ctx.rng() < 0.06 then think = think + ctx.lognormal(0.9, 0.5) end
+  end
+  return think
+end
+
+function decide_delay(ctx)
+  local think
+  local allow_bank = false
+
+  if ctx.in_riichi then
+    -- Only claim windows reach this point in riichi (Majsoul auto-
+    -- discards our draws). Measured: still ~1.4s — humans do glance.
+    think = ctx.lognormal(OTHER.in_riichi[1], OTHER.in_riichi[2])
+    return { delay_ms = think * 1000 }
+  end
+
+  if ctx.action == "dahai" then
+    if ctx.post_call then
+      think = ctx.lognormal(OTHER.post_call_dahai[1], OTHER.post_call_dahai[2])
+    else
+      think = discard_think(ctx)
+    end
+  elseif ctx.action == "reach" then
+    think = ctx.lognormal(OTHER.reach[1], OTHER.reach[2])
+  elseif ctx.action == "hora" then
+    think = ctx.lognormal(OTHER.hora[1], OTHER.hora[2])
+  elseif ctx.action == "ankan" or ctx.action == "kakan" then
+    -- Own-turn kan declaration thinks like a middle-tile tedashi.
+    think = ctx.lognormal(THINK.tedashi.middle[1], THINK.tedashi.middle[2])
+  else
+    -- Claim-window responses: chi/pon/daiminkan/skip/kyuushu.
+    think = ctx.lognormal(OTHER.claim[1], OTHER.claim[2])
+  end
+
+  -- First action of a kyoku: the fresh hand gets surveyed.
+  if ctx.first_action then
+    think = think + 0.5 + 0.8 * ctx.rng()
+  end
+
+  -- A declarable riichi makes this discard a real decision even when
+  -- the bot ends up not declaring.
+  if ctx.can_riichi and ctx.action == "dahai" then
+    think = think + 0.4 + 0.8 * ctx.rng()
+  end
+
+  -- Genuinely close call (bot's top two nearly tied): think visibly
+  -- longer, and spending the time bank on it is exactly what a human
+  -- would do.
+  if ctx.margin ~= nil and ctx.margin < 0.02 then
+    think = think + ctx.lognormal(0.6, 0.5)
+    allow_bank = true
+  end
+
+  -- Occasional genuine tank — recounting discards, weighing a fold.
+  if ctx.rng() < 0.02 then
+    think = think + 2.0 + ctx.lognormal(0.8, 0.6)
+    allow_bank = true
+  end
+
+  -- Budget shaping. The server grants fixed_ms per decision plus a
+  -- bank (add_ms) that REFILLS EVERY KYOKU — measured Throne players
+  -- dip into it on ~7% of draws, so exceeding the free window is
+  -- normal play, not an emergency. But when the bank is nearly dry,
+  -- humans wrap up instead of risking the auto-discard timer.
+  if ctx.budget ~= nil then
+    local free_s = ctx.budget.fixed_ms / 1000 - 1.0
+    local bank_s = ctx.budget.add_ms / 1000
+    if think > free_s then
+      if bank_s >= 3.0 then
+        allow_bank = true -- natural dip; Akagi bounds how much is spent
+      else
+        think = free_s    -- nearly broke: finish the thought quickly
+      end
+    end
+  end
+
+  return { delay_ms = think * 1000, allow_bank = allow_bank }
+end

--- a/assets/delay_default_superseded/2e5d892.lua
+++ b/assets/delay_default_superseded/2e5d892.lua
@@ -1,0 +1,200 @@
+-- Akagi autoplay delay model.
+--
+-- Akagi generated this file next to your config.toml. Edit it freely —
+-- it hot-reloads every time you save. Delete it to get a fresh copy of
+-- the default on the next start. If the script ever errors, Akagi keeps
+-- playing with its built-in model and logs the reason once.
+--
+-- decide_delay(ctx) returns { delay_ms = <number>, allow_bank = <bool> }.
+--
+-- delay_ms is the target TOTAL thinking time for the decision window —
+-- the time the SERVER observes between offering the decision and
+-- receiving the action. It is NOT a sleep length: Akagi subtracts
+-- whatever networking and bot inference already consumed.
+--
+-- Akagi always enforces on top of whatever this script returns:
+--   * a minimum delay (config `min_delay_ms`; the higher
+--     `min_button_delay_ms` for chi/pon/kan/ron/skip/riichi buttons,
+--     which render later than hand tiles) — clicks issued before the
+--     UI exists are silently lost
+--   * the dealing-animation wait on the dealer's opening discard
+--   * the server time budget — autoplay can never run into an
+--     auto-discard; the extra time bank is only spent when this script
+--     returns allow_bank = true
+--
+-- Context passed to decide_delay:
+--   ctx.action          "dahai" | "reach" | "chi" | "pon" | "daiminkan"
+--                       | "ankan" | "kakan" | "hora" | "ryukyoku" | "kita"
+--                       | "none"  (declining a call window)
+--   ctx.tsumogiri       the discard is the just-drawn tile
+--   ctx.post_call       discard following our own chi/pon
+--   ctx.tile_class      "honor" | "terminal" | "middle" for a discard
+--   ctx.first_action    first action of the kyoku
+--   ctx.dealer_opening  dealer's 14-tile opening discard
+--   ctx.can_riichi      riichi is declarable this turn
+--   ctx.is_kan          the action is a kan declaration
+--   ctx.in_riichi       we are in accepted riichi
+--   ctx.opponent_riichi an opponent has declared riichi
+--   ctx.junme           our discard number this kyoku (1 = first)
+--   ctx.legal_count     number of legal actions
+--   ctx.top_prob        bot's top candidate probability (0..1), or nil
+--   ctx.second_prob     second candidate probability, or nil
+--   ctx.margin          top_prob - second_prob, or nil
+--   ctx.budget          { fixed_ms, add_ms, elapsed_ms } or nil
+--   ctx.rng()           uniform random in [0, 1)
+--   ctx.lognormal(mu, sigma)  log-normal sample in SECONDS
+--
+-- Every number below is calibrated against ranked Throne-room game
+-- records (30 games, ~21,500 decisions, think times on the server
+-- clock). Real discards are a MIXTURE: a "routine" cluster (~1s — the
+-- tile was already decided) and a genuine think whose length depends on
+-- what is being discarded, how deep the hand is, and whether someone
+-- has declared riichi.
+
+-- Probability that a discard is routine (no real thought). These are
+-- MIXTURE WEIGHTS, not the measured fast-fractions directly: the
+-- routine cluster only puts ~84% of its own mass under 1.2s and the
+-- genuine-think cluster contributes sub-1.2s mass too, so each weight
+-- w solves  w*0.844 + (1-w)*P_think(<1.2s) = measured fast-fraction
+-- (tedashi h/t/m: 21%/10%/4%; tsumogiri h/t/m: 31%/26%/20%). Tedashi
+-- terminal/middle round to zero — their think cluster alone already
+-- covers the measured fast mass.
+local ROUTINE = {
+  tedashi   = { honor = 0.12, terminal = 0.00, middle = 0.00 },
+  tsumogiri = { honor = 0.15, terminal = 0.10, middle = 0.04 },
+}
+
+-- Log-normal { mu, sigma } (ln-seconds) of the *genuine-think* cluster.
+local THINK = {
+  tedashi   = { honor = { 0.77, 0.50 }, terminal = { 0.83, 0.50 },
+                middle = { 1.01, 0.55 }, default = { 0.87, 0.55 } },
+  tsumogiri = { honor = { 0.54, 0.45 }, terminal = { 0.57, 0.45 },
+                middle = { 0.63, 0.48 }, default = { 0.57, 0.47 } },
+}
+
+-- Non-discard decisions (single log-normal fits them well).
+local OTHER = {
+  reach           = { 1.10, 0.55 }, -- riichi declaration   (median ~3.0s)
+  claim           = { 0.26, 0.57 }, -- call window incl pass (median ~1.3s)
+  post_call_dahai = { 0.52, 0.42 }, -- discard after own call (median ~1.7s)
+  hora            = { 0.15, 0.50 }, -- ron / tsumo           (median ~1.2s)
+  in_riichi       = { 0.35, 0.30 }, -- skip while in riichi  (median ~1.4s)
+}
+
+local function routine_probability(ctx, giri)
+  local p = (ROUTINE[giri] or {})[ctx.tile_class or "middle"] or 0.04
+  -- The bot's confidence is a good proxy for "this tile was already
+  -- decided": a dominant top candidate doubles the routine odds.
+  if ctx.top_prob ~= nil then
+    if ctx.top_prob > 0.97 then p = p * 1.8 end
+    -- Disabled: some bots report flat policy probabilities (top well
+    -- under 0.60 on nearly every decision), which turned this into a
+    -- permanent slowdown rather than a "contested call" signal.
+    -- if ctx.top_prob < 0.60 then p = p * 0.3 end
+  end
+  -- A riichi on the table means every discard gets a safety read.
+  if ctx.opponent_riichi then p = p * 0.4 end
+  if p > 0.6 then p = 0.6 end
+  return p
+end
+
+local function discard_think(ctx)
+  local giri = ctx.tsumogiri and "tsumogiri" or "tedashi"
+  if ctx.rng() < routine_probability(ctx, giri) then
+    -- Routine flick: tight cluster around one second.
+    return ctx.lognormal(0.0, 0.18)
+  end
+  local params = THINK[giri][ctx.tile_class or "default"]
+                 or THINK[giri].default
+  local think = ctx.lognormal(params[1], params[2])
+  -- Deeper hands are read longer — but only tedashi shows this
+  -- (measured tsumogiri medians are junme-flat).
+  if giri == "tedashi" and ctx.junme ~= nil and ctx.junme > 0 then
+    think = think * (1.0 + 0.012 * math.min(ctx.junme, 15))
+  end
+  -- Defence reads against a live riichi: +16% tedashi, +25% tsumogiri,
+  -- with a fatter tail.
+  if ctx.opponent_riichi then
+    think = think * (giri == "tedashi" and 1.16 or 1.25)
+    if ctx.rng() < 0.06 then think = think + ctx.lognormal(0.9, 0.5) end
+  end
+  return think
+end
+
+function decide_delay(ctx)
+  local think
+  local allow_bank = false
+
+  if ctx.in_riichi then
+    -- Only claim windows reach this point in riichi (Majsoul auto-
+    -- discards our draws). Measured: still ~1.4s — humans do glance.
+    think = ctx.lognormal(OTHER.in_riichi[1], OTHER.in_riichi[2])
+    return { delay_ms = think * 1000 }
+  end
+
+  if ctx.action == "dahai" then
+    if ctx.post_call then
+      think = ctx.lognormal(OTHER.post_call_dahai[1], OTHER.post_call_dahai[2])
+    else
+      think = discard_think(ctx)
+    end
+  elseif ctx.action == "reach" then
+    think = ctx.lognormal(OTHER.reach[1], OTHER.reach[2])
+  elseif ctx.action == "hora" then
+    think = ctx.lognormal(OTHER.hora[1], OTHER.hora[2])
+  elseif ctx.action == "ankan" or ctx.action == "kakan" then
+    -- Own-turn kan declaration thinks like a middle-tile tedashi.
+    think = ctx.lognormal(THINK.tedashi.middle[1], THINK.tedashi.middle[2])
+  else
+    -- Claim-window responses: chi/pon/daiminkan/skip/kyuushu.
+    think = ctx.lognormal(OTHER.claim[1], OTHER.claim[2])
+  end
+
+  -- First action of a kyoku: the fresh hand gets surveyed.
+  if ctx.first_action then
+    think = think + 0.5 + 0.8 * ctx.rng()
+  end
+
+  -- A declarable riichi makes this discard a real decision even when
+  -- the bot ends up not declaring.
+  if ctx.can_riichi and ctx.action == "dahai" then
+    think = think + 0.4 + 0.8 * ctx.rng()
+  end
+
+  -- Genuinely close call (bot's top two nearly tied): think visibly
+  -- longer, and spending the time bank on it is exactly what a human
+  -- would do.
+  if ctx.margin ~= nil and ctx.margin < 0.02 then
+    think = think + ctx.lognormal(0.6, 0.5)
+    allow_bank = true
+  end
+
+  -- Occasional genuine tank — recounting discards, weighing a fold.
+  if ctx.rng() < 0.02 then
+    think = think + 2.0 + ctx.lognormal(0.8, 0.6)
+    allow_bank = true
+  end
+
+  -- Budget shaping. The server grants fixed_ms per decision plus a
+  -- bank (add_ms) that REFILLS EVERY KYOKU — measured Throne players
+  -- dip into it on ~7% of draws, so exceeding the free window is
+  -- normal play, not an emergency. But when the bank is nearly dry,
+  -- humans wrap up instead of risking the auto-discard timer.
+  if ctx.budget ~= nil then
+    -- Floored at 0: a sub-second fixed_ms must degrade to "answer at
+    -- the enforced minimum", not to a negative delay_ms that Akagi
+    -- would reject (which would silently disable this script for the
+    -- whole room).
+    local free_s = math.max(ctx.budget.fixed_ms / 1000 - 1.0, 0)
+    local bank_s = ctx.budget.add_ms / 1000
+    if think > free_s then
+      if bank_s >= 3.0 then
+        allow_bank = true -- natural dip; Akagi bounds how much is spent
+      else
+        think = free_s    -- nearly broke: finish the thought quickly
+      end
+    end
+  end
+
+  return { delay_ms = think * 1000, allow_bank = allow_bank }
+end

--- a/assets/delay_default_superseded/cb1f146.lua
+++ b/assets/delay_default_superseded/cb1f146.lua
@@ -1,0 +1,189 @@
+-- Akagi autoplay delay model.
+--
+-- Akagi generated this file next to your config.toml. Edit it freely —
+-- it hot-reloads every time you save. Delete it to get a fresh copy of
+-- the default on the next start. If the script ever errors, Akagi keeps
+-- playing with its built-in model and logs the reason once.
+--
+-- decide_delay(ctx) returns { delay_ms = <number>, allow_bank = <bool> }.
+--
+-- delay_ms is the target TOTAL thinking time for the decision window —
+-- the time the SERVER observes between offering the decision and
+-- receiving the action. It is NOT a sleep length: Akagi subtracts
+-- whatever networking and bot inference already consumed.
+--
+-- Akagi always enforces on top of whatever this script returns:
+--   * a minimum delay (config `min_delay_ms`; the higher
+--     `min_button_delay_ms` for chi/pon/kan/ron/skip/riichi buttons,
+--     which render later than hand tiles) — clicks issued before the
+--     UI exists are silently lost
+--   * the dealing-animation wait on the dealer's opening discard
+--   * the server time budget — autoplay can never run into an
+--     auto-discard; the extra time bank is only spent when this script
+--     returns allow_bank = true
+--
+-- Context passed to decide_delay:
+--   ctx.action          "dahai" | "reach" | "chi" | "pon" | "daiminkan"
+--                       | "ankan" | "kakan" | "hora" | "ryukyoku" | "kita"
+--                       | "none"  (declining a call window)
+--   ctx.tsumogiri       the discard is the just-drawn tile
+--   ctx.post_call       discard following our own chi/pon
+--   ctx.tile_class      "honor" | "terminal" | "middle" for a discard
+--   ctx.first_action    first action of the kyoku
+--   ctx.dealer_opening  dealer's 14-tile opening discard
+--   ctx.can_riichi      riichi is declarable this turn
+--   ctx.is_kan          the action is a kan declaration
+--   ctx.in_riichi       we are in accepted riichi
+--   ctx.opponent_riichi an opponent has declared riichi
+--   ctx.junme           our discard number this kyoku (1 = first)
+--   ctx.legal_count     number of legal actions
+--   ctx.top_prob        bot's top candidate probability (0..1), or nil
+--   ctx.second_prob     second candidate probability, or nil
+--   ctx.margin          top_prob - second_prob, or nil
+--   ctx.budget          { fixed_ms, add_ms, elapsed_ms } or nil
+--   ctx.rng()           uniform random in [0, 1)
+--   ctx.lognormal(mu, sigma)  log-normal sample in SECONDS
+--
+-- Every number below is calibrated against ranked Throne-room game
+-- records (30 games, ~21,500 decisions, think times on the server
+-- clock). Real discards are a MIXTURE: a "routine" cluster (~1s — the
+-- tile was already decided) and a genuine think whose length depends on
+-- what is being discarded, how deep the hand is, and whether someone
+-- has declared riichi.
+
+-- Probability that a discard is routine (no real thought). Measured
+-- fast-fraction (<1.2s): lone honors get flicked away, middle tiles
+-- almost never do.
+local ROUTINE = {
+  tedashi   = { honor = 0.21, terminal = 0.10, middle = 0.04 },
+  tsumogiri = { honor = 0.31, terminal = 0.26, middle = 0.20 },
+}
+
+-- Log-normal { mu, sigma } (ln-seconds) of the *genuine-think* cluster.
+local THINK = {
+  tedashi   = { honor = { 0.77, 0.50 }, terminal = { 0.83, 0.50 },
+                middle = { 1.01, 0.55 }, default = { 0.87, 0.55 } },
+  tsumogiri = { honor = { 0.54, 0.45 }, terminal = { 0.57, 0.45 },
+                middle = { 0.63, 0.48 }, default = { 0.57, 0.47 } },
+}
+
+-- Non-discard decisions (single log-normal fits them well).
+local OTHER = {
+  reach           = { 1.10, 0.55 }, -- riichi declaration   (median ~3.0s)
+  claim           = { 0.26, 0.57 }, -- call window incl pass (median ~1.3s)
+  post_call_dahai = { 0.52, 0.42 }, -- discard after own call (median ~1.7s)
+  hora            = { 0.15, 0.50 }, -- ron / tsumo           (median ~1.2s)
+  in_riichi       = { 0.35, 0.30 }, -- skip while in riichi  (median ~1.4s)
+}
+
+local function routine_probability(ctx, giri)
+  local p = (ROUTINE[giri] or {})[ctx.tile_class or "middle"] or 0.05
+  -- The bot's confidence is a good proxy for "this tile was already
+  -- decided": a dominant top candidate doubles the routine odds, a
+  -- contested one collapses them.
+  if ctx.top_prob ~= nil then
+    if ctx.top_prob > 0.97 then p = p * 1.8 end
+    if ctx.top_prob < 0.60 then p = p * 0.3 end
+  end
+  -- A riichi on the table means every discard gets a safety read.
+  if ctx.opponent_riichi then p = p * 0.4 end
+  if p > 0.6 then p = 0.6 end
+  return p
+end
+
+local function discard_think(ctx)
+  local giri = ctx.tsumogiri and "tsumogiri" or "tedashi"
+  if ctx.rng() < routine_probability(ctx, giri) then
+    -- Routine flick: tight cluster around one second.
+    return ctx.lognormal(0.0, 0.18)
+  end
+  local params = THINK[giri][ctx.tile_class or "default"]
+                 or THINK[giri].default
+  local think = ctx.lognormal(params[1], params[2])
+  -- Deeper hands are read longer — but only tedashi shows this
+  -- (measured tsumogiri medians are junme-flat).
+  if giri == "tedashi" and ctx.junme ~= nil and ctx.junme > 0 then
+    think = think * (1.0 + 0.012 * math.min(ctx.junme, 15))
+  end
+  -- Defence reads against a live riichi: +16% tedashi, +25% tsumogiri,
+  -- with a fatter tail.
+  if ctx.opponent_riichi then
+    think = think * (giri == "tedashi" and 1.16 or 1.25)
+    if ctx.rng() < 0.06 then think = think + ctx.lognormal(0.9, 0.5) end
+  end
+  return think
+end
+
+function decide_delay(ctx)
+  local think
+  local allow_bank = false
+
+  if ctx.in_riichi then
+    -- Only claim windows reach this point in riichi (Majsoul auto-
+    -- discards our draws). Measured: still ~1.4s — humans do glance.
+    think = ctx.lognormal(OTHER.in_riichi[1], OTHER.in_riichi[2])
+    return { delay_ms = think * 1000 }
+  end
+
+  if ctx.action == "dahai" then
+    if ctx.post_call then
+      think = ctx.lognormal(OTHER.post_call_dahai[1], OTHER.post_call_dahai[2])
+    else
+      think = discard_think(ctx)
+    end
+  elseif ctx.action == "reach" then
+    think = ctx.lognormal(OTHER.reach[1], OTHER.reach[2])
+  elseif ctx.action == "hora" then
+    think = ctx.lognormal(OTHER.hora[1], OTHER.hora[2])
+  elseif ctx.action == "ankan" or ctx.action == "kakan" then
+    -- Own-turn kan declaration thinks like a middle-tile tedashi.
+    think = ctx.lognormal(THINK.tedashi.middle[1], THINK.tedashi.middle[2])
+  else
+    -- Claim-window responses: chi/pon/daiminkan/skip/kyuushu.
+    think = ctx.lognormal(OTHER.claim[1], OTHER.claim[2])
+  end
+
+  -- First action of a kyoku: the fresh hand gets surveyed.
+  if ctx.first_action then
+    think = think + 0.5 + 0.8 * ctx.rng()
+  end
+
+  -- A declarable riichi makes this discard a real decision even when
+  -- the bot ends up not declaring.
+  if ctx.can_riichi and ctx.action == "dahai" then
+    think = think + 0.4 + 0.8 * ctx.rng()
+  end
+
+  -- Genuinely close call (bot's top two nearly tied): think visibly
+  -- longer, and spending the time bank on it is exactly what a human
+  -- would do.
+  if ctx.margin ~= nil and ctx.margin < 0.02 then
+    think = think + ctx.lognormal(0.6, 0.5)
+    allow_bank = true
+  end
+
+  -- Occasional genuine tank — recounting discards, weighing a fold.
+  if ctx.rng() < 0.02 then
+    think = think + 2.0 + ctx.lognormal(0.8, 0.6)
+    allow_bank = true
+  end
+
+  -- Budget shaping. The server grants fixed_ms per decision plus a
+  -- bank (add_ms) that REFILLS EVERY KYOKU — measured Throne players
+  -- dip into it on ~7% of draws, so exceeding the free window is
+  -- normal play, not an emergency. But when the bank is nearly dry,
+  -- humans wrap up instead of risking the auto-discard timer.
+  if ctx.budget ~= nil then
+    local free_s = ctx.budget.fixed_ms / 1000 - 1.0
+    local bank_s = ctx.budget.add_ms / 1000
+    if think > free_s then
+      if bank_s >= 3.0 then
+        allow_bank = true -- natural dip; Akagi bounds how much is spent
+      else
+        think = free_s    -- nearly broke: finish the thought quickly
+      end
+    end
+  end
+
+  return { delay_ms = think * 1000, allow_bank = allow_bank }
+end

--- a/assets/delay_default_superseded/f1f2842.lua
+++ b/assets/delay_default_superseded/f1f2842.lua
@@ -1,0 +1,198 @@
+-- Akagi autoplay delay model.
+--
+-- Akagi generated this file next to your config.toml. Edit it freely —
+-- it hot-reloads every time you save. Delete it to get a fresh copy of
+-- the default on the next start. If the script ever errors, Akagi keeps
+-- playing with its built-in model and logs the reason once.
+--
+-- decide_delay(ctx) returns { delay_ms = <number>, allow_bank = <bool> }.
+--
+-- delay_ms is the target TOTAL thinking time for the decision window —
+-- the time the SERVER observes between offering the decision and
+-- receiving the action. It is NOT a sleep length: Akagi subtracts
+-- whatever networking and bot inference already consumed.
+--
+-- Akagi always enforces on top of whatever this script returns:
+--   * a minimum delay (config `min_delay_ms`; the higher
+--     `min_button_delay_ms` for chi/pon/kan/ron/skip/riichi buttons,
+--     which render later than hand tiles) — clicks issued before the
+--     UI exists are silently lost
+--   * the dealing-animation wait on the dealer's opening discard
+--   * the server time budget — autoplay can never run into an
+--     auto-discard; the extra time bank is only spent when this script
+--     returns allow_bank = true
+--
+-- Context passed to decide_delay:
+--   ctx.action          "dahai" | "reach" | "chi" | "pon" | "daiminkan"
+--                       | "ankan" | "kakan" | "hora" | "ryukyoku" | "kita"
+--                       | "none"  (declining a call window)
+--   ctx.tsumogiri       the discard is the just-drawn tile
+--   ctx.post_call       discard following our own chi/pon
+--   ctx.tile_class      "honor" | "terminal" | "middle" for a discard
+--   ctx.first_action    first action of the kyoku
+--   ctx.dealer_opening  dealer's 14-tile opening discard
+--   ctx.can_riichi      riichi is declarable this turn
+--   ctx.is_kan          the action is a kan declaration
+--   ctx.in_riichi       we are in accepted riichi
+--   ctx.opponent_riichi an opponent has declared riichi
+--   ctx.junme           our discard number this kyoku (1 = first)
+--   ctx.legal_count     number of legal actions
+--   ctx.top_prob        bot's top candidate probability (0..1), or nil
+--   ctx.second_prob     second candidate probability, or nil
+--   ctx.margin          top_prob - second_prob, or nil
+--   ctx.budget          { fixed_ms, add_ms, elapsed_ms } or nil
+--   ctx.rng()           uniform random in [0, 1)
+--   ctx.lognormal(mu, sigma)  log-normal sample in SECONDS
+--
+-- Every number below is calibrated against ranked Throne-room game
+-- records (30 games, ~21,500 decisions, think times on the server
+-- clock). Real discards are a MIXTURE: a "routine" cluster (~1s — the
+-- tile was already decided) and a genuine think whose length depends on
+-- what is being discarded, how deep the hand is, and whether someone
+-- has declared riichi.
+
+-- Probability that a discard is routine (no real thought). These are
+-- MIXTURE WEIGHTS, not the measured fast-fractions directly: the
+-- routine cluster only puts ~84% of its own mass under 1.2s and the
+-- genuine-think cluster contributes sub-1.2s mass too, so each weight
+-- w solves  w*0.844 + (1-w)*P_think(<1.2s) = measured fast-fraction
+-- (tedashi h/t/m: 21%/10%/4%; tsumogiri h/t/m: 31%/26%/20%). Tedashi
+-- terminal/middle round to zero — their think cluster alone already
+-- covers the measured fast mass.
+local ROUTINE = {
+  tedashi   = { honor = 0.12, terminal = 0.00, middle = 0.00 },
+  tsumogiri = { honor = 0.15, terminal = 0.10, middle = 0.04 },
+}
+
+-- Log-normal { mu, sigma } (ln-seconds) of the *genuine-think* cluster.
+local THINK = {
+  tedashi   = { honor = { 0.77, 0.50 }, terminal = { 0.83, 0.50 },
+                middle = { 1.01, 0.55 }, default = { 0.87, 0.55 } },
+  tsumogiri = { honor = { 0.54, 0.45 }, terminal = { 0.57, 0.45 },
+                middle = { 0.63, 0.48 }, default = { 0.57, 0.47 } },
+}
+
+-- Non-discard decisions (single log-normal fits them well).
+local OTHER = {
+  reach           = { 1.10, 0.55 }, -- riichi declaration   (median ~3.0s)
+  claim           = { 0.26, 0.57 }, -- call window incl pass (median ~1.3s)
+  post_call_dahai = { 0.52, 0.42 }, -- discard after own call (median ~1.7s)
+  hora            = { 0.15, 0.50 }, -- ron / tsumo           (median ~1.2s)
+  in_riichi       = { 0.35, 0.30 }, -- skip while in riichi  (median ~1.4s)
+}
+
+local function routine_probability(ctx, giri)
+  local p = (ROUTINE[giri] or {})[ctx.tile_class or "middle"] or 0.04
+  -- The bot's confidence is a good proxy for "this tile was already
+  -- decided": a dominant top candidate doubles the routine odds, a
+  -- contested one collapses them.
+  if ctx.top_prob ~= nil then
+    if ctx.top_prob > 0.97 then p = p * 1.8 end
+    if ctx.top_prob < 0.60 then p = p * 0.3 end
+  end
+  -- A riichi on the table means every discard gets a safety read.
+  if ctx.opponent_riichi then p = p * 0.4 end
+  if p > 0.6 then p = 0.6 end
+  return p
+end
+
+local function discard_think(ctx)
+  local giri = ctx.tsumogiri and "tsumogiri" or "tedashi"
+  if ctx.rng() < routine_probability(ctx, giri) then
+    -- Routine flick: tight cluster around one second.
+    return ctx.lognormal(0.0, 0.18)
+  end
+  local params = THINK[giri][ctx.tile_class or "default"]
+                 or THINK[giri].default
+  local think = ctx.lognormal(params[1], params[2])
+  -- Deeper hands are read longer — but only tedashi shows this
+  -- (measured tsumogiri medians are junme-flat).
+  if giri == "tedashi" and ctx.junme ~= nil and ctx.junme > 0 then
+    think = think * (1.0 + 0.012 * math.min(ctx.junme, 15))
+  end
+  -- Defence reads against a live riichi: +16% tedashi, +25% tsumogiri,
+  -- with a fatter tail.
+  if ctx.opponent_riichi then
+    think = think * (giri == "tedashi" and 1.16 or 1.25)
+    if ctx.rng() < 0.06 then think = think + ctx.lognormal(0.9, 0.5) end
+  end
+  return think
+end
+
+function decide_delay(ctx)
+  local think
+  local allow_bank = false
+
+  if ctx.in_riichi then
+    -- Only claim windows reach this point in riichi (Majsoul auto-
+    -- discards our draws). Measured: still ~1.4s — humans do glance.
+    think = ctx.lognormal(OTHER.in_riichi[1], OTHER.in_riichi[2])
+    return { delay_ms = think * 1000 }
+  end
+
+  if ctx.action == "dahai" then
+    if ctx.post_call then
+      think = ctx.lognormal(OTHER.post_call_dahai[1], OTHER.post_call_dahai[2])
+    else
+      think = discard_think(ctx)
+    end
+  elseif ctx.action == "reach" then
+    think = ctx.lognormal(OTHER.reach[1], OTHER.reach[2])
+  elseif ctx.action == "hora" then
+    think = ctx.lognormal(OTHER.hora[1], OTHER.hora[2])
+  elseif ctx.action == "ankan" or ctx.action == "kakan" then
+    -- Own-turn kan declaration thinks like a middle-tile tedashi.
+    think = ctx.lognormal(THINK.tedashi.middle[1], THINK.tedashi.middle[2])
+  else
+    -- Claim-window responses: chi/pon/daiminkan/skip/kyuushu.
+    think = ctx.lognormal(OTHER.claim[1], OTHER.claim[2])
+  end
+
+  -- First action of a kyoku: the fresh hand gets surveyed.
+  if ctx.first_action then
+    think = think + 0.5 + 0.8 * ctx.rng()
+  end
+
+  -- A declarable riichi makes this discard a real decision even when
+  -- the bot ends up not declaring.
+  if ctx.can_riichi and ctx.action == "dahai" then
+    think = think + 0.4 + 0.8 * ctx.rng()
+  end
+
+  -- Genuinely close call (bot's top two nearly tied): think visibly
+  -- longer, and spending the time bank on it is exactly what a human
+  -- would do.
+  if ctx.margin ~= nil and ctx.margin < 0.02 then
+    think = think + ctx.lognormal(0.6, 0.5)
+    allow_bank = true
+  end
+
+  -- Occasional genuine tank — recounting discards, weighing a fold.
+  if ctx.rng() < 0.02 then
+    think = think + 2.0 + ctx.lognormal(0.8, 0.6)
+    allow_bank = true
+  end
+
+  -- Budget shaping. The server grants fixed_ms per decision plus a
+  -- bank (add_ms) that REFILLS EVERY KYOKU — measured Throne players
+  -- dip into it on ~7% of draws, so exceeding the free window is
+  -- normal play, not an emergency. But when the bank is nearly dry,
+  -- humans wrap up instead of risking the auto-discard timer.
+  if ctx.budget ~= nil then
+    -- Floored at 0: a sub-second fixed_ms must degrade to "answer at
+    -- the enforced minimum", not to a negative delay_ms that Akagi
+    -- would reject (which would silently disable this script for the
+    -- whole room).
+    local free_s = math.max(ctx.budget.fixed_ms / 1000 - 1.0, 0)
+    local bank_s = ctx.budget.add_ms / 1000
+    if think > free_s then
+      if bank_s >= 3.0 then
+        allow_bank = true -- natural dip; Akagi bounds how much is spent
+      else
+        think = free_s    -- nearly broke: finish the thought quickly
+      end
+    end
+  end
+
+  return { delay_ms = think * 1000, allow_bank = allow_bank }
+end

--- a/assets/delay_default_superseded/f8c7cfd.lua
+++ b/assets/delay_default_superseded/f8c7cfd.lua
@@ -1,0 +1,125 @@
+-- Akagi autoplay delay model.
+--
+-- Akagi generated this file next to your config.toml. Edit it freely —
+-- it hot-reloads every time you save. Delete it to get a fresh copy of
+-- the default on the next start. If the script ever errors, Akagi keeps
+-- playing with its built-in model and logs the reason once.
+--
+-- decide_delay(ctx) returns { delay_ms = <number>, allow_bank = <bool> }.
+--
+-- delay_ms is the target TOTAL thinking time for the decision window —
+-- the time the SERVER observes between offering the decision and
+-- receiving the action. It is NOT a sleep length: Akagi subtracts
+-- whatever networking and bot inference already consumed.
+--
+-- Akagi always enforces on top of whatever this script returns:
+--   * a minimum delay (config `min_delay_ms`) — clicks issued before
+--     Mahjong Soul finishes rendering buttons/tiles are silently lost
+--   * the dealing-animation wait on the dealer's opening discard
+--   * the server time budget — autoplay can never run into an
+--     auto-discard; the extra time bank is only spent when this script
+--     returns allow_bank = true
+--
+-- Context passed to decide_delay:
+--   ctx.action        "dahai" | "reach" | "chi" | "pon" | "daiminkan"
+--                     | "ankan" | "kakan" | "hora" | "ryukyoku" | "kita"
+--                     | "none"  (declining a call window)
+--   ctx.tsumogiri     the discard is the just-drawn tile
+--   ctx.post_call     discard following our own chi/pon
+--   ctx.first_action  first action of the kyoku
+--   ctx.dealer_opening dealer's 14-tile opening discard
+--   ctx.can_riichi    riichi is declarable this turn
+--   ctx.is_kan        the action is a kan declaration
+--   ctx.in_riichi     we are in accepted riichi
+--   ctx.junme         our discard number this kyoku (1 = first)
+--   ctx.legal_count   number of legal actions
+--   ctx.top_prob      bot's top candidate probability (0..1), or nil
+--   ctx.second_prob   second candidate probability, or nil
+--   ctx.margin        top_prob - second_prob, or nil
+--   ctx.budget        { fixed_ms, add_ms, elapsed_ms } or nil
+--   ctx.rng()         uniform random in [0, 1)
+--   ctx.lognormal(mu, sigma)  log-normal sample in SECONDS
+--
+-- The base numbers below are calibrated against ranked Throne-room game
+-- records (~4100 decisions, think times measured on the server clock).
+
+-- Per-decision log-normal parameters { mu, sigma } in ln-seconds.
+-- Median think time = e^mu seconds.
+local BASE = {
+  dahai_tedashi   = { 0.90, 0.60 }, -- discard from hand      (median ~2.4s)
+  dahai_tsumogiri = { 0.62, 0.55 }, -- discard the drawn tile (median ~1.9s)
+  post_call_dahai = { 0.44, 0.35 }, -- discard after own call (median ~1.5s)
+  reach           = { 1.00, 0.45 }, -- riichi declaration     (median ~2.7s)
+  claim           = { 0.27, 0.55 }, -- call window, incl pass (median ~1.3s)
+  hora            = { 0.15, 0.50 }, -- ron / tsumo            (median ~1.2s)
+}
+
+local function base_key(ctx)
+  if ctx.action == "dahai" then
+    if ctx.post_call then return "post_call_dahai" end
+    if ctx.tsumogiri then return "dahai_tsumogiri" end
+    return "dahai_tedashi"
+  end
+  if ctx.action == "reach" then return "reach" end
+  if ctx.action == "hora" then return "hora" end
+  -- Own-turn kan declarations get tedashi-like thought; every claim
+  -- window response (chi/pon/daiminkan/skip/kyuushu) shares the fast
+  -- reaction-window distribution.
+  if ctx.action == "ankan" or ctx.action == "kakan" then
+    return "dahai_tedashi"
+  end
+  return "claim"
+end
+
+function decide_delay(ctx)
+  -- In riichi there is nothing left to decide — the only windows that
+  -- reach this script are call windows we are about to decline. Humans
+  -- answer these almost instantly (the host minimum still applies).
+  if ctx.in_riichi then
+    return { delay_ms = 700 + 500 * ctx.rng() }
+  end
+
+  local p = BASE[base_key(ctx)]
+  local think = ctx.lognormal(p[1], p[2])
+  local allow_bank = false
+
+  -- Humans slow down as the hand develops (more to read on the table):
+  -- measured ~+20% median between early and mid game.
+  if ctx.junme ~= nil and ctx.junme > 0 then
+    think = think * (1.0 + 0.015 * math.min(ctx.junme, 15))
+  end
+
+  -- First action of a kyoku: a fresh hand gets surveyed first.
+  if ctx.first_action then
+    think = think + 0.5 + 0.8 * ctx.rng()
+  end
+
+  -- A declarable riichi makes this discard a real decision, even when
+  -- the bot ends up not declaring.
+  if ctx.can_riichi and ctx.action == "dahai" then
+    think = think + 0.4 + 0.8 * ctx.rng()
+  end
+
+  -- Difficulty, from the bot's own candidate probabilities.
+  if ctx.margin ~= nil and ctx.margin < 0.02 then
+    -- Genuinely close call: think visibly longer and let Akagi spend
+    -- the time bank on it (it refills every kyoku).
+    think = think + ctx.lognormal(0.6, 0.5)
+    allow_bank = true
+  elseif ctx.margin ~= nil and ctx.margin < 0.10 then
+    think = think + ctx.lognormal(-0.2, 0.5)
+  end
+  if ctx.top_prob ~= nil and ctx.top_prob > 0.97 then
+    -- Obvious move: humans snap these.
+    think = think * 0.6
+  end
+
+  -- Occasional genuine tank — reading discards, counting payouts.
+  -- Real players' p99 think times run 7-15s.
+  if ctx.rng() < 0.03 then
+    think = think + 2.0 + ctx.lognormal(0.8, 0.6)
+    allow_bank = true
+  end
+
+  return { delay_ms = think * 1000, allow_bank = allow_bank }
+end

--- a/src/autoplay/README.md
+++ b/src/autoplay/README.md
@@ -29,7 +29,15 @@ Layers, in order:
 1. **Policy** — selected by `autoplay.delay.mode`. `lua` (default):
    `delay.lua` next to the config file, generated from
    `assets/delay_default.lua` (embedded as `script::DEFAULT_SCRIPT`) on
-   first use and hot-reloaded; the built-in model (per-decision-kind
+   first use and hot-reloaded. An existing `delay.lua` that is an
+   unmodified copy of an *older* bundled default is replaced by the
+   current one on start; user-edited scripts are never touched. This
+   works by verbatim comparison against every previously shipped
+   default, embedded from `assets/delay_default_superseded/` — **when
+   changing `assets/delay_default.lua`, copy the version being replaced
+   into that directory and add it to `script::SUPERSEDED_DEFAULT_SCRIPTS`**,
+   or existing installs will keep the old behaviour. The built-in model
+   (per-decision-kind
    log-normal + decision-type bonuses, `delay/mod.rs`) is the fallback
    when the script fails. `legacy`: the historical uniform draw — the
    distribution is forced to Uniform and the script is not consulted.

--- a/src/autoplay/delay/script.rs
+++ b/src/autoplay/delay/script.rs
@@ -45,6 +45,49 @@ pub const DEFAULT_SCRIPT: &str = include_str!(concat!(
     "/assets/delay_default.lua"
 ));
 
+/// Every bundled default shipped by an earlier version, verbatim. An
+/// existing `delay.lua` identical (modulo line endings) to one of these
+/// is an untouched auto-generated copy of an outdated default, so
+/// [`ScriptHost::ensure_default`] replaces it with [`DEFAULT_SCRIPT`];
+/// anything else is a user edit and is never touched.
+///
+/// When changing `assets/delay_default.lua`, copy the version being
+/// replaced into `assets/delay_default_superseded/<short-commit>.lua`
+/// and add it here — otherwise existing installs keep the old script.
+const SUPERSEDED_DEFAULT_SCRIPTS: &[&str] = &[
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/delay_default_superseded/f8c7cfd.lua"
+    )),
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/delay_default_superseded/1893c05.lua"
+    )),
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/delay_default_superseded/cb1f146.lua"
+    )),
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/delay_default_superseded/f1f2842.lua"
+    )),
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/delay_default_superseded/2e5d892.lua"
+    )),
+];
+
+/// Is `content` an unmodified copy of an earlier bundled default? Line
+/// endings are normalized on both sides: the file on disk or the
+/// compiled-in constant may carry CRLF depending on the checkout and
+/// platform, and a pure EOL difference is not a user edit.
+fn is_superseded_default(content: &str) -> bool {
+    let normalized = content.replace("\r\n", "\n");
+    SUPERSEDED_DEFAULT_SCRIPTS
+        .iter()
+        .any(|old| old.replace("\r\n", "\n") == normalized)
+}
+
 /// Hard sanity range for a script-provided target (10 minutes). Values
 /// outside are treated as a script bug, not clamped silently.
 const MAX_SCRIPT_DELAY_MS: f64 = 600_000.0;
@@ -311,31 +354,33 @@ pub struct ScriptHost {
     /// Default-file generation failed (read-only fs) — logged once,
     /// not retried every hand.
     generate_failed: bool,
+    /// The existing file was already checked against the superseded
+    /// defaults this session — the check reads the whole file, so it
+    /// runs once per host, not once per hand.
+    superseded_checked: bool,
 }
 
 impl ScriptHost {
-    /// Write [`DEFAULT_SCRIPT`] to `path` if no file exists there yet.
-    /// A deleted file is regenerated on the next start; a failure (e.g.
-    /// read-only install) is logged once and the built-in model runs.
+    /// Write [`DEFAULT_SCRIPT`] to `path` if no file exists there yet,
+    /// or if the existing file is an unmodified copy of an earlier
+    /// bundled default (see [`SUPERSEDED_DEFAULT_SCRIPTS`]) — without
+    /// this, installs that generated `delay.lua` on an older version
+    /// would keep its behaviour forever after an update. A deleted file
+    /// is regenerated on the next start; a failure (e.g. read-only
+    /// install) is logged once and the built-in model runs.
     pub fn ensure_default(&mut self, path: &Path) {
-        if self.generate_failed || path.exists() {
+        if self.generate_failed {
             return;
         }
-        let write = || -> std::io::Result<()> {
-            if let Some(parent) = path.parent() {
-                if !parent.as_os_str().is_empty() {
-                    std::fs::create_dir_all(parent)?;
-                }
+        if path.exists() {
+            self.refresh_superseded_default(path);
+            return;
+        }
+        match write_atomic(path, DEFAULT_SCRIPT) {
+            Ok(()) => {
+                info!("generated default delay script: {}", path.display());
+                self.superseded_checked = true; // just wrote the current one
             }
-            // Write-then-rename: a crash or full disk mid-write must not
-            // leave a truncated delay.lua that the `path.exists()` gate
-            // above would then treat as the user's file forever.
-            let tmp = path.with_extension("lua.tmp");
-            std::fs::write(&tmp, DEFAULT_SCRIPT)?;
-            std::fs::rename(&tmp, path)
-        };
-        match write() {
-            Ok(()) => info!("generated default delay script: {}", path.display()),
             Err(e) => {
                 warn!(
                     "could not generate delay script at {} — using built-in model: {e}",
@@ -343,6 +388,32 @@ impl ScriptHost {
                 );
                 self.generate_failed = true;
             }
+        }
+    }
+
+    /// Overwrite `path` with [`DEFAULT_SCRIPT`] iff its content is an
+    /// unmodified copy of an earlier bundled default. User-edited
+    /// scripts never match and are left alone.
+    fn refresh_superseded_default(&mut self, path: &Path) {
+        if self.superseded_checked {
+            return;
+        }
+        self.superseded_checked = true;
+        let Ok(existing) = std::fs::read_to_string(path) else {
+            return; // unreadable — maybe_reload logs that case
+        };
+        if existing == DEFAULT_SCRIPT || !is_superseded_default(&existing) {
+            return;
+        }
+        match write_atomic(path, DEFAULT_SCRIPT) {
+            Ok(()) => info!(
+                "delay script was an outdated bundled default — updated: {}",
+                path.display()
+            ),
+            Err(e) => warn!(
+                "could not update outdated delay script at {} — keeping it: {e}",
+                path.display()
+            ),
         }
     }
 
@@ -393,6 +464,21 @@ impl ScriptHost {
     pub fn script(&self) -> Option<&DelayScript> {
         self.script.as_ref()
     }
+}
+
+/// Write-then-rename: a crash or full disk mid-write must not leave a
+/// truncated delay.lua that the exists/superseded gates in
+/// [`ScriptHost::ensure_default`] would then treat as the user's file
+/// forever.
+fn write_atomic(path: &Path, content: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let tmp = path.with_extension("lua.tmp");
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, path)
 }
 
 #[cfg(test)]
@@ -860,6 +946,89 @@ mod tests {
                 .starts_with("-- user edit"),
             "an existing file must never be overwritten"
         );
+
+        // Same for a fresh host (no superseded_checked short-circuit):
+        // a user script simply doesn't match any old default.
+        let mut fresh = ScriptHost::default();
+        fresh.ensure_default(&path);
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .starts_with("-- user edit"),
+            "a user-edited file must survive the superseded-default check"
+        );
+    }
+
+    /// Regression (issue #231): a delay.lua auto-generated by an older
+    /// version must be replaced by the current bundled default on the
+    /// next run — updates used to leave the stale script in place until
+    /// the user deleted it by hand.
+    #[test]
+    fn outdated_bundled_default_is_refreshed() {
+        for old in SUPERSEDED_DEFAULT_SCRIPTS {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("delay.lua");
+            std::fs::write(&path, old).unwrap();
+
+            let mut host = ScriptHost::default();
+            host.ensure_default(&path);
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                DEFAULT_SCRIPT,
+                "an unmodified older default must be updated in place"
+            );
+        }
+    }
+
+    /// A pure CRLF re-encoding of an old default (Windows editors,
+    /// autocrlf checkouts) is still not a user edit.
+    #[test]
+    fn outdated_default_with_crlf_is_refreshed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delay.lua");
+        let old = SUPERSEDED_DEFAULT_SCRIPTS.last().unwrap();
+        std::fs::write(&path, old.replace('\n', "\r\n")).unwrap();
+
+        let mut host = ScriptHost::default();
+        host.ensure_default(&path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), DEFAULT_SCRIPT);
+    }
+
+    /// The check runs once per host: rewriting the old script back mid-
+    /// session is treated as a (bizarre) user edit until the next start.
+    #[test]
+    fn superseded_check_runs_once_per_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delay.lua");
+        let old = SUPERSEDED_DEFAULT_SCRIPTS.last().unwrap();
+        std::fs::write(&path, old).unwrap();
+
+        let mut host = ScriptHost::default();
+        host.ensure_default(&path);
+        std::fs::write(&path, old).unwrap();
+        host.ensure_default(&path);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap().as_str(),
+            *old,
+            "the whole-file comparison must not repeat every hand"
+        );
+    }
+
+    /// Maintenance guard: the superseded list must contain real *old*
+    /// versions — each one detected, none of them the current default
+    /// (copying the wrong file into the superseded directory would
+    /// otherwise go unnoticed).
+    #[test]
+    fn superseded_list_is_distinct_from_current_default() {
+        for old in SUPERSEDED_DEFAULT_SCRIPTS {
+            assert!(is_superseded_default(old));
+            assert_ne!(
+                old.replace("\r\n", "\n"),
+                DEFAULT_SCRIPT.replace("\r\n", "\n"),
+                "the current default must never be listed as superseded"
+            );
+        }
+        assert!(!is_superseded_default(DEFAULT_SCRIPT));
     }
 
     #[test]


### PR DESCRIPTION
Closes #231

## Problem

`ScriptHost::ensure_default` only wrote the bundled default delay script when `<config_dir>/delay.lua` did not exist. Users who auto-generated `delay.lua` on an older version therefore kept the stale script after every update — most recently missing the fix that removed the probability-based rules inflating discard timing — unless they knew to delete the file so it would be regenerated.

## Fix

`ensure_default` now also handles the case where the file exists: if its content is identical (modulo CRLF/LF) to a bundled default shipped by an **earlier** version, it is atomically replaced with the current default. Anything else is treated as a user edit and is never touched.

The comparison uses every previously shipped default embedded verbatim from the new `assets/delay_default_superseded/` directory (one file per superseded version, named by the commit that introduced it). This is self-maintaining by convention: whenever `assets/delay_default.lua` changes, the replaced version is copied into that directory and added to `script::SUPERSEDED_DEFAULT_SCRIPTS` (documented in the module README and on the constant).

Details:
- The whole-file check runs once per session (`superseded_checked`), not once per hand.
- The write path is the existing write-then-rename, factored into `write_atomic` and shared with first-time generation.
- After a refresh, the hot-reload mtime stamp changes, so `maybe_reload` picks up the new script on the same planning pass.

## Tests

- `outdated_bundled_default_is_refreshed` — each of the five superseded defaults is replaced in place (regression for #231).
- `outdated_default_with_crlf_is_refreshed` — a pure CRLF re-encoding of an old default is still refreshed.
- `superseded_check_runs_once_per_host` — the whole-file comparison doesn't repeat every hand.
- `superseded_list_is_distinct_from_current_default` — maintenance guard: every listed script is detected and none of them is the current default.
- Existing `ensure_default_generates_once_and_preserves_edits` extended: a user-edited file survives the superseded check on a fresh host.

`cargo test --lib`: 750 passed. `cargo fmt --check`: clean.