### PR TITLE
feat(proxy): block Aliyun SLS telemetry beacons

### DIFF
--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -301,6 +301,8 @@
     "capture_chromium_option": "Chromium browser (experimental)",
     "capture_mitm_only": "This platform has no web client — MITM capture only.",
     "proxy_enabled": "Proxy enabled",
+    "block_telemetry": "Block game telemetry",
+    "block_telemetry_hint": "Drop the game's Aliyun analytics beacons instead of forwarding them, so login stats and device / account identifiers never leave your machine. Many ad blockers already block this host, so a missing beacon is not a sign of a tool. On by default.",
     "ca_dir_hint": "Where root certificate / keys are written.",
     "browser_executable": "Browser executable",
     "browser_executable_hint": "Leave blank to auto-detect.",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -301,6 +301,8 @@
     "capture_chromium_option": "Chromium ブラウザ（実験的）",
     "capture_mitm_only": "このプラットフォームには Web クライアントがありません — MITM キャプチャのみ対応です。",
     "proxy_enabled": "プロキシを有効化",
+    "block_telemetry": "ゲームのテレメトリをブロック",
+    "block_telemetry_hint": "ゲームがAliyunへ送る分析ビーコンを転送せずに破棄し、ログイン統計や端末・アカウント識別子が端末外に出ないようにします。多くの広告ブロッカーもこのホストを遮断するため、ビーコンが無いことはツール使用の証拠にはなりません。既定でオン。",
     "ca_dir_hint": "ルート証明書／鍵を書き出すディレクトリです。",
     "browser_executable": "ブラウザ実行ファイル",
     "browser_executable_hint": "空欄にすると自動検出します。",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -301,6 +301,8 @@
     "capture_chromium_option": "Chromium 浏览器(实验性)",
     "capture_mitm_only": "该平台没有网页客户端 — 仅支持 MITM 抓取。",
     "proxy_enabled": "启用代理",
+    "block_telemetry": "屏蔽游戏遥测",
+    "block_telemetry_hint": "丢弃游戏发往阿里云的分析遥测数据而不转发,让登录统计、设备与账号标识符完全不离开你的电脑。许多广告拦截器本来就会屏蔽该主机,因此缺少遥测数据并不代表使用了工具。默认开启。",
     "ca_dir_hint": "CA 根证书／密钥写入的目录。",
     "browser_executable": "浏览器可执行文件",
     "browser_executable_hint": "留空以自动检测。",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -301,6 +301,8 @@
     "capture_chromium_option": "Chromium 瀏覽器(實驗性)",
     "capture_mitm_only": "此平台沒有網頁用戶端 — 僅支援 MITM 擷取。",
     "proxy_enabled": "啟用代理",
+    "block_telemetry": "封鎖遊戲遙測",
+    "block_telemetry_hint": "丟棄遊戲送往阿里雲的分析遙測封包而不轉發,讓登入統計、裝置與帳號識別碼完全不離開你的電腦。許多廣告攔截器本來就會封鎖這個主機,因此缺少遙測封包並不代表使用了工具。預設開啟。",
     "ca_dir_hint": "CA 根憑證／金鑰寫入的目錄。",
     "browser_executable": "瀏覽器執行檔",
     "browser_executable_hint": "留空以自動偵測。",

