### PR TITLE
fix(#257): riichi under autoplay for plain-mjai bots via reach follow-up

### DIFF
--- a/src/autoplay/README.md
+++ b/src/autoplay/README.md
@@ -129,29 +129,31 @@ plan the moved window is expected, and the tile is still owed.
 **Riichi** is one plan, not two: the declaration button and then the tile
 the bot named on its `Reach`. The client takes them as separate inputs and
 sits on its clock until it has both, and nothing prompts a second bot
-decision — the `reach` the server echoes back is our own action coming
+decision here — the `reach` the server echoes back is our own action coming
 home, not a new question.
 
-`Reach.pai` is a V3 extension; mjai itself has no such field, and the
-original design took the other route — `inject_reach_for_followup` posts a
-synthetic `Reach` back onto the `MjaiBus` so the bot answers with the
-declaring dahai. **That route does not work and never has**: `BotManager`
-does not treat a `reach` as a decision point (it never has, including in
-the commit that added the injection), so the synthetic event is buffered
-and the bot is never asked. Nothing has noticed because the built-in bot
-always fills `pai` — it resolves the riichi discard before replying and
-declines the reach outright if it cannot.
+`Reach.pai` is a V3 extension; mjai itself has no such field, so a correct
+third-party mjai bot declares riichi as a bare `reach` with no tile. The
+tile is resolved **before** the plan is built, in `bot::manager`: when a
+bot's reaction is a bare `reach` and autoplay is on, the manager feeds the
+same runner a synthetic `reach` and reads back the declaring `dahai` —
+exactly the declare → echo → discard shape mjai prescribes — then fills
+`Reach.pai`. The built-in native bot does this internally already; the
+manager generalises it to any runner. The follow-up is gated on autoplay
+because it mutates a stateful bot as though riichi were declared, which is
+only safe when we then commit that declaration; in analysis mode the human
+may decline. The bridge's later own-seat `reach` echo is dropped from the
+runner's view (`drop_next_own_reach`) so a stateful bot never applies
+`reach` twice. See issue #257.
 
-So today a bot that declares riichi without naming the tile cannot riichi
-under autoplay on **either** platform. Tenhou skips the declaration whole
-and says so in the log — pressing the button without a tile to follow is
-worse than not pressing it, because at clock expiry the *client* completes
-the riichi itself by throwing the drawn tile, committing the hand to a
-wait the bot never chose. The same refusal applies when the tracked hand
-cannot produce the tile the bot named. Tracked as issue #257, along with
-why the obvious repair — making our own `reach` a decision point — needs
-care on Mahjong Soul, where the bridge emits `reach` and the committing
-`dahai` together.
+If that resolution fails (the bot answers with something other than a
+dahai, or the follow-up errors), the plan still sees a bare `reach` and
+declines the declaration whole rather than pressing the button half:
+pressing it without a tile to follow is worse than not pressing it, because
+at clock expiry the *client* completes the riichi itself by throwing the
+drawn tile, committing the hand to a wait the bot never chose. The same
+refusal applies when the tracked hand cannot produce the tile the bot
+named.
 
 ### Still to verify against a live game
 

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -13,7 +13,7 @@
 pub mod coords;
 
 use crate::autoplay::delay::{self, DecisionKind, DelayInput};
-use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};
+use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, Step};
 use crate::bridge::majsoul::tile::compare_pai;
 use crate::schema::MjaiEvent;
 #[cfg(test)]