--- a/frontend/src/lib/setupDefaults.test.ts
+++ b/frontend/src/lib/setupDefaults.test.ts
@@ -15,7 +15,7 @@ function makeConfig(over: {
     },
     logging: { dir: '', level: 'info', all_level: 'warn' },
     platform: { kind: over.platform ?? 'Majsoul' },
-    proxy: { enabled: true, addr: '127.0.0.1:23410', ca_dir: '' },
+    proxy: { enabled: true, addr: '127.0.0.1:23410', ca_dir: '', block_telemetry: true },
     bot: {
       enabled: true,
       active_4p: 'akagi-native',

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1178,6 +1178,14 @@ function CaptureCard({
                 onChange={(e) => setDraft({ ...draft, proxy: { ...draft.proxy, ca_dir: e.target.value } })}
               />
             </Field>
+            <Toggle
+              label={t('settings.block_telemetry')}
+              value={draft.proxy.block_telemetry}
+              onChange={(v) => setDraft({ ...draft, proxy: { ...draft.proxy, block_telemetry: v } })}
+            />
+            <span className="text-xs text-muted-foreground">
+              {t('settings.block_telemetry_hint')}
+            </span>
           </>
         )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -195,7 +195,7 @@ export type AppConfig = {
   general: { first_run_completed: boolean; developer_mode: boolean }
   logging: { dir: string; level: string; all_level: string }
   platform: { kind: PlatformKind }
-  proxy: { enabled: boolean; addr: string; ca_dir: string }
+  proxy: { enabled: boolean; addr: string; ca_dir: string; block_telemetry: boolean }
   bot: {
     enabled: boolean
     active_4p: string

--- a/src/config/proxy.rs
+++ b/src/config/proxy.rs
@@ -20,6 +20,27 @@ pub struct ProxyConfig {
     /// browser cannot report peer certificates in the first place.
     /// See `src/proxy/rewrite/majsoul_cert.rs`.
     pub rewrite_certificate_report: bool,
+    /// Drop the game client's Aliyun SLS web-tracking (telemetry) beacons
+    /// instead of forwarding them upstream.
+    ///
+    /// On by default. The client fires these fire-and-forget analytics
+    /// beacons at `*.log.aliyuncs.com/logstores/<store>/track`, reporting on
+    /// itself — login stats, game status, device/account identifiers. Many
+    /// ad blockers already block that host, so a missing beacon is
+    /// indistinguishable from an ad-blocked one and is not evidence of a
+    /// third-party tool; dropping them keeps that data from leaving the
+    /// machine at all.
+    ///
+    /// Takes precedence over `rewrite_certificate_report`: when this is on
+    /// the Mahjong Soul certificate report is dropped along with every other
+    /// beacon, so there is nothing left to rewrite (and nothing left to leak
+    /// Akagi's CA before the genuine upstream certificate has been
+    /// observed). Turn this off to forward the beacons — the certificate
+    /// report then still gets corrected.
+    ///
+    /// MITM-mode only: the chromium backend intercepts nothing to drop.
+    /// See `src/proxy/handler.rs`.
+    pub block_telemetry: bool,
 }
 
 impl Default for ProxyConfig {
@@ -29,6 +50,7 @@ impl Default for ProxyConfig {
             addr: "127.0.0.1:23410".to_string(),
             ca_dir: PathBuf::from("./ca"),
             rewrite_certificate_report: true,
+            block_telemetry: true,
         }
     }
 }
@@ -44,13 +66,21 @@ mod tests {
         assert!(ProxyConfig::default().rewrite_certificate_report);
     }
 
-    /// A `config.toml` written before the field existed must still load,
-    /// and must pick up the default rather than silently disabling it.
+    /// Telemetry blocking is on by default — the whole point is that it
+    /// protects without the user having to know the beacons exist.
+    #[test]
+    fn telemetry_is_blocked_by_default() {
+        assert!(ProxyConfig::default().block_telemetry);
+    }
+
+    /// A `config.toml` written before either field existed must still load,
+    /// and must pick up the defaults rather than silently disabling them.
     #[test]
     fn older_configs_gain_the_correction() {
         let cfg: ProxyConfig =
             toml::from_str("enabled = true\naddr = \"127.0.0.1:23410\"\nca_dir = \"./ca\"")
                 .expect("older config must still parse");
         assert!(cfg.rewrite_certificate_report);
+        assert!(cfg.block_telemetry);
     }
 }

--- a/src/inspector/annotate/README.md
+++ b/src/inspector/annotate/README.md
@@ -23,9 +23,12 @@ annotation from its `kind` / `summary` / `data` without knowing what produced it
 
 When the proxy declines to intercept something, that decision is recorded as an
 annotation on the CONNECT (`akagi_bypass`), and a response we could not attribute
-to a request is marked too (`akagi_unpaired`). A blind spot that announces itself
-is not a blind spot — a timeline that silently omits what we could not see is
-indistinguishable from one where the game never sent it.
+to a request is marked too (`akagi_unpaired`). When the proxy *drops* a request
+instead of forwarding it — an Aliyun SLS telemetry beacon, when `block_telemetry`
+is on — that too is recorded (`akagi_blocked`), alongside the beacon's own
+`sls_beacon` annotation so the timeline still shows what was dropped. A blind spot
+that announces itself is not a blind spot — a timeline that silently omits what we
+could not see is indistinguishable from one where the game never sent it.
 
 ## Adding a recognizer
 

--- a/src/proxy/README.md
+++ b/src/proxy/README.md
@@ -44,6 +44,7 @@ Lives under `[proxy]` in `config.toml`:
 enabled = true
 addr = "127.0.0.1:23410"
 ca_dir = "./ca"
+block_telemetry = true
 ```
 
 ## HTTP capture
@@ -118,6 +119,36 @@ the correction is still complete after a client update. MITM-only; a
 browser cannot report peer certificates at all, so the chromium backend
 has nothing to correct. Covered by `tests/proxy_cert_report_rewrite.rs`,
 which stands up a real TLS origin and asserts on what left the machine.
+
+## Telemetry beacons are blocked
+
+The game clients report on themselves through Aliyun SLS **web-tracking**
+beacons — fire-and-forget requests to `*.log.aliyuncs.com/logstores/<store>/track`
+carrying login stats, game status, and device / account identifiers (the
+`certificate_info` beacon above is one of these). `handle_request` drops
+every one the recognizer matches instead of forwarding it, answering the
+client with the same empty `200` the real endpoint returns —
+`handler.rs::block_telemetry_beacon`.
+
+We used to forward them on the theory that a *missing* beacon might itself
+be a signal. It is not: many ad blockers already block that host, so a
+missing beacon is indistinguishable from an ad-blocked one. Dropping them
+keeps that data from leaving the machine at all.
+
+Blocking takes precedence over the certificate-report correction above:
+when it is on, the `certificate_info` beacon is dropped along with every
+other beacon, so there is nothing left to rewrite — and nothing that could
+leak Akagi's CA in the window before the genuine upstream certificate has
+been observed. The drop is still recorded on the timeline (`akagi_blocked`
+plus the beacon's own `sls_beacon` annotation): an announced gap is not a
+blind spot.
+
+Switched by `[proxy] block_telemetry` (default **on**). Turn it off to
+forward the beacons — the certificate report is then corrected instead of
+dropped. MITM-only; the chromium backend intercepts nothing to drop.
+Covered by `tests/proxy_telemetry_block.rs`, which asserts a beacon is
+answered locally and never reaches the upstream while ordinary traffic
+still forwards.
 
 ## Adding traffic interception
 

--- a/src/proxy/handler.rs
+++ b/src/proxy/handler.rs
@@ -86,6 +86,9 @@ pub struct ProxyHandler {
     /// Whether to correct the client's certificate report. See
     /// `rewrite::majsoul_cert`.
     rewrite_cert_report: bool,
+    /// Whether to drop the game's Aliyun SLS telemetry beacons instead of
+    /// forwarding them. See `block_telemetry_beacon`.
+    block_telemetry: bool,
 }
 
 impl ProxyHandler {
@@ -102,6 +105,7 @@ impl ProxyHandler {
         http_policy: HttpCapturePolicy,
         certs: Arc<CertStore>,
         rewrite_cert_report: bool,
+        block_telemetry: bool,
     ) -> anyhow::Result<Self> {
         let binary = session.binary_logger("proxy")?;
         let inspector = session.inspector();
@@ -121,6 +125,7 @@ impl ProxyHandler {
             pairing: Arc::new(ExchangePairing::default()),
             certs,
             rewrite_cert_report,
+            block_telemetry,
         })
     }
 
@@ -184,6 +189,83 @@ impl ProxyHandler {
             source: CaptureSource::Mitm,
             exchange,
         });
+    }
+
+    /// Drop an Aliyun SLS web-tracking beacon instead of forwarding it, and
+    /// record the drop on the timeline.
+    ///
+    /// Returns the synthetic response to answer the client with when `req`
+    /// is such a beacon, or `None` for ordinary traffic that must be
+    /// forwarded unchanged. The recognizer is the same path-based one the
+    /// annotator uses, so anything the timeline would label `sls_beacon` is
+    /// exactly what gets blocked.
+    ///
+    /// The genuine endpoint answers `200` with an empty body, so that is
+    /// what we return — indistinguishable from an ad blocker or the real
+    /// server, and the client fires these fire-and-forget so it never reads
+    /// the reply anyway. The drop is still recorded (with the beacon's own
+    /// annotation plus an `akagi_blocked` marker): an annotated gap is not a
+    /// gap, exactly as with the raw-tunnel bypass in `should_intercept`.
+    fn block_telemetry_beacon(&self, req: &Request<Body>) -> Option<Response<Body>> {
+        annotate::sls::parse_uri(req.uri())?;
+
+        let method = req.method().to_string();
+        let url = req.uri().to_string();
+        let host = req
+            .uri()
+            .host()
+            .map(str::to_string)
+            .or_else(|| {
+                req.headers()
+                    .get(hyper::header::HOST)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|h| h.split(':').next().unwrap_or(h).to_string())
+            })
+            .unwrap_or_default();
+        let headers = httpcap::headers_of(req.headers());
+
+        // Keep the beacon's own annotation so the timeline still shows what
+        // it was (logstore, log_category, params), then mark that Akagi
+        // dropped it rather than forwarded it.
+        let mut annotations =
+            annotate::annotate_request(&RequestView::new(&method, &url, &headers));
+        annotations.push(HttpAnnotation {
+            kind: "akagi_blocked".to_string(),
+            summary: "telemetry blocked — not forwarded".to_string(),
+            data: serde_json::json!({
+                "reason": "Aliyun SLS web-tracking beacon dropped before it left the machine; \
+                           many ad blockers block this host too, so a missing beacon is not a signal",
+            }),
+        });
+
+        info!(
+            target: "akagi::proxy::http",
+            "blocked telemetry beacon on {host}: {url}",
+        );
+
+        self.inspector.record(InspectorEntry::Http {
+            ts_ms: Local::now().timestamp_millis(),
+            source: CaptureSource::Mitm,
+            exchange: HttpExchange {
+                exchange_id: None,
+                phase: HttpPhase::Request,
+                method,
+                url,
+                host,
+                version: format!("{:?}", req.version()),
+                status: None,
+                headers,
+                body: None,
+                annotations,
+            },
+        });
+
+        Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(Body::empty())
+                .expect("static telemetry-block response must build"),
+        )
     }
 
     /// Substitute the genuine upstream certificates into a Mahjong Soul
@@ -404,6 +486,15 @@ impl HttpHandler for ProxyHandler {
                 .body(Body::empty())
                 .expect("Failed to build loopback CONNECT refusal")
                 .into();
+        }
+
+        // Telemetry blocking comes first: a dropped beacon is never
+        // forwarded, so there is nothing left for the rewrite below to
+        // correct. See `block_telemetry_beacon`.
+        if self.block_telemetry {
+            if let Some(resp) = self.block_telemetry_beacon(&req) {
+                return resp.into();
+            }
         }
 
         // The one place Akagi deliberately changes what it forwards: the

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -58,6 +58,7 @@ where
         http_cfg.policy(),
         certs.clone(),
         config.rewrite_certificate_report,
+        config.block_telemetry,
     )?;
 
     info!("Starting proxy on {addr}");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -153,6 +153,12 @@ pub struct Harness {
 
 impl Harness {
     pub async fn start(http_cfg: HttpCaptureConfig) -> Self {
+        // Existing capture tests want beacons forwarded and recorded, so the
+        // default harness leaves blocking off. `start_with` opts in.
+        Self::start_with(http_cfg, false).await
+    }
+
+    pub async fn start_with(http_cfg: HttpCaptureConfig, block_telemetry: bool) -> Self {
         let tmp = TempDir::new().expect("tempdir");
         let session = Arc::new(
             Session::init(&tmp.path().join("logs"), "info", "info", &[]).expect("session"),
@@ -165,6 +171,7 @@ impl Harness {
             addr: format!("127.0.0.1:{proxy_port}"),
             ca_dir: tmp.path().join("ca"),
             rewrite_certificate_report: true,
+            block_telemetry,
         };
         let (stop, stop_rx) = oneshot::channel::<()>();
         let task = tokio::spawn(start_proxy(

--- a/tests/proxy_cert_report_rewrite.rs
+++ b/tests/proxy_cert_report_rewrite.rs
@@ -203,6 +203,9 @@ async fn the_report_that_leaves_describes_the_origin_not_akagi() {
             addr: format!("127.0.0.1:{proxy_port}"),
             ca_dir: tmp.path().join("ca"),
             rewrite_certificate_report: true,
+            // This test exercises the rewrite path, which only runs when the
+            // beacon is actually forwarded — so blocking must be off here.
+            block_telemetry: false,
         },
         HttpCaptureConfig::default(),
         Platform::Majsoul,

--- a/tests/proxy_loopback_connect.rs
+++ b/tests/proxy_loopback_connect.rs
@@ -97,6 +97,7 @@ async fn loopback_connect_is_refused_without_blocking() {
         addr: format!("127.0.0.1:{port}"),
         ca_dir: tmp.path().join("ca"),
         rewrite_certificate_report: true,
+        block_telemetry: true,
     };
 
     let notify = notify_bus();

--- a/tests/proxy_telemetry_block.rs
+++ b/tests/proxy_telemetry_block.rs
@@ -1,0 +1,74 @@
+//! With `block_telemetry` on, an Aliyun SLS web-tracking beacon must be
+//! answered by the proxy itself and never reach the upstream — while
+//! ordinary traffic on the same proxy still forwards untouched.
+//!
+//! The stub upstream returns a distinctive body (`UPSTREAM_BODY`). A
+//! forwarded request carries that body back to the client; a blocked one
+//! cannot, because it never reached the upstream. That difference is the
+//! whole proof, so no request counter is needed. Its own binary because
+//! `Session::init` installs a process-global tracing subscriber — see
+//! `tests/common/mod.rs`.
+
+mod common;
+
+use akagi::config::HttpCaptureConfig;
+use common::{get_through_proxy, Harness, BEACON_QUERY, UPSTREAM_BODY};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_beacon_is_blocked_while_ordinary_traffic_forwards() {
+    let h = Harness::start_with(HttpCaptureConfig::default(), true).await;
+
+    // The beacon: recognized by path, so it must be dropped. The client
+    // still gets a 200 (the real endpoint answers the same), but the
+    // upstream body cannot be there because the upstream never saw it.
+    let beacon = h.url(&format!("/logstores/client/track?{BEACON_QUERY}"));
+    let blocked = get_through_proxy(h.proxy_port, &beacon, &h.host()).await;
+    assert!(
+        blocked.contains("200 OK"),
+        "a blocked beacon should still be answered 200: {blocked}"
+    );
+    assert!(
+        !blocked.contains(UPSTREAM_BODY),
+        "a blocked beacon must be answered locally, not from upstream: {blocked}"
+    );
+
+    // The control: an ordinary request down the same proxy must still be
+    // forwarded and come back with the upstream's body. This is what rules
+    // out "the upstream was simply unreachable" as the reason the beacon
+    // body was missing.
+    let routes = h.url("/api/clientgate/routes?platform=Steam_Win");
+    let forwarded = get_through_proxy(h.proxy_port, &routes, &h.host()).await;
+    assert!(
+        forwarded.contains(UPSTREAM_BODY),
+        "ordinary traffic must still forward untouched: {forwarded}"
+    );
+
+    // The drop is recorded, not silent: the beacon is on the timeline with
+    // both its own `sls_beacon` annotation (so we still see what it was) and
+    // the `akagi_blocked` marker (so the action is visible).
+    let entries = h.finish().await;
+    let beacon_row = entries
+        .iter()
+        .find(|e| e["kind"] == "http" && e["url"].as_str().is_some_and(|u| u.contains("/track?")))
+        .expect("the blocked beacon must be on the timeline");
+
+    let kinds: Vec<&str> = beacon_row["annotations"]
+        .as_array()
+        .expect("annotations array")
+        .iter()
+        .map(|a| a["kind"].as_str().unwrap_or_default())
+        .collect();
+    assert!(
+        kinds.contains(&"sls_beacon"),
+        "the beacon's own annotation must survive so we can see what was dropped: {beacon_row}"
+    );
+    assert!(
+        kinds.contains(&"akagi_blocked"),
+        "the drop must announce itself with an akagi_blocked annotation: {beacon_row}"
+    );
+
+    // A dropped request is answered locally, so it never pairs with an
+    // upstream response.
+    assert_eq!(beacon_row["phase"], "request");
+    assert_eq!(beacon_row["status"], serde_json::Value::Null);
+}


### PR DESCRIPTION
Closes #261.

## What

Adds `proxy.block_telemetry` (default **on**): the proxy drops every recognized Aliyun SLS web-tracking beacon (`*.log.aliyuncs.com/logstores/<store>/track`) instead of forwarding it, answering the client with the same empty `200` the real endpoint returns.

The game clients (Mahjong Soul, Riichi City) fire these fire-and-forget beacons to report on themselves — login stats, game status, device/account identifiers, and on Mahjong Soul the TLS certificate chain the client was served. Until now Akagi forwarded all of them and only rewrote the `certificate_info` beacon.

We previously kept forwarding on the theory that a *missing* beacon could itself look like a signal. It does not: many ad blockers already block `*.log.aliyuncs.com`, so a missing beacon is indistinguishable from an ad-blocked one and is not evidence of a third-party tool.

## Behaviour

- Blocking happens in `handle_request`, before the certificate-report rewrite and before any request/response pairing is opened (so no dangling pairing state).
- The drop is recorded on the inspector timeline with an `akagi_blocked` annotation next to the beacon's own `sls_beacon` annotation — an announced gap is not a blind spot.
- **Precedence:** when blocking is on, the Mahjong Soul certificate report is dropped along with every other beacon, so there is nothing to rewrite — and nothing that could leak Akagi's CA in the window before the genuine upstream certificate has been observed. Turn blocking off to forward the beacons; the certificate report is then corrected as before.
- MITM-only; the chromium backend intercepts nothing to drop.

## UI

A "Block game telemetry" toggle in the Settings page (MITM mode section), default on. Labels added for en / zh-TW / zh-CN / ja.

## Tests

- `config::proxy`: default-on and legacy-config-gains-default.
- `tests/proxy_telemetry_block.rs`: with blocking on, a beacon is answered locally (no upstream body) and never reaches the upstream, while an ordinary request on the same proxy still forwards; the timeline carries `sls_beacon` + `akagi_blocked`.
- Existing `proxy_cert_report_rewrite` / `proxy_http_capture` / `proxy_loopback_connect` updated for the new field and still pass.

## Docs

`src/proxy/README.md` (new "Telemetry beacons are blocked" section + config example) and `src/inspector/annotate/README.md` (`akagi_blocked`).