@@ -41,9 +41,10 @@ impl PlatformAutoplay for MajsoulAutoplay {
         match ctx.action {
             // ----- Dahai (打牌) ---------------------------------------------
             MjaiEvent::Dahai { actor, pai, .. } if *actor == ctx.our_seat => {
-                // While in riichi, Majsoul auto-discards. Suppress unless
-                // this dahai is the riichi-declaring tile (Path B follow-up).
-                if ctx.self_riichi_accepted && ctx.reach_state != ReachState::AwaitingDahai {
+                // While in riichi, Majsoul auto-discards, so ours would be a
+                // second one. (The riichi-declaring tile goes out inside the
+                // Reach plan below, before acceptance, so it is unaffected.)
+                if ctx.self_riichi_accepted {
                     // …with one exception: the auto-discard is held back
                     // while an own-draw operation prompt is open — kita on
                     // a drawn North (sanma), a riichi-legal ankan, or a
@@ -73,16 +74,21 @@ impl PlatformAutoplay for MajsoulAutoplay {
                 }
             }
 
-            // ----- Reach (立直) — two paths -------------------------------
+            // ----- Reach (立直) — declaration + tile in one plan ----------
             MjaiEvent::Reach { actor, pai } if *actor == ctx.our_seat => {
-                // Path A clicks the riichi tile right after the button, so
-                // reserve one extra click of overhead.
-                push_pre_delay(
-                    &mut result.steps,
-                    ctx,
-                    DecisionKind::Reach,
-                    u32::from(pai.is_some()),
-                );
+                // Majsoul fuses declaring + discarding into one action, so the
+                // tile must be known up front. It normally is — the bot fills
+                // `Reach.pai` (natively or via the manager's autoplay reach
+                // follow-up, #257, which logs when it cannot). A bare reach
+                // here means that resolution failed; declare nothing rather
+                // than press the button and leave the client sitting on an
+                // owed discard until timeout.
+                let Some(tile) = pai else {
+                    return PlanResult::default();
+                };
+                // Clicks the riichi tile right after the button, so reserve
+                // one extra click of overhead.
+                push_pre_delay(&mut result.steps, ctx, DecisionKind::Reach, 1);
                 if let Some(button) = action_button_for(MajsoulOpType::Reach, ctx) {
                     result.steps.push(Step::Click {
                         x_norm: button.0,
@@ -92,23 +98,11 @@ impl PlatformAutoplay for MajsoulAutoplay {
                     // Reach not in legal_actions — bridge desync; bail.
                     return PlanResult::default();
                 }
-
-                match pai {
-                    // Path A: bot pre-filled the riichi tile.
-                    Some(tile) => {
-                        result.steps.push(Step::Sleep {
-                            duration_ms: ctx.cfg.inter_click_delay_ms,
-                        });
-                        if let Some(click) = plan_dahai_click(tile, ctx) {
-                            result.steps.push(click);
-                        }
-                    }
-                    // Path B: bot needs a synthetic Reach event before it
-                    // emits the riichi-declaring dahai. Manager will inject.
-                    None => {
-                        result.inject_reach_for_followup = true;
-                        result.awaiting_riichi_dahai = true;
-                    }
+                result.steps.push(Step::Sleep {
+                    duration_ms: ctx.cfg.inter_click_delay_ms,
+                });
+                if let Some(click) = plan_dahai_click(tile, ctx) {
+                    result.steps.push(click);
                 }
             }
 
@@ -341,40 +335,19 @@ fn push_pre_delay(
         .and_then(|s| s.try_decide(&input))
         .unwrap_or_else(|| delay::decide(&input, &mut rand::rng()));
 
-    // The Path-B riichi follow-up dahai is a *second* plan inside the
-    // same (still open) decision window: the reach-stage pre-delay and
-    // click already consumed the think time the model targeted for the
-    // whole riichi action (the calibration source measures declaration
-    // plus tile as ONE server-observed interval). Sleeping a full fresh
-    // target here would roughly double the human riichi median, so the
-    // follow-up gets only the residual of its target — usually zero —
-    // floored at the tile-click UI-readiness pause (`min_delay_ms`,
-    // on a clock that restarts at our reach click: the hand re-renders
-    // highlighted before the tile exists to click), and still clamped
-    // so the window total never exceeds the budget cap. Floor last —
-    // losing the click is worse than shaving budget headroom.
-    let follow_up = kind == DecisionKind::Dahai && ctx.reach_state == ReachState::AwaitingDahai;
-
     // Convert target total time to a sleep: subtract what the window has
     // already consumed AND what the click sequence itself will take —
     // the target is the server-observed total, and hover/hold/candidate
     // clicks all land after this sleep. Without a budget there is no
-    // window clock — only the click overhead is deducted.
+    // window clock — only the click overhead is deducted. A riichi's
+    // declaration and tile go out in one plan, so the whole action is
+    // budgeted here as a single interval (the calibration source measures
+    // declaration plus tile as one server-observed interval).
     let sleep = match ctx.budget {
-        Some(b) if follow_up => {
-            let residual = decision
-                .total_target_ms
-                .saturating_sub(b.elapsed_ms)
-                .saturating_sub(click_overhead_ms);
-            let remaining =
-                delay::budget_cap(&input, decision.allow_bank).saturating_sub(b.elapsed_ms);
-            residual.min(remaining).max(delay_cfg.min_delay_ms)
-        }
         Some(b) => decision
             .total_target_ms
             .saturating_sub(b.elapsed_ms)
             .saturating_sub(click_overhead_ms),
-        None if follow_up => delay_cfg.min_delay_ms,
         None => decision.total_target_ms.saturating_sub(click_overhead_ms),
     };
     // The overhead deduction must not undercut UI readiness: the first
@@ -844,7 +817,6 @@ mod tests {
         last_kawa: Option<&'a str>,
         last_tsumo: Option<&'a str>,
         riichi_accepted: bool,
-        reach_state: ReachState,
         cfg_ref: &'a MajsoulAutoplayConfig,
     ) -> ActionContext<'a> {
         ActionContext {
@@ -855,7 +827,6 @@ mod tests {
             last_kawa_tile: last_kawa,
             last_self_tsumo: last_tsumo,
             self_riichi_accepted: riichi_accepted,
-            reach_state,
             num_players: snapshot.num_players,
             cfg: cfg_ref,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -891,7 +862,6 @@ mod tests {
             Some("1m"),
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -931,7 +901,6 @@ mod tests {
             Some("1m"),
             Some("5p"),
             true,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -974,7 +943,6 @@ mod tests {
             Some("1z"),
             Some("N"),
             true,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1022,7 +990,6 @@ mod tests {
             Some("1z"),
             Some("5p"),
             true,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1061,7 +1028,6 @@ mod tests {
             Some("1z"),
             Some("1m"),
             true,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1073,39 +1039,6 @@ mod tests {
             }
             _ => panic!("expected a click on the X button"),
         }
-    }
-
-    #[test]
-    fn dahai_under_riichi_awaiting_riichi_dahai_clicks() {
-        // Path B follow-up: even though manager has self_riichi_accepted=false
-        // (it only flips on ReachAccepted from server), reach_state being
-        // AwaitingDahai means we should click. self_riichi_accepted is
-        // expected to be false here too, but the suppression check is
-        // ANDed with reach_state — verify both false-cases:
-        let snap = snapshot_with_hand(0, vec!["1m", "2m", "3m"]);
-        let act = MjaiEvent::Dahai {
-            actor: 0,
-            pai: "3m".into(),
-            tsumogiri: false,
-        };
-        let cfg_ref = cfg();
-        // Hand of 3 tiles is unusual but the Path B click should not be
-        // suppressed even when self_riichi_accepted=true happens to be set.
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            true,
-            ReachState::AwaitingDahai,
-            &cfg_ref,
-        );
-        let result = MajsoulAutoplay::new().plan(&ctx);
-        assert!(
-            !result.steps.is_empty(),
-            "Path B follow-up dahai must click"
-        );
     }
 
     /// Regression: `is_post_call` was derived from `hand_len % 3 == 1`,
@@ -1158,7 +1091,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         ctx.delay_script = Some(&script);
@@ -1182,7 +1114,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         ctx.delay_script = Some(&script);
@@ -1193,69 +1124,6 @@ mod tests {
                 Some(Step::Sleep { duration_ms: 3456 })
             ),
             "script must see post_call=false: {:?}",
-            result.steps.first()
-        );
-    }
-
-    /// Regression: the Path-B riichi follow-up dahai used to sleep a
-    /// full fresh target on top of the reach-stage delay, roughly
-    /// doubling the human riichi median. The follow-up gets only the
-    /// residual of its target (usually zero) floored at the tile-click
-    /// UI-readiness pause.
-    #[test]
-    fn follow_up_riichi_dahai_sleeps_only_the_ui_floor() {
-        let script = crate::autoplay::delay::DelayScript::compile(
-            "function decide_delay(ctx) return { delay_ms = 2000 } end",
-            "test",
-        )
-        .unwrap();
-        let snap = snapshot_with_hand(0, vec!["1m", "2m", "3m"]);
-        let act = MjaiEvent::Dahai {
-            actor: 0,
-            pai: "3m".into(),
-            tsumogiri: false,
-        };
-        let cfg_ref = cfg();
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            ReachState::AwaitingDahai,
-            &cfg_ref,
-        );
-        ctx.delay_script = Some(&script);
-        let floor = ctx.delay_cfg.min_delay_ms;
-
-        // With a budget clock: the reach stage already consumed more
-        // than the 2000ms target — only the UI floor remains.
-        ctx.budget = Some(crate::autoplay::delay::BudgetSnapshot {
-            fixed_ms: 20_000,
-            add_ms: 0,
-            elapsed_ms: 10_000,
-        });
-        let result = MajsoulAutoplay::new().plan(&ctx);
-        assert!(
-            matches!(
-                result.steps.first(),
-                Some(Step::Sleep { duration_ms }) if *duration_ms == floor
-            ),
-            "budgeted follow-up must sleep exactly the UI floor: {:?}",
-            result.steps.first()
-        );
-
-        // Without a budget clock there is nothing to subtract from —
-        // the follow-up still must not sleep a second full target.
-        ctx.budget = None;
-        let result = MajsoulAutoplay::new().plan(&ctx);
-        assert!(
-            matches!(
-                result.steps.first(),
-                Some(Step::Sleep { duration_ms }) if *duration_ms == floor
-            ),
-            "unbudgeted follow-up must sleep exactly the UI floor: {:?}",
             result.steps.first()
         );
     }
@@ -1287,7 +1155,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         ctx.delay_script = Some(&script);
@@ -1345,7 +1212,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         ctx.delay_script = Some(&script);
@@ -1384,7 +1250,6 @@ mod tests {
             Some("1m"),
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1392,11 +1257,13 @@ mod tests {
         assert_eq!(result.steps.len(), 4);
         assert!(matches!(result.steps[1], Step::Click { .. }));
         assert!(matches!(result.steps[3], Step::Click { .. }));
-        assert!(!result.inject_reach_for_followup);
     }
 
+    /// A reach that still names no tile (the manager's follow-up failed to
+    /// resolve it, #257) declares nothing — pressing the button alone would
+    /// leave the client owing a discard until timeout.
     #[test]
-    fn reach_path_b_signals_inject() {
+    fn reach_without_pai_declines() {
         let snap = snapshot_with_hand(0, vec!["1m"]);
         let act = MjaiEvent::Reach {
             actor: 0,
@@ -1404,21 +1271,12 @@ mod tests {
         };
         let cfg_ref = cfg();
         let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1m"),
-            None,
-            false,
-            ReachState::Idle,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1m"), None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
-        // sleep + reach btn click only
-        assert_eq!(result.steps.len(), 2);
-        assert!(result.inject_reach_for_followup);
-        assert!(result.awaiting_riichi_dahai);
+        assert!(
+            result.steps.is_empty(),
+            "a tile-less reach must not press anything"
+        );
     }
 
     #[test]
@@ -1440,7 +1298,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1470,7 +1327,6 @@ mod tests {
             Some("1m"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1498,7 +1354,6 @@ mod tests {
             Some("1m"),
             Some("1m"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1536,7 +1391,6 @@ mod tests {
             None,
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1574,7 +1428,6 @@ mod tests {
             None,
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1621,7 +1474,6 @@ mod tests {
             Some("9m"),
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1660,7 +1512,6 @@ mod tests {
             None,
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1698,7 +1549,6 @@ mod tests {
                 Some("1m"),
                 Some("5p"),
                 false,
-                ReachState::Idle,
                 &cfg_ref,
             );
             ctx.delay_cfg = crate::config::DelayModelConfig {
@@ -1723,69 +1573,6 @@ mod tests {
     }
 
     /// The Path-B riichi follow-up dahai runs inside the same still-open
-    /// window whose elapsed already contains the reach-button stage — the
-    /// stage that consumed the think time targeted for the whole riichi
-    /// action. It sleeps only the residual of its own target (usually
-    /// zero), floored at the tile-click UI pause. (Regression both ways:
-    /// plain `target - elapsed` saturates to 0 and snaps the tile before
-    /// the UI re-renders; a full fresh target doubles the human riichi
-    /// median.)
-    #[test]
-    fn riichi_followup_dahai_sleeps_residual_with_ui_floor() {
-        let snap = snapshot_with_oya(
-            0,
-            1,
-            vec![
-                "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "1p", "2p", "3p", "4p", "5p",
-            ],
-        );
-        let act = MjaiEvent::Dahai {
-            actor: 0,
-            pai: "5p".into(),
-            tsumogiri: false,
-        };
-        let mut cfg_ref = cfg();
-        cfg_ref.pre_click_delay_min_ms = 1000;
-        cfg_ref.pre_click_delay_max_ms = 1000;
-
-        let sleep_for = |fixed_ms: u32, elapsed_ms: u32| {
-            let mut ctx = ctx_for(
-                &act,
-                &snap,
-                &[],
-                Some("1m"),
-                Some("5p"),
-                false,
-                ReachState::AwaitingDahai,
-                &cfg_ref,
-            );
-            ctx.delay_cfg = crate::config::DelayModelConfig {
-                distribution: crate::config::DelayDistribution::Uniform,
-                // Lower than the 1s target so the floor and the residual
-                // are distinguishable in the assertions below.
-                min_delay_ms: 200,
-                ..Default::default()
-            };
-            ctx.budget = Some(crate::autoplay::delay::BudgetSnapshot {
-                fixed_ms,
-                add_ms: 0,
-                elapsed_ms,
-            });
-            let result = MajsoulAutoplay::new().plan(&ctx);
-            match result.steps[0] {
-                Step::Sleep { duration_ms } => duration_ms,
-                _ => panic!("expected leading sleep"),
-            }
-        };
-
-        // The reach stage (2.5s) already consumed the whole 1s target:
-        // only the UI-readiness floor remains — not a second full
-        // target, and not a raw 0 that would click into the re-render.
-        assert_eq!(sleep_for(10_000, 2500), 200);
-        // A target not yet fully consumed sleeps its residual.
-        assert_eq!(sleep_for(10_000, 400), 600);
-    }
-
     /// Legacy mode must reproduce the historical fixed model even when
     /// the config still carries log-normal parameters: the distribution
     /// is forced to uniform and the sleep is exactly min==max.
@@ -1813,7 +1600,6 @@ mod tests {
             Some("1m"),
             Some("5p"),
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         // Config keeps LogNormal + calibrated table, but mode is legacy.
@@ -1908,7 +1694,6 @@ mod tests {
             None,       // opening turn: no kawa tile yet
             Some("1m"), // rinshan replacement is the live tsumohai
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1967,7 +1752,6 @@ mod tests {
             Some(pai),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -2076,7 +1860,6 @@ mod tests {
             Some("5p"),
             None,
             false,
-            ReachState::Idle,
             &cfg_ref,
         );
         let result = MajsoulAutoplay::new().plan(&ctx);

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -855,15 +855,7 @@ mod tests {
             tsumogiri: false,
         };
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], Some("1m"), Some("5p"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         // sleep + click
         assert_eq!(result.steps.len(), 2);
@@ -894,15 +886,7 @@ mod tests {
             tsumogiri: true,
         };
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            Some("5p"),
-            true,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], Some("1m"), Some("5p"), true, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(result.steps.is_empty(), "no click while riichi accepted");
     }
@@ -936,15 +920,7 @@ mod tests {
             Action::new(ActionType::Discard, Some(120), vec![], Some(0)),
             Action::new(ActionType::Kita, Some(120), vec![], Some(0)),
         ];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1z"),
-            Some("N"),
-            true,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1z"), Some("N"), true, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2, "sleep + X click, got {result:?}");
         match &result.steps[1] {
@@ -983,15 +959,7 @@ mod tests {
             Action::new(ActionType::Discard, Some(53), vec![], Some(0)),
             Action::new(ActionType::Kita, Some(120), vec![], Some(0)),
         ];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1z"),
-            Some("5p"),
-            true,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1z"), Some("5p"), true, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
             result.steps.is_empty(),
@@ -1021,15 +989,7 @@ mod tests {
             Action::new(ActionType::Discard, Some(3), vec![], Some(0)),
             Action::new(ActionType::Ankan, Some(0), vec![0, 1, 2, 3], Some(0)),
         ];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1z"),
-            Some("1m"),
-            true,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1z"), Some("1m"), true, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2, "sleep + X click, got {result:?}");
         match &result.steps[1] {
@@ -1084,15 +1044,7 @@ mod tests {
         };
         let cfg_ref = cfg();
         let script = assert_script(true);
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), None, false, &cfg_ref);
         ctx.delay_script = Some(&script);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
@@ -1107,15 +1059,7 @@ mod tests {
         // Post-draw discard on the same melded hand: draw tracked.
         snap.players[0].drawn_tile = Some("2p".into());
         let script = assert_script(false);
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), None, false, &cfg_ref);
         ctx.delay_script = Some(&script);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
@@ -1148,15 +1092,7 @@ mod tests {
         let mut cfg_ref = cfg();
         cfg_ref.hover_delay_ms = 200;
         cfg_ref.click_hold_ms = 100; // single-click dahai → 300ms overhead
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), None, false, &cfg_ref);
         ctx.delay_script = Some(&script);
 
         // No budget clock: target minus the click overhead.
@@ -1205,15 +1141,7 @@ mod tests {
         let mut cfg_ref = cfg();
         cfg_ref.hover_delay_ms = 200;
         cfg_ref.click_hold_ms = 100;
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), None, false, &cfg_ref);
         ctx.delay_script = Some(&script);
         let floor = ctx.delay_cfg.min_delay_ms;
 
@@ -1243,15 +1171,7 @@ mod tests {
         let cfg_ref = cfg();
         // Reach must be in legal_actions for the button position to resolve.
         let legal = vec![Action::new(ActionType::Riichi, None, vec![], Some(0))];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1m"),
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1m"), Some("5p"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         // sleep + reach btn + sleep + tile click
         assert_eq!(result.steps.len(), 4);
@@ -1291,15 +1211,7 @@ mod tests {
             Action::new(ActionType::Pass, None, vec![], Some(0)),
             Action::new(ActionType::Pon, None, vec![], Some(0)),
         ];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1m"), None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2);
         match &result.steps[1] {
@@ -1320,15 +1232,7 @@ mod tests {
         let snap = snapshot_with_hand(0, vec!["1m"]);
         let act = MjaiEvent::None;
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], Some("1m"), None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
             result.steps.is_empty(),
@@ -1347,15 +1251,7 @@ mod tests {
             Action::new(ActionType::Discard, Some(0), vec![], Some(0)),
             Action::new(ActionType::Discard, Some(4), vec![], Some(0)),
         ];
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("1m"),
-            Some("1m"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("1m"), Some("1m"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert!(
             result.steps.is_empty(),
@@ -1384,15 +1280,7 @@ mod tests {
         let cfg_ref = cfg();
         // Even with last_self_tsumo set, dealer-first-discard layout
         // must override the tsumohai-offset path.
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            None,
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], None, Some("5p"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         assert_eq!(result.steps.len(), 2);
         match &result.steps[1] {
@@ -1421,15 +1309,7 @@ mod tests {
             tsumogiri: false,
         };
         let cfg_ref = cfg_with_dealer_delay(2000);
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            None,
-            None,
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], None, None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         // The dealer-pad wait is folded into the single pre-delay sleep:
         // [pre-delay sleep (>= animation pad), click]. With the zeroed
@@ -1467,15 +1347,7 @@ mod tests {
             tsumogiri: false,
         };
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("9m"),
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], Some("9m"), Some("5p"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         match &result.steps.last().unwrap() {
             Step::Click { x_norm, .. } => {
@@ -1505,15 +1377,7 @@ mod tests {
             tsumogiri: false,
         };
         let cfg_ref = cfg_with_dealer_delay(2000);
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            None,
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &[], None, Some("5p"), false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         // No dealer pad: just [pre-delay, click].
         assert_eq!(result.steps.len(), 2);
@@ -1542,15 +1406,7 @@ mod tests {
         cfg_ref.pre_click_delay_max_ms = 1000;
 
         let sleep_with_elapsed = |elapsed_ms: u32| {
-            let mut ctx = ctx_for(
-                &act,
-                &snap,
-                &[],
-                Some("1m"),
-                Some("5p"),
-                false,
-                &cfg_ref,
-            );
+            let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), Some("5p"), false, &cfg_ref);
             ctx.delay_cfg = crate::config::DelayModelConfig {
                 distribution: crate::config::DelayDistribution::Uniform,
                 ..Default::default()
@@ -1593,15 +1449,7 @@ mod tests {
         let mut cfg_ref = cfg();
         cfg_ref.pre_click_delay_min_ms = 1234;
         cfg_ref.pre_click_delay_max_ms = 1234;
-        let mut ctx = ctx_for(
-            &act,
-            &snap,
-            &[],
-            Some("1m"),
-            Some("5p"),
-            false,
-            &cfg_ref,
-        );
+        let mut ctx = ctx_for(&act, &snap, &[], Some("1m"), Some("5p"), false, &cfg_ref);
         // Config keeps LogNormal + calibrated table, but mode is legacy.
         ctx.delay_cfg.mode = crate::config::DelayMode::Legacy;
         let result = MajsoulAutoplay::new().plan(&ctx);
@@ -1745,15 +1593,7 @@ mod tests {
             consumed: [consumed[0].to_string(), consumed[1].to_string()],
         };
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            legal,
-            Some(pai),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, legal, Some(pai), None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         result
             .steps
@@ -1853,15 +1693,7 @@ mod tests {
             consumed: ["5p".into(), "5p".into()],
         };
         let cfg_ref = cfg();
-        let ctx = ctx_for(
-            &act,
-            &snap,
-            &legal,
-            Some("5p"),
-            None,
-            false,
-            &cfg_ref,
-        );
+        let ctx = ctx_for(&act, &snap, &legal, Some("5p"), None, false, &cfg_ref);
         let result = MajsoulAutoplay::new().plan(&ctx);
         let clicks: Vec<(f64, f64)> = result
             .steps

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -6,7 +6,7 @@
 //! - One long-lived `tokio::select!` loop over `BotResponseBus` and
 //!   `MjaiBus`. Bot responses drive clicks; mjai events update local
 //!   per-game tracking state (`last_kawa_tile`, `last_self_tsumo`,
-//!   `self_riichi_accepted`, `reach_state`).
+//!   `self_riichi_accepted`).
 //!
 //! Failure modes are silent-by-design: if the page handle is missing
 //! (chromium backend not running) or the canvas-rect query fails, the
@@ -16,7 +16,7 @@
 use crate::autoplay::cdp_input::{dispatch_click_shaped, evaluate_canvas_rect};
 use crate::autoplay::context::{AutoplayContext, CanvasRect};
 use crate::autoplay::majsoul::MajsoulAutoplay;
-use crate::autoplay::platform::{ActionContext, PlatformAutoplay, ReachState, Step};
+use crate::autoplay::platform::{ActionContext, PlatformAutoplay, Step};
 use crate::autoplay::tenhou::TenhouAutoplay;
 use crate::autoplay::verify::InputTicket;
 use crate::bot::BotResponse;
@@ -63,7 +63,6 @@ struct ManagerState {
     last_kawa_tile: Option<String>,
     last_self_tsumo: Option<String>,
     self_riichi_accepted: bool,
-    reach_state: ReachState,
     canvas_rect_at: Option<Instant>,
     /// Decisions in a row where the client accepted nothing we pressed.
     /// Reset by any input the client does accept.
@@ -211,7 +210,6 @@ impl AutoplayManager {
             last_kawa_tile: self.state.last_kawa_tile.as_deref(),
             last_self_tsumo: self.state.last_self_tsumo.as_deref(),
             self_riichi_accepted: self.state.self_riichi_accepted,
-            reach_state: self.state.reach_state,
             num_players,
             cfg: &cfg,
             delay_cfg,
@@ -239,16 +237,14 @@ impl AutoplayManager {
         }
 
         let plan = platform.plan(&action_ctx);
-        if plan.steps.is_empty() && !plan.inject_reach_for_followup {
+        if plan.steps.is_empty() {
             return;
         }
 
         debug!(
-            "autoplay: action={:?} steps={} inject_reach={} await_riichi_dahai={}",
+            "autoplay: action={:?} steps={}",
             resp.action,
             plan.steps.len(),
-            plan.inject_reach_for_followup,
-            plan.awaiting_riichi_dahai
         );
 
         // Only a click needs to know where the canvas is. A plan built of
@@ -278,11 +274,10 @@ impl AutoplayManager {
         // the previous decision cannot be mistaken for this one landing.
         let ticket = self.ctx.input_watch.ticket();
 
-        // Whether this plan declares riichi — either Path A (button then
-        // tile in one plan) or the Path B follow-up discard, which the
-        // client only sends as a declaration if the button press landed.
-        let declares_reach = matches!(resp.action, MjaiEvent::Reach { .. })
-            || matches!(self.state.reach_state, ReachState::AwaitingDahai);
+        // Whether this plan declares riichi: the reach declaration and its
+        // tile go out in one plan (the declaring discard is pre-resolved onto
+        // `Reach.pai`), so the reach action alone identifies it.
+        let declares_reach = matches!(resp.action, MjaiEvent::Reach { .. });
 
         if let Some(w) = planned_window {
             self.state.acted_window = Some(w.opened_at);
@@ -440,17 +435,12 @@ impl AutoplayManager {
         // Did the client accept any of that? A swallowed click reports
         // success like any other — the page dispatched the events and the
         // engine ignored them — so the proof has to come from the client's
-        // own uplink. Skipped for a plan that deliberately stops mid-action
-        // (Path B presses Reach and waits for the bot's follow-up dahai;
-        // Mahjong Soul sends nothing until that tile is chosen).
+        // own uplink.
         // Only canvas clicks need proving. The Tenhou steps run the client's
         // own handlers — a DOM press or its discard call either resolved or
         // reported that it did not, with no swallowed-input case in between —
         // and `rect` is `None` for a plan built of those, which skips this.
-        if let (true, Some(rect)) = (
-            cfg.verify_input_ms > 0 && !plan.inject_reach_for_followup,
-            rect,
-        ) {
+        if let (true, Some(rect)) = (cfg.verify_input_ms > 0, rect) {
             // What counts as proof. A discard plan is proven by any input.
             // Every other plan pressed action buttons, and for those a
             // plain discard can only be the client's own turn-timeout
@@ -501,7 +491,10 @@ impl AutoplayManager {
             // discard, which the presence check happily accepts. The wire
             // tells them apart, so check, and say so — the tile is gone
             // either way, but the player is now in a hand they did not
-            // choose and nothing else would tell them.
+            // choose and nothing else would tell them. It is also the one
+            // window where the bot's own view can drift: if the declaring
+            // tile came from an autoplay reach follow-up (#257), the bot was
+            // fed a reach that then did not happen, so flag that too.
             if declares_reach
                 && self.ctx.input_watch.sent_since(ticket)
                 && !self.ctx.input_watch.reach_since(ticket)
@@ -512,47 +505,9 @@ impl AutoplayManager {
                 );
                 let _ = self.notify.send(
                     crate::schema::Notification::error("Riichi did not go through").body(
-                        "The declaration press was lost and the tile was discarded without it. This hand is not in riichi.",
+                        "The declaration press was lost and the tile was discarded without it. This hand is not in riichi — and the bot may still believe it declared, so its reads for the rest of this hand can be off.",
                     ),
                 );
-            }
-        }
-
-        // A plan that declared riichi without throwing the tile is owed one,
-        // and the next dahai from our seat is it. Both platforms normally
-        // take the tile straight off the bot's `Reach { pai }` and do it in
-        // the same plan; this is the fallback for a bot that names no tile,
-        // where Majsoul manufactures a decision (Path B below) and Tenhou
-        // has nothing to manufacture one with.
-        if plan.awaiting_riichi_dahai {
-            self.state.reach_state = ReachState::AwaitingDahai;
-        }
-
-        // Path-B side effect: inject synthetic Reach so the bot will
-        // emit the riichi-declaring dahai we need to click next.
-        if plan.inject_reach_for_followup {
-            self.state.reach_state = ReachState::AwaitingDahai;
-            let synthetic = MjaiEvent::Reach {
-                actor: our_seat,
-                pai: None,
-            };
-            if let Err(e) = self.mjai_bus.send(synthetic) {
-                // No subscribers (e.g. bot disabled) — nothing to do, but
-                // log for visibility because Path B without a downstream
-                // bot would soft-hang autoplay until reach_state resets.
-                debug!("autoplay: synthetic Reach send had no subscribers: {e:?}");
-            } else {
-                info!("autoplay: injected synthetic Reach (Path B) for seat {our_seat}");
-            }
-        }
-
-        // After a successful Path-B follow-up dahai, return to Idle.
-        // The check is conservative: only flip on Dahai by our seat.
-        if matches!(self.state.reach_state, ReachState::AwaitingDahai) {
-            if let MjaiEvent::Dahai { actor, .. } = &resp.action {
-                if *actor == our_seat {
-                    self.state.reach_state = ReachState::Idle;
-                }
             }
         }
     }

--- a/src/autoplay/mod.rs
+++ b/src/autoplay/mod.rs
@@ -71,5 +71,5 @@ pub mod verify;
 pub use budget::{BudgetSource, SharedTimeBudget, TimeBudget};
 pub use context::{AutoplayContext, CanvasRect};
 pub use manager::run_autoplay_manager;
-pub use platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};
+pub use platform::{ActionContext, PlanResult, PlatformAutoplay, Step};
 pub use verify::{InputKind, InputWatch, SharedInputWatch};

--- a/src/autoplay/platform.rs
+++ b/src/autoplay/platform.rs
@@ -56,21 +56,6 @@ pub enum Step {
     Discard { tile_index: u32 },
 }
 
-/// State machine for handling Majsoul's fused reach+discard: the platform
-/// emits one reach action that combines the declaration and the discard,
-/// so we click reach first, await the bot's follow-up `Dahai`, then click
-/// the discard tile.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ReachState {
-    #[default]
-    Idle,
-    /// Path B: we clicked the reach button and injected a synthetic
-    /// `Reach` event into MjaiBus. The next `Dahai` from the bot is the
-    /// riichi tile and must be clicked even though the bot didn't pre-fill
-    /// `Reach.pai`.
-    AwaitingDahai,
-}
-
 /// Everything the platform impl needs to translate one bot decision
 /// into a concrete click sequence.
 pub struct ActionContext<'a> {
@@ -99,8 +84,6 @@ pub struct ActionContext<'a> {
     /// kyoku ends. While set, dahai clicks are suppressed (Majsoul auto-
     /// discards in riichi mode).
     pub self_riichi_accepted: bool,
-    /// Reach two-step state (see [`ReachState`]).
-    pub reach_state: ReachState,
     /// 3 (sanma) or 4 (yonma).
     pub num_players: u8,
     /// Per-platform config knobs (delays, mouse-move emission, ...).
@@ -124,25 +107,16 @@ pub struct ActionContext<'a> {
     pub tenhou: Option<&'a crate::autoplay::tenhou_state::TenhouState>,
 }
 
-/// Output of `PlatformAutoplay::plan`. Captures both the click sequence
-/// and the side-effect signal the manager needs to fulfil Path B reach
-/// (inject a synthetic `Reach` event back to MjaiBus so the bot emits
-/// the follow-up dahai).
+/// Output of `PlatformAutoplay::plan`: the click sequence to execute.
+///
+/// The riichi declaring discard is always resolved before the plan is
+/// built — the bot fills `Reach.pai` (natively or via the manager's
+/// autoplay reach follow-up, see `bot::manager` and #257) — so both
+/// platforms declare and discard in a single plan; there is no
+/// bus-injection follow-up path.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PlanResult {
     pub steps: Vec<Step>,
-    /// When `true`, the manager should send a synthetic
-    /// `MjaiEvent::Reach { actor: our_seat, pai: None }` onto MjaiBus
-    /// after the steps run, and transition `ReachState` to
-    /// `AwaitingDahai`. Set only when the bot's `Reach` event omits
-    /// `pai` and the platform needs a follow-up dahai.
-    pub inject_reach_for_followup: bool,
-    /// When `true`, the plan declared riichi without throwing the tile, so
-    /// the next bot Dahai for our seat is that tile and should be performed
-    /// even though the manager has flipped its `self_riichi_accepted` gate.
-    /// Only reached when the bot's `Reach` names no `pai` — with one, both
-    /// platforms declare and discard in a single plan.
-    pub awaiting_riichi_dahai: bool,
 }
 
 pub trait PlatformAutoplay: Send + Sync {

--- a/src/autoplay/tenhou/mod.rs
+++ b/src/autoplay/tenhou/mod.rs
@@ -35,7 +35,7 @@
 
 use crate::autoplay::cdp_input::{self, menu};
 use crate::autoplay::delay::{BudgetSnapshot, DecisionKind, DelayInput};
-use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, ReachState, Step};
+use crate::autoplay::platform::{ActionContext, PlanResult, PlatformAutoplay, Step};
 use crate::autoplay::tenhou_state;
 use crate::schema::MjaiEvent;
 use tracing::{debug, warn};
@@ -373,11 +373,8 @@ impl PlatformAutoplay for TenhouAutoplay {
         // Once riichi is accepted the client discards for itself, so ours
         // would be a second one. Claims that survive riichi (ankan, hora) are
         // still ours. The riichi tile arrives before acceptance and so is
-        // unaffected, but check `reach_state` anyway.
-        if kind == DecisionKind::Dahai
-            && ctx.self_riichi_accepted
-            && ctx.reach_state != ReachState::AwaitingDahai
-        {
+        // unaffected.
+        if kind == DecisionKind::Dahai && ctx.self_riichi_accepted {
             debug!(target: LOG, "riichi accepted; leaving the discard to the client");
             return result;
         }
@@ -447,19 +444,14 @@ impl PlatformAutoplay for TenhouAutoplay {
 
         // Wait for the client before thinking, not after: the delay is meant
         // to look like a human deciding, and a human cannot decide before the
-        // board has finished moving.
-        //
-        // Except after our own riichi declaration. Readiness is measured by
-        // the client's clock, and its button handler takes that clock *down*
-        // (`ec.Z(); Ub.Z(); ...`) when the declaration is pressed. Nothing
-        // raises it again: the riichi tile follows our own press, not a new
-        // frame, so there is no animation to wait out and no clock to wait
-        // for — waiting cost a declared riichi its discard.
-        if ctx.reach_state != ReachState::AwaitingDahai {
-            result.steps.push(Step::AwaitReady {
-                timeout_ms: READY_TIMEOUT_MS,
-            });
-        }
+        // board has finished moving. This wait precedes the reach button, when
+        // the client's clock is still up; the riichi tile that follows the
+        // press (below) does not wait again — the declaration takes the clock
+        // down and nothing raises it before the tile goes out in the same
+        // plan.
+        result.steps.push(Step::AwaitReady {
+            timeout_ms: READY_TIMEOUT_MS,
+        });
         push_pre_delay(&mut result.steps, ctx, kind);
         result.steps.push(step);
 
@@ -749,7 +741,6 @@ mod tests {
             last_kawa_tile: None,
             last_self_tsumo: None,
             self_riichi_accepted: false,
-            reach_state: ReachState::Idle,
             num_players: 4,
             cfg: &cfg,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -774,10 +765,6 @@ mod tests {
             pressed < discarded,
             "declare, then discard: {:?}",
             plan.steps
-        );
-        assert!(
-            !plan.awaiting_riichi_dahai,
-            "the plan performed the discard; nothing is owed"
         );
     }
 
@@ -812,7 +799,6 @@ mod tests {
             last_kawa_tile: None,
             last_self_tsumo: None,
             self_riichi_accepted: false,
-            reach_state: ReachState::Idle,
             num_players: 4,
             cfg: &cfg,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -858,7 +844,6 @@ mod tests {
             last_kawa_tile: None,
             last_self_tsumo: None,
             self_riichi_accepted: false,
-            reach_state: ReachState::Idle,
             num_players: 4,
             cfg: &cfg,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -904,7 +889,6 @@ mod tests {
             last_kawa_tile: None,
             last_self_tsumo: None,
             self_riichi_accepted: false,
-            reach_state: ReachState::Idle,
             num_players: 4,
             cfg: &cfg,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -982,7 +966,6 @@ mod tests {
             last_kawa_tile: None,
             last_self_tsumo: None,
             self_riichi_accepted: false,
-            reach_state: ReachState::Idle,
             num_players: 4,
             cfg: &cfg,
             delay_cfg: crate::config::DelayModelConfig::default(),
@@ -997,36 +980,6 @@ mod tests {
             "readiness must come first, got {:?}",
             plan.steps
         );
-
-        // ...but not for the riichi tile: pressing the declaration takes the
-        // client's clock down, and nothing raises it again.
-        let mut after_reach = ctx;
-        after_reach.reach_state = ReachState::AwaitingDahai;
-        let dahai = MjaiEvent::Dahai {
-            actor: 0,
-            pai: "1m".into(),
-            tsumogiri: false,
-        };
-        after_reach.action = &dahai;
-        let plan = TenhouAutoplay::new().plan(&after_reach);
-        assert!(
-            !plan
-                .steps
-                .iter()
-                .any(|s| matches!(s, Step::AwaitReady { .. })),
-            "the riichi discard must not wait for a clock that will not return: {:?}",
-            plan.steps
-        );
-        // ... and the press must come after the think, not before it.
-        let sleep_at = plan
-            .steps
-            .iter()
-            .position(|s| matches!(s, Step::Sleep { .. }));
-        let act_at = plan
-            .steps
-            .iter()
-            .position(|s| matches!(s, Step::DomClick { .. } | Step::Discard { .. }));
-        assert!(sleep_at < act_at, "{:?}", plan.steps);
     }
 
     /// A discard has no button — it is the one action that needs a position.

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -80,6 +80,17 @@ pub struct BotManager {
     pending: Vec<MjaiEvent>,
     /// Bot's seat in the current game; set on `start_game`.
     actor_id: Option<u8>,
+    /// One-shot: drop the next own-seat bridge `reach` echo before it is
+    /// fed to the runner. Set after an autoplay reach follow-up (see
+    /// [`Self::handle_tracked`]) has already fed this runner a synthetic
+    /// `reach` to resolve the declaring discard; the bridge's later real
+    /// reach echo for the same declaration would otherwise be a *second*
+    /// `reach` and desync a stateful bot. The tracker and history still see
+    /// the echo on their own bus subscriptions — only the runner's view is
+    /// deduplicated. Cleared when consumed, or on any kyoku/game boundary so
+    /// a lost declaration (whose echo never arrives) can't leak the flag
+    /// into the next hand.
+    drop_next_own_reach: bool,
     out_tx: BotResponseBus,
     status_tx: BotStatusBus,
     notify_tx: NotifyBus,
@@ -114,6 +125,7 @@ impl BotManager {
             runner: None,
             pending: Vec::new(),
             actor_id: None,
+            drop_next_own_reach: false,
             out_tx,
             status_tx,
             notify_tx,
@@ -178,6 +190,18 @@ impl BotManager {
     /// Drive one tracked event through the manager.
     pub async fn handle_tracked(&mut self, tracked: TrackedEvent) -> Result<()> {
         let TrackedEvent { event, can_act } = tracked;
+        // Kyoku/game boundaries clear the one-shot reach-echo drop: a lost
+        // declaration never produces the echo it was waiting for, so the flag
+        // must not survive into the next hand and eat a real reach there.
+        if matches!(
+            event,
+            MjaiEvent::StartGame { .. }
+                | MjaiEvent::StartKyoku { .. }
+                | MjaiEvent::EndKyoku
+                | MjaiEvent::EndGame { .. }
+        ) {
+            self.drop_next_own_reach = false;
+        }
         // Spawn the runner the moment we see the bot's seat in start_game.
         if let MjaiEvent::StartGame {
             id: Some(seat),
@@ -219,11 +243,35 @@ impl BotManager {
             return Ok(());
         }
 
+        // Deduplicate the bridge's own-seat reach echo when an autoplay
+        // follow-up already fed this runner a synthetic reach for the same
+        // declaration (see the follow-up below and #257). Only the runner's
+        // view is affected; the tracker/history saw the echo on their own
+        // subscriptions.
+        if self.drop_next_own_reach {
+            if let MjaiEvent::Reach { actor, .. } = &event {
+                if Some(*actor) == self.actor_id {
+                    self.drop_next_own_reach = false;
+                    debug!(
+                        "bot manager: dropped duplicate bridge reach echo for seat {actor} \
+                         (already resolved via autoplay follow-up)"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
         self.pending.push(event.clone());
 
         if !self.is_decision_point(&event, can_act) {
             return Ok(());
         }
+
+        // Read once, before borrowing the runner: whether autoplay is on
+        // gates the reach follow-up below. Runtime-toggled — the same flag
+        // the autoplay manager re-reads on every response.
+        let autoplay_enabled = self.config.read().await.autoplay.enabled;
+        let our_seat = self.actor_id;
 
         let runner = self
             .runner
@@ -231,7 +279,7 @@ impl BotManager {
             .expect("runner is Some — checked above");
         let batch = std::mem::take(&mut self.pending);
         let started = Instant::now();
-        let resp = match runner.react(&batch).await {
+        let mut resp = match runner.react(&batch).await {
             Ok(r) => r,
             Err(e) => {
                 let err_str = format!("{e:#}");
@@ -245,6 +293,59 @@ impl BotManager {
             }
         };
         let reaction_ms = started.elapsed().as_millis() as u64;
+
+        // Autoplay reach follow-up (#257). A bot that declares riichi as
+        // plain mjai — `reach` with no `pai` — leaves the declaring discard
+        // unresolved, and Majsoul fuses declaration + discard into one action
+        // so autoplay needs the tile up front. Ask the same runner for it now
+        // by feeding it the reach, exactly as the mjai protocol prescribes
+        // (declare → the engine echoes reach → the bot answers with the
+        // dahai). This is what the built-in native bot already does
+        // internally; here it is generalised to any runner.
+        //
+        // Gated on autoplay because the follow-up mutates a stateful bot's
+        // state as though riichi were declared. Under autoplay we commit that
+        // declaration, so it holds; in analysis mode the human may decline,
+        // and a speculative reach that never happens would desync the bot.
+        // The bridge's later real reach echo for this declaration is dropped
+        // from the runner's view (`drop_next_own_reach`) so it isn't a second
+        // reach.
+        let mut did_reach_followup = false;
+        if autoplay_enabled {
+            if let MjaiEvent::Reach { pai: None, .. } = &resp.action {
+                if let Some(seat) = our_seat {
+                    let reach_ev = MjaiEvent::Reach {
+                        actor: seat,
+                        pai: None,
+                    };
+                    match runner.react(std::slice::from_ref(&reach_ev)).await {
+                        Ok(follow) => match follow.action {
+                            MjaiEvent::Dahai { pai, .. } => {
+                                resp.action = MjaiEvent::Reach {
+                                    actor: seat,
+                                    pai: Some(pai),
+                                };
+                                did_reach_followup = true;
+                            }
+                            other => warn!(
+                                "bot manager: reach follow-up returned {other:?}, not a dahai; \
+                                 leaving the reach unresolved (autoplay will decline it)"
+                            ),
+                        },
+                        Err(e) => warn!(
+                            "bot manager: reach follow-up react failed ({e:#}); \
+                             leaving the reach unresolved"
+                        ),
+                    }
+                }
+            }
+        }
+        // The follow-up fed the runner a reach; drop the bridge's later echo
+        // of the same declaration so a stateful bot doesn't apply reach twice.
+        if did_reach_followup {
+            self.drop_next_own_reach = true;
+        }
+
         debug!(action = ?resp.action, meta = ?resp.meta, reaction_ms, "bot reacted");
         // Inspector record: pair the trigger event (the last item in the
         // batch is the one that crossed the decision-point threshold)
@@ -1488,5 +1589,152 @@ mod tests {
             .expect("manager exited")
             .expect("join")
             .expect("Ok");
+    }
+
+    // ---- #257: autoplay reach follow-up for plain-mjai bots ----------------
+
+    fn reach_none(actor: u8) -> BotResponse {
+        BotResponse {
+            action: MjaiEvent::Reach { actor, pai: None },
+            meta: None,
+        }
+    }
+
+    fn dahai_reply(actor: u8, pai: &str) -> BotResponse {
+        BotResponse {
+            action: MjaiEvent::Dahai {
+                actor,
+                pai: pai.into(),
+                tsumogiri: false,
+            },
+            meta: None,
+        }
+    }
+
+    fn our_tsumo() -> MjaiEvent {
+        MjaiEvent::Tsumo {
+            actor: 2,
+            pai: "3p".into(),
+        }
+    }
+
+    /// A stateful third-party bot declares riichi as plain mjai (`reach` with
+    /// no `pai`). Under autoplay the manager resolves the declaring discard by
+    /// feeding the runner a synthetic reach, fills `pai`, and then drops the
+    /// bridge's own-seat reach echo so the runner never sees a second reach.
+    #[tokio::test]
+    async fn autoplay_reach_followup_fills_pai_and_dedups_bridge_echo() {
+        let (mut mgr, calls, mut resp_rx, _, _) =
+            manager_with_mock(vec![reach_none(2), dahai_reply(2, "3p")]);
+        mgr.config.write().await.autoplay.enabled = true;
+
+        // Own draw → decision point → bot declares bare reach → follow-up.
+        mgr.handle(our_tsumo()).await.unwrap();
+
+        {
+            let c = calls.lock().await;
+            assert_eq!(c.len(), 2, "tsumo react + reach follow-up react");
+            assert!(matches!(c[0].as_slice(), [MjaiEvent::Tsumo { .. }]));
+            assert!(
+                matches!(c[1].as_slice(), [MjaiEvent::Reach { actor: 2, pai: None }]),
+                "follow-up feeds the runner the reach"
+            );
+        }
+
+        let emitted = resp_rx.try_recv().expect("a bot response");
+        assert!(
+            matches!(emitted.action, MjaiEvent::Reach { actor: 2, pai: Some(ref t) } if t == "3p"),
+            "the emitted reach carries the resolved riichi tile"
+        );
+        assert!(mgr.drop_next_own_reach, "the bridge echo is now armed to drop");
+
+        // The bridge's later reach echo for our seat must not reach the runner.
+        mgr.handle(MjaiEvent::Reach { actor: 2, pai: None })
+            .await
+            .unwrap();
+        assert_eq!(
+            calls.lock().await.len(),
+            2,
+            "bridge reach echo dropped — no third react call"
+        );
+        assert!(!mgr.drop_next_own_reach, "drop flag consumed by the echo");
+    }
+
+    /// Analysis mode (autoplay off): the bare reach is forwarded unchanged and
+    /// the bridge echo is NOT dropped — mutating a stateful bot with a
+    /// speculative reach the human may decline is exactly what we must avoid.
+    #[tokio::test]
+    async fn analysis_mode_leaves_bare_reach_and_forwards_bridge_echo() {
+        let (mut mgr, calls, mut resp_rx, _, _) = manager_with_mock(vec![reach_none(2)]);
+        // autoplay.enabled stays false (default).
+
+        mgr.handle(our_tsumo()).await.unwrap();
+        assert_eq!(
+            calls.lock().await.len(),
+            1,
+            "no reach follow-up when autoplay is off"
+        );
+        let emitted = resp_rx.try_recv().expect("a bot response");
+        assert!(
+            matches!(emitted.action, MjaiEvent::Reach { actor: 2, pai: None }),
+            "bare reach forwarded unchanged"
+        );
+        assert!(!mgr.drop_next_own_reach);
+
+        // Bridge reach echo is buffered for the runner, not eaten.
+        mgr.handle(MjaiEvent::Reach { actor: 2, pai: None })
+            .await
+            .unwrap();
+        assert_eq!(calls.lock().await.len(), 1, "reach is not a decision point");
+        assert!(
+            mgr.pending
+                .iter()
+                .any(|e| matches!(e, MjaiEvent::Reach { actor: 2, .. })),
+            "echo buffered for the next flush, not dropped"
+        );
+    }
+
+    /// A bot that pre-fills `pai` (the built-in native bot, or a V3-aware
+    /// bot) needs no follow-up even under autoplay, and arms no echo drop.
+    #[tokio::test]
+    async fn autoplay_prefilled_reach_pai_skips_followup() {
+        let prefilled = BotResponse {
+            action: MjaiEvent::Reach {
+                actor: 2,
+                pai: Some("3p".into()),
+            },
+            meta: None,
+        };
+        let (mut mgr, calls, mut resp_rx, _, _) = manager_with_mock(vec![prefilled]);
+        mgr.config.write().await.autoplay.enabled = true;
+
+        mgr.handle(our_tsumo()).await.unwrap();
+        assert_eq!(
+            calls.lock().await.len(),
+            1,
+            "pre-filled pai needs no follow-up"
+        );
+        let emitted = resp_rx.try_recv().expect("a bot response");
+        assert!(
+            matches!(emitted.action, MjaiEvent::Reach { actor: 2, pai: Some(ref t) } if t == "3p")
+        );
+        assert!(
+            !mgr.drop_next_own_reach,
+            "no follow-up ran, so the bridge echo must still reach the runner"
+        );
+    }
+
+    /// Leak guard: a declaration whose reach press is lost never produces the
+    /// echo the drop flag waits for, so a kyoku/game boundary must clear it or
+    /// it would eat the next hand's real reach.
+    #[tokio::test]
+    async fn stale_reach_drop_flag_clears_on_kyoku_boundary() {
+        let (mut mgr, _calls, _, _, _) = manager_with_mock(vec![]);
+        mgr.drop_next_own_reach = true;
+        mgr.handle(MjaiEvent::EndKyoku).await.unwrap();
+        assert!(
+            !mgr.drop_next_own_reach,
+            "a kyoku boundary clears a stale drop flag"
+        );
     }
 }

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -1636,7 +1636,13 @@ mod tests {
             assert_eq!(c.len(), 2, "tsumo react + reach follow-up react");
             assert!(matches!(c[0].as_slice(), [MjaiEvent::Tsumo { .. }]));
             assert!(
-                matches!(c[1].as_slice(), [MjaiEvent::Reach { actor: 2, pai: None }]),
+                matches!(
+                    c[1].as_slice(),
+                    [MjaiEvent::Reach {
+                        actor: 2,
+                        pai: None
+                    }]
+                ),
                 "follow-up feeds the runner the reach"
             );
         }
@@ -1646,12 +1652,18 @@ mod tests {
             matches!(emitted.action, MjaiEvent::Reach { actor: 2, pai: Some(ref t) } if t == "3p"),
             "the emitted reach carries the resolved riichi tile"
         );
-        assert!(mgr.drop_next_own_reach, "the bridge echo is now armed to drop");
+        assert!(
+            mgr.drop_next_own_reach,
+            "the bridge echo is now armed to drop"
+        );
 
         // The bridge's later reach echo for our seat must not reach the runner.
-        mgr.handle(MjaiEvent::Reach { actor: 2, pai: None })
-            .await
-            .unwrap();
+        mgr.handle(MjaiEvent::Reach {
+            actor: 2,
+            pai: None,
+        })
+        .await
+        .unwrap();
         assert_eq!(
             calls.lock().await.len(),
             2,
@@ -1676,15 +1688,24 @@ mod tests {
         );
         let emitted = resp_rx.try_recv().expect("a bot response");
         assert!(
-            matches!(emitted.action, MjaiEvent::Reach { actor: 2, pai: None }),
+            matches!(
+                emitted.action,
+                MjaiEvent::Reach {
+                    actor: 2,
+                    pai: None
+                }
+            ),
             "bare reach forwarded unchanged"
         );
         assert!(!mgr.drop_next_own_reach);
 
         // Bridge reach echo is buffered for the runner, not eaten.
-        mgr.handle(MjaiEvent::Reach { actor: 2, pai: None })
-            .await
-            .unwrap();
+        mgr.handle(MjaiEvent::Reach {
+            actor: 2,
+            pai: None,
+        })
+        .await
+        .unwrap();
         assert_eq!(calls.lock().await.len(), 1, "reach is not a decision point");
         assert!(
             mgr.pending


### PR DESCRIPTION
Fixes #257.

## Problem

A bot that declares riichi as plain mjai — `{"type":"reach","actor":N}` with no
`pai` — could not riichi under autoplay on either platform. The declaring tile
was never resolved, so the hand ran to the client's timeout and it discarded for
itself. `Reach.pai` is a V3 extension mjai has no such field for, so a bare
reach is exactly what a correct third-party mjai bot emits. The built-in native
bot masks this by filling `pai` itself; standard third-party bots cannot.

The original route for it (`inject_reach_for_followup` posting a synthetic
`Reach` onto the `MjaiBus`) was dead: `BotManager` never treats a `reach` as a
decision point, so the synthetic event was buffered and the bot was never asked.
It also posted onto the raw bus, which the tracker and history recorder consume
— risking a double-applied declaration and a phantom reach in the log.

## Fix

Resolve the declaring discard **before** the plan is built, in `bot::manager`:
when a runner's reaction is a bare `reach` and autoplay is enabled, feed the same
runner a synthetic `reach` and read back the declaring `dahai` — exactly the
declare → echo → discard shape the mjai protocol prescribes — then fill
`Reach.pai`. This is what the native bot already does internally, generalised to
any runner.

- **Gated on autoplay.** The follow-up mutates a stateful bot as though riichi
  were declared, which is only safe when we then commit that declaration. In
  analysis mode the human may decline the riichi, so a speculative reach would
  desync the bot — analysis mode is left byte-for-byte unchanged.
- **De-duplicated.** The bridge's later own-seat `reach` echo is dropped from the
  runner's view (`drop_next_own_reach`, cleared on consume or at any kyoku/game
  boundary) so a stateful bot never applies `reach` twice. The tracker and
  history still see the echo on their own subscriptions.

## Cleanup

With `pai` always resolved under autoplay, the platform planners never see a bare
reach, so the Path B machinery is unreachable. Removed `ReachState`,
`PlanResult::inject_reach_for_followup` / `awaiting_riichi_dahai`, and the
manager's synthetic-`Reach` bus injection. The `AwaitingDahai` branches were
behaviour-preserving constants on the live Path A, so their removal changes
nothing. The Majsoul planner's tile-less reach now declines cleanly instead of
pressing the button half.

## Known limitation

If the autoplay reach press is lost after the follow-up (a rare failure the
manager already detects), the bot's state can still drift. Accepted as a known
limitation and surfaced via the existing transient "Riichi did not go through"
toast, now also noting the bot's view may be off.

## Tests

- `bot::manager`: 4 new regression tests — follow-up fills `pai` and drops the
  bridge echo; analysis mode leaves the bare reach untouched and forwards the
  echo; a pre-filled `pai` skips the follow-up; the drop flag clears on a kyoku
  boundary.
- `autoplay::majsoul`: new `reach_without_pai_declines`; removed four tests that
  covered the deleted Path B; test helper updated.
- `cargo fmt` / `clippy` clean; `cargo test --lib` — 890 pass.
