### PR TITLE
fix(bot): open the chankan ron window on the engine's replay path

### DIFF
--- a/native_bot/src/chankan.rs
+++ b/native_bot/src/chankan.rs
@@ -1,0 +1,297 @@
+//! Open the chankan (槍槓) ron window on the mjai replay path.
+//!
+//! riichienv-core 0.4.8 models the chankan window only on its *live action*
+//! path: when a kakan is applied there (`state/mod.rs`, `ActionType::Kakan`),
+//! the engine checks every other seat for a robable hand and, if one exists,
+//! switches to `Phase::WaitResponse` with a `Ron` claim. The mjai *replay*
+//! path (`apply_mjai_event`) — the one Akagi's tracker and the native bot's
+//! engine drive — applies a kakan by moving straight to `WaitAct` for the
+//! declarer and opens nothing.
+//!
+//! Consequence (observed 2026-08-22, West 1): the server offered our seat a
+//! ron on an opponent's added 5p kan, but every consumer of the engine's
+//! legal set — the native bot's candidate enumeration, autoplay's Ron-button
+//! lookup, its Pass-button gate, the tracker's `can_act` — saw an empty set.
+//! The bot answered `none` instantly, autoplay clicked nothing, and the
+//! window hung until the human pressed Ron (the server's own timer would
+//! otherwise have declined it).
+//!
+//! The fix is the live path's own check, re-applied after the fact: whenever
+//! a replayed kakan by another seat lands, re-run the chankan check for our
+//! seat and, when the kan tile completes a yaku-bearing, non-furiten win,
+//! open the same `WaitResponse` window the live path would have opened —
+//! `Ron` in `current_claims`, our seat in `active_players`, and the robbed
+//! tile in `last_discard` (the live path does the same, and it doubles as
+//! the hora's target: the kan declarer pays).
+//!
+//! The window closes itself through the normal event stream: a `Hora` ends
+//! the hand, a `Tsumo`/`Dahai` moves the phase on, and the next `Dahai`
+//! clears `current_claims`.
+//!
+//! An ankan can only be robbed for kokushi musou, which riichienv gates on
+//! `rule.allows_ron_on_ankan_for_kokushi_musou` (off under the Tenhou
+//! defaults Akagi constructs), so ankans intentionally open nothing here.
+
+use riichienv_core::action::{Action, ActionType, Phase};
+use riichienv_core::hand_evaluator::HandEvaluator;
+use riichienv_core::hand_evaluator_3p::HandEvaluator3P;
+use riichienv_core::parser::mjai_to_tid;
+use riichienv_core::state::GameState;
+use riichienv_core::state_3p::GameState3P;
+use riichienv_core::types::{Conditions, Wind};
+
+/// 4-player: open the chankan window for `seat` after `kan_actor` (another
+/// seat) declared a kakan on `pai`. Returns whether the window opened —
+/// i.e. the robbed tile completes a yaku-bearing, non-furiten win.
+pub fn open_on_kakan(state: &mut GameState, kan_actor: u8, pai: &str, seat: u8) -> bool {
+    let Some(tile) = mjai_to_tid(pai) else {
+        return false;
+    };
+    if state.is_done || kan_actor == seat || seat >= 4 {
+        return false;
+    }
+    let us = &state.players[seat as usize];
+    let calc = HandEvaluator::new(us.hand.clone(), us.melds.clone());
+    let waits = calc.get_waits_u8();
+    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)))
+        || us.missed_agari_riichi
+        || us.missed_agari_doujun;
+    let win = !furiten && {
+        let cond = Conditions {
+            tsumo: false,
+            riichi: us.riichi_declared,
+            double_riichi: us.double_riichi_declared,
+            ippatsu: us.ippatsu_cycle,
+            player_wind: Wind::from((seat + 4 - state.oya) % 4),
+            round_wind: Wind::from(state.round_wind),
+            chankan: true,
+            riichi_sticks: state.riichi_sticks,
+            honba: state.honba as u32,
+            ..Default::default()
+        };
+        let res = calc.calc(tile, state.wall.dora_indicators.clone(), vec![], Some(cond));
+        res.is_win && (res.yakuman || res.han >= 1)
+    };
+    if !win {
+        return false;
+    }
+    // Entry-replace, not push: the live path appends into a freshly-cleared
+    // map, but the replay path's map can carry residue for our seat, and
+    // stacking a second identical Ron serves nobody.
+    let ron = Action::new(ActionType::Ron, Some(tile), vec![], Some(seat));
+    state.current_claims.insert(seat, vec![ron]);
+    state.phase = Phase::WaitResponse;
+    state.active_players = vec![seat];
+    // The live path's own trick: treat the robbed tile as the last discard,
+    // both so the observation shows the tile being claimed and so the ron
+    // targets the kan declarer.
+    state.last_discard = Some((kan_actor, tile));
+    true
+}
+
+/// 3-player twin of [`open_on_kakan`] for the sanma engine.
+pub fn open_on_kakan_3p(state: &mut GameState3P, kan_actor: u8, pai: &str, seat: u8) -> bool {
+    let Some(tile) = mjai_to_tid(pai) else {
+        return false;
+    };
+    if state.is_done || kan_actor == seat || seat >= 3 {
+        return false;
+    }
+    let us = &state.players[seat as usize];
+    let calc = HandEvaluator3P::new(us.hand.clone(), us.melds.clone());
+    let waits = calc.get_waits_u8();
+    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)))
+        || us.missed_agari_riichi
+        || us.missed_agari_doujun;
+    let win = !furiten && {
+        let cond = Conditions {
+            tsumo: false,
+            riichi: us.riichi_declared,
+            double_riichi: us.double_riichi_declared,
+            ippatsu: us.ippatsu_cycle,
+            player_wind: Wind::from((seat + 3 - state.oya) % 3),
+            round_wind: Wind::from(state.round_wind),
+            chankan: true,
+            riichi_sticks: state.riichi_sticks,
+            honba: state.honba as u32,
+            is_sanma: true,
+            num_players: 3,
+            ..Default::default()
+        };
+        let res = calc.calc(tile, state.wall.dora_indicators.clone(), vec![], Some(cond));
+        res.is_win && (res.yakuman || res.han >= 1)
+    };
+    if !win {
+        return false;
+    }
+    // Entry-replace, not push — same rationale as the 4p path above.
+    let ron = Action::new(ActionType::Ron, Some(tile), vec![], Some(seat));
+    state.current_claims.insert(seat, vec![ron]);
+    state.phase = Phase::WaitResponse;
+    state.active_players = vec![seat];
+    state.last_discard = Some((kan_actor, tile));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use riichienv_core::replay::MjaiEvent;
+    use riichienv_core::rule::GameRule;
+    use riichienv_core::state::legal_actions::GameStateLegalActions;
+
+    fn ev(line: &str) -> MjaiEvent {
+        serde_json::from_str(line).expect("valid mjai event")
+    }
+
+    /// Menzen tanyao hand waiting on 5s (`234m 567m 234p 567p 5s`) — robbing
+    /// a 5s kakan is a valid ron without riichi.
+    const OUR_HAND: &str = r#"["2m","3m","4m","5m","6m","7m","2p","3p","4p","5p","6p","7p","5s"]"#;
+    /// Same shape but waiting on 8s — nothing to do with a 5s kan.
+    const UNRELATED_HAND: &str =
+        r#"["2m","3m","4m","5m","6m","7m","2p","3p","4p","5p","6p","7p","8s"]"#;
+    /// Seat 0 holds two 5s to pon the third with, plus filler.
+    const KAN_SEAT_HAND: &str =
+        r#"["5s","5s","1p","2p","3p","7p","8p","9p","1z","2z","3z","4z","5z"]"#;
+    const JUNK: &str = r#"["1m","9m","1p","9p","1s","9s","1z","2z","3z","4z","5z","6z","7z"]"#;
+
+    /// Drive a 4p game to just after seat 0 kakans a 5s (pon'd from seat 2
+    /// earlier, fourth copy drawn). `our_hand` seeds seat 1.
+    fn game_at_kakan(our_hand: &str) -> GameState {
+        let mut state = GameState::new(0, true, None, 0, GameRule::default_tenhou());
+        state.apply_mjai_event(ev(r#"{"type":"start_game","names":["a","b","c","d"]}"#));
+        state.apply_mjai_event(ev(&format!(
+            r#"{{"type":"start_kyoku","bakaze":"E","dora_marker":"2m","kyoku":1,"honba":0,
+                 "kyotaku":0,"oya":0,"scores":[25000,25000,25000,25000],
+                 "tehais":[{KAN_SEAT_HAND},{our_hand},{JUNK},{JUNK}]}}"#
+        )));
+        // Seat 2 throws the third 5s; seat 0 pons it.
+        state.apply_mjai_event(ev(r#"{"type":"tsumo","actor":2,"pai":"5s"}"#));
+        state.apply_mjai_event(ev(
+            r#"{"type":"dahai","actor":2,"pai":"5s","tsumogiri":true}"#,
+        ));
+        state.apply_mjai_event(ev(
+            r#"{"type":"pon","actor":0,"target":2,"pai":"5s","consumed":["5s","5s"]}"#,
+        ));
+        // Turn order reaches seat 0 again; it draws the last 5s and kakans.
+        for (actor, pai) in [(0u8, "1z"), (1, "2z"), (2, "3z"), (3, "4z")] {
+            state.apply_mjai_event(ev(&format!(
+                r#"{{"type":"tsumo","actor":{actor},"pai":"{pai}"}}"#
+            )));
+            state.apply_mjai_event(ev(&format!(
+                r#"{{"type":"dahai","actor":{actor},"pai":"{pai}","tsumogiri":true}}"#
+            )));
+        }
+        state.apply_mjai_event(ev(r#"{"type":"tsumo","actor":0,"pai":"5s"}"#));
+        state.apply_mjai_event(ev(r#"{"type":"kakan","actor":0,"pai":"5s"}"#));
+        state
+    }
+
+    #[test]
+    fn robable_kakan_opens_a_ron_pass_window() {
+        let mut state = game_at_kakan(OUR_HAND);
+        assert!(open_on_kakan(&mut state, 0, "5s", 1));
+
+        assert_eq!(state.phase, Phase::WaitResponse);
+        assert_eq!(state.active_players, vec![1]);
+        // The robbed tile is the "discard": the obs's last-discard plane and
+        // the hora's target both read it.
+        let five_s = mjai_to_tid("5s").unwrap();
+        assert_eq!(state.last_discard, Some((0, five_s)));
+
+        let legal = state._get_legal_actions_internal(1);
+        assert!(legal
+            .iter()
+            .any(|a| a.action_type == ActionType::Ron && a.tile == Some(five_s)));
+        assert!(legal.iter().any(|a| a.action_type == ActionType::Pass));
+        // And nobody else was granted a claim — WaitResponse hands every
+        // seat the ubiquitous lone Pass, but no other Ron.
+        assert!(state
+            ._get_legal_actions_internal(2)
+            .iter()
+            .all(|a| a.action_type == ActionType::Pass));
+    }
+
+    #[test]
+    fn kakan_we_cannot_robe_opens_nothing() {
+        let mut state = game_at_kakan(UNRELATED_HAND);
+        assert!(!open_on_kakan(&mut state, 0, "5s", 1));
+        assert_eq!(state.phase, Phase::WaitAct);
+        assert!(state._get_legal_actions_internal(1).is_empty());
+    }
+
+    #[test]
+    fn own_kakan_opens_nothing() {
+        let mut state = game_at_kakan(OUR_HAND);
+        assert!(!open_on_kakan(&mut state, 0, "5s", 0));
+    }
+
+    #[test]
+    fn furiten_blocks_the_window() {
+        let mut state = game_at_kakan(OUR_HAND);
+        // A 5s in our own river makes the wait furiten.
+        state.players[1].discards.push(mjai_to_tid("5s").unwrap());
+        assert!(!open_on_kakan(&mut state, 0, "5s", 1));
+
+        let mut state = game_at_kakan(OUR_HAND);
+        state.players[1].missed_agari_doujun = true;
+        assert!(!open_on_kakan(&mut state, 0, "5s", 1));
+    }
+
+    /// The window must not linger: the rinshan draw after a passed chankan
+    /// moves the engine on, and the next discard clears the claims.
+    #[test]
+    fn window_closes_through_the_normal_event_stream() {
+        let mut state = game_at_kakan(OUR_HAND);
+        assert!(open_on_kakan(&mut state, 0, "5s", 1));
+        // We pass; seat 0 draws its rinshan replacement.
+        state.apply_mjai_event(ev(r#"{"type":"tsumo","actor":0,"pai":"6z"}"#));
+        assert_eq!(state.phase, Phase::WaitAct);
+        assert!(state._get_legal_actions_internal(1).is_empty());
+        state.apply_mjai_event(ev(
+            r#"{"type":"dahai","actor":0,"pai":"6z","tsumogiri":true}"#,
+        ));
+        assert!(!state
+            ._get_legal_actions_internal(1)
+            .iter()
+            .any(|a| a.action_type == ActionType::Ron));
+    }
+
+    /// Sanma twin of [`robable_kakan_opens_a_ron_pass_window`]: same tanyao
+    /// shape, three seats.
+    #[test]
+    fn sanma_robable_kakan_opens_a_ron_pass_window() {
+        use riichienv_core::state_3p::legal_actions::GameState3PLegalActions;
+        let sanma_hand = OUR_HAND; // 234m 567m 234p 567p 5s — tanyao works in sanma
+        let mut state = GameState3P::new(0, true, None, 0, GameRule::default_tenhou());
+        state.apply_mjai_event(ev(r#"{"type":"start_game","names":["a","b","c"]}"#));
+        state.apply_mjai_event(ev(&format!(
+            r#"{{"type":"start_kyoku","bakaze":"E","dora_marker":"2m","kyoku":1,"honba":0,
+                 "kyotaku":0,"oya":0,"scores":[35000,35000,35000],
+                 "tehais":[{KAN_SEAT_HAND},{sanma_hand},{JUNK}]}}"#
+        )));
+        state.apply_mjai_event(ev(r#"{"type":"tsumo","actor":2,"pai":"5s"}"#));
+        state.apply_mjai_event(ev(
+            r#"{"type":"dahai","actor":2,"pai":"5s","tsumogiri":true}"#,
+        ));
+        state.apply_mjai_event(ev(
+            r#"{"type":"pon","actor":0,"target":2,"pai":"5s","consumed":["5s","5s"]}"#,
+        ));
+        for (actor, pai) in [(0u8, "1z"), (1, "2z"), (2, "3z")] {
+            state.apply_mjai_event(ev(&format!(
+                r#"{{"type":"tsumo","actor":{actor},"pai":"{pai}"}}"#
+            )));
+            state.apply_mjai_event(ev(&format!(
+                r#"{{"type":"dahai","actor":{actor},"pai":"{pai}","tsumogiri":true}}"#
+            )));
+        }
+        state.apply_mjai_event(ev(r#"{"type":"tsumo","actor":0,"pai":"5s"}"#));
+        state.apply_mjai_event(ev(r#"{"type":"kakan","actor":0,"pai":"5s"}"#));
+
+        assert!(open_on_kakan_3p(&mut state, 0, "5s", 1));
+        assert_eq!(state.phase, Phase::WaitResponse);
+        let legal = state._get_legal_actions_internal(1);
+        assert!(legal.iter().any(|a| a.action_type == ActionType::Ron));
+        assert!(legal.iter().any(|a| a.action_type == ActionType::Pass));
+    }
+}

--- a/native_bot/src/chankan.rs
+++ b/native_bot/src/chankan.rs
@@ -53,9 +53,15 @@ pub fn open_on_kakan(state: &mut GameState, kan_actor: u8, pai: &str, seat: u8) 
     let us = &state.players[seat as usize];
     let calc = HandEvaluator::new(us.hand.clone(), us.melds.clone());
     let waits = calc.get_waits_u8();
-    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)))
-        || us.missed_agari_riichi
-        || us.missed_agari_doujun;
+    // Own-river furiten only. The live path also consults the missed-agari
+    // flags (temporary / riichi furiten), but `apply_mjai_event` never sets
+    // them — it only ever *clears* `missed_agari_doujun` — so checking them
+    // here would be dead code. The replay path's ordinary discard-ron windows
+    // share the blind spot (`_get_claim_actions_for_player` reads the same
+    // always-false flags): after a declined ron, the engine may offer a ron
+    // the server will not. Autoplay's stray click lands on an empty table and
+    // the next event moves the state on, so the cost stays cosmetic.
+    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)));
     let win = !furiten && {
         let cond = Conditions {
             tsumo: false,
@@ -78,6 +84,13 @@ pub fn open_on_kakan(state: &mut GameState, kan_actor: u8, pai: &str, seat: u8) 
     // Entry-replace, not push: the live path appends into a freshly-cleared
     // map, but the replay path's map can carry residue for our seat, and
     // stacking a second identical Ron serves nobody.
+    //
+    // Deliberately NOT the live path's `pending_kan = Some(..)`: on the
+    // replay path nothing clears that field before the next start_kyoku, so
+    // setting it would tag every later ron of the hand as a chankan in
+    // `evaluate_hora`'s score preview. Leaving it unset costs less and stays
+    // confined to this window — the preview misses the chankan han itself
+    // (see `game_state/score.rs`).
     let ron = Action::new(ActionType::Ron, Some(tile), vec![], Some(seat));
     state.current_claims.insert(seat, vec![ron]);
     state.phase = Phase::WaitResponse;
@@ -100,9 +113,9 @@ pub fn open_on_kakan_3p(state: &mut GameState3P, kan_actor: u8, pai: &str, seat:
     let us = &state.players[seat as usize];
     let calc = HandEvaluator3P::new(us.hand.clone(), us.melds.clone());
     let waits = calc.get_waits_u8();
-    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)))
-        || us.missed_agari_riichi
-        || us.missed_agari_doujun;
+    // Own-river furiten only — the missed-agari flags are never set on the
+    // replay path; see the note in [`open_on_kakan`].
+    let furiten = us.discards.iter().any(|&d| waits.contains(&(d / 4)));
     let win = !furiten && {
         let cond = Conditions {
             tsumo: false,
@@ -124,7 +137,8 @@ pub fn open_on_kakan_3p(state: &mut GameState3P, kan_actor: u8, pai: &str, seat:
     if !win {
         return false;
     }
-    // Entry-replace, not push — same rationale as the 4p path above.
+    // Entry-replace, not push; `pending_kan` stays unset — same rationale as
+    // the 4p path above.
     let ron = Action::new(ActionType::Ron, Some(tile), vec![], Some(seat));
     state.current_claims.insert(seat, vec![ron]);
     state.phase = Phase::WaitResponse;
@@ -227,15 +241,25 @@ mod tests {
     }
 
     #[test]
-    fn furiten_blocks_the_window() {
+    fn own_river_furiten_blocks_the_window() {
         let mut state = game_at_kakan(OUR_HAND);
         // A 5s in our own river makes the wait furiten.
         state.players[1].discards.push(mjai_to_tid("5s").unwrap());
         assert!(!open_on_kakan(&mut state, 0, "5s", 1));
+    }
 
+    /// Characterization, not aspiration: the missed-agari flags are dead on
+    /// the replay path (`apply_mjai_event` never sets them), so the helper
+    /// deliberately ignores them and the window opens anyway. If Akagi ever
+    /// starts maintaining the flags — an ippatsu-patch-style fixup in the
+    /// tracker, or an upstream riichienv fix — flip this test and put the
+    /// flag checks back into the furiten test above.
+    #[test]
+    fn missed_agari_flags_are_ignored_by_design() {
         let mut state = game_at_kakan(OUR_HAND);
         state.players[1].missed_agari_doujun = true;
-        assert!(!open_on_kakan(&mut state, 0, "5s", 1));
+        state.players[1].missed_agari_riichi = true;
+        assert!(open_on_kakan(&mut state, 0, "5s", 1));
     }
 
     /// The window must not linger: the rinshan draw after a passed chankan

--- a/native_bot/src/engine.rs
+++ b/native_bot/src/engine.rs
@@ -172,12 +172,28 @@ impl Engine {
     /// log's `nukidora` has to be renamed to `kita` *before* serde sees it, or
     /// it deserializes into `MjaiEvent::Other` and the event is lost.
     pub fn feed(&mut self, ev: MjaiEvent) {
+        // The chankan check needs the kakan's actor/tile after the event is
+        // applied — `apply_mjai_event` consumes it.
+        let opponent_kakan = match &ev {
+            MjaiEvent::Kakan { actor, pai } if *actor as u8 != self.seat => {
+                Some((*actor as u8, pai.clone()))
+            }
+            _ => None,
+        };
         match &mut self.backend {
-            Backend::Four { state, .. } => state.apply_mjai_event(ev),
+            Backend::Four { state, .. } => {
+                state.apply_mjai_event(ev);
+                if let Some((actor, pai)) = opponent_kakan {
+                    crate::chankan::open_on_kakan(state, actor, &pai, self.seat);
+                }
+            }
             Backend::Three { state, .. } => {
                 let mut ev = ev;
                 sanitize_3p(&mut ev);
-                state.apply_mjai_event(ev)
+                state.apply_mjai_event(ev);
+                if let Some((actor, pai)) = opponent_kakan {
+                    crate::chankan::open_on_kakan_3p(state, actor, &pai, self.seat);
+                }
             }
         }
     }

--- a/native_bot/src/lib.rs
+++ b/native_bot/src/lib.rs
@@ -11,10 +11,13 @@
 //!   riichienv-core state (shared by extraction and inference).
 //! - [`replay`] — drive an mjai game log through the engine, emitting
 //!   `(obs, action, mask)` training samples (extractor side).
+//! - [`chankan`] — open the chankan ron window that riichienv-core's mjai
+//!   replay path skips (used by both live engines below).
 //! - [`model`] / [`engine`] — candle CNN inference (behind the `infer` feature).
 
 pub mod action_codec;
 pub mod adapt;
+pub mod chankan;
 pub mod mjai_compat;
 pub mod obs;
 pub mod replay;

--- a/src/autoplay/majsoul/mod.rs
+++ b/src/autoplay/majsoul/mod.rs
@@ -891,6 +891,75 @@ mod tests {
         assert!(result.steps.is_empty(), "no click while riichi accepted");
     }
 
+    /// Regression (2026-08-22, West 1): a bot `hora` on a robbed kan must
+    /// click the Ron button. The engine's legal set used to be empty after
+    /// an opponent kakan, so the button never resolved and the window hung
+    /// until a human pressed Ron.
+    #[test]
+    fn chankan_hora_clicks_the_ron_button() {
+        let mut snap = snapshot_with_hand(
+            0,
+            vec![
+                "2m", "3m", "4m", "5m", "6m", "7m", "2p", "3p", "4p", "5p", "6p", "7p", "5s",
+            ],
+        );
+        snap.phase = Phase::WaitResponse;
+        let act = MjaiEvent::Hora {
+            actor: 0,
+            target: 1,
+            deltas: None,
+            ura_markers: None,
+        };
+        // What the tracker now offers on a robable kakan: the ron plus the
+        // always-present pass.
+        let legal = vec![
+            Action::new(ActionType::Ron, Some(88), vec![], Some(0)), // 5s
+            Action::new(ActionType::Pass, None, vec![], Some(0)),
+        ];
+        let cfg_ref = cfg();
+        let ctx = ctx_for(&act, &snap, &legal, Some("4z"), None, false, &cfg_ref);
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert_eq!(result.steps.len(), 2, "sleep + ron click, got {result:?}");
+        match &result.steps[1] {
+            Step::Click { x_norm, y_norm } => {
+                // [Ron, Pass] sorted by priority → Ron in slot 1, one left
+                // of the always-rightmost pass.
+                assert_eq!(*x_norm, 8.637_5);
+                assert_eq!(*y_norm, 7.0);
+            }
+            _ => panic!("second step should be a click"),
+        }
+    }
+
+    /// The decline side of the same window: a bot `none` on a robbed kan
+    /// must click the pass button rather than leave the client hanging.
+    #[test]
+    fn chankan_decline_clicks_the_pass_button() {
+        let mut snap = snapshot_with_hand(
+            0,
+            vec![
+                "2m", "3m", "4m", "5m", "6m", "7m", "2p", "3p", "4p", "5p", "6p", "7p", "5s",
+            ],
+        );
+        snap.phase = Phase::WaitResponse;
+        let act = MjaiEvent::None;
+        let legal = vec![
+            Action::new(ActionType::Ron, Some(88), vec![], Some(0)), // 5s
+            Action::new(ActionType::Pass, None, vec![], Some(0)),
+        ];
+        let cfg_ref = cfg();
+        let ctx = ctx_for(&act, &snap, &legal, Some("4z"), None, false, &cfg_ref);
+        let result = MajsoulAutoplay::new().plan(&ctx);
+        assert_eq!(result.steps.len(), 2, "sleep + pass click, got {result:?}");
+        match &result.steps[1] {
+            Step::Click { x_norm, y_norm } => {
+                assert_eq!(*x_norm, 10.875);
+                assert_eq!(*y_norm, 7.0);
+            }
+            _ => panic!("second step should be a click"),
+        }
+    }
+
     /// Regression: in sanma, drawing a North while in riichi opens the
     /// kita prompt and Majsoul holds the auto-discard until it is
     /// answered. The bot deciding to tsumogiri the North must decline

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -672,13 +672,13 @@ impl BotManager {
     /// learns the hand is over, and `EndGame` is where the runner is torn
     /// down. They are also once per hand, so flushing them costs nothing.
     ///
-    /// So is another seat's kakan, for a different reason: riichienv does not
-    /// model the chankan window on the path the tracker drives. It applies a
-    /// kakan by moving straight to `WaitAct` for the caller, so our legal set
-    /// comes back empty whether we could rob the kan or not. That is the
-    /// engine having nothing to say rather than saying no, and a robbed kan
-    /// is too expensive to lose to the difference. Kakan is rare enough that
-    /// always asking costs nothing measurable.
+    /// An opponent's kakan used to need an exemption from `can_act` — the
+    /// engine's replay path opened no chankan window, so a robable kan
+    /// looked exactly like an unrobable one. The tracker now opens that
+    /// window itself (`native_bot::chankan`), so a kakan is just another
+    /// claim window: `can_act = true` when the robbed tile completes a win
+    /// for our seat, and the engine genuinely saying "not ours" needs no
+    /// override.
     fn is_decision_point(&self, e: &MjaiEvent, can_act: Option<bool>) -> bool {
         if self.actor_id.is_none() {
             return false;
@@ -691,7 +691,6 @@ impl BotManager {
             | MjaiEvent::Ryukyoku { .. }
             | MjaiEvent::EndKyoku
             | MjaiEvent::EndGame { .. } => true,
-            MjaiEvent::Kakan { .. } => self.opens_a_window(e),
             _ => self.opens_a_window(e) && can_act != Some(false),
         }
     }
@@ -993,13 +992,32 @@ mod tests {
         assert_eq!(calls.lock().await.len(), 1, "shape alone decides");
     }
 
-    /// A robbed kan must still be offered to the bot. riichienv's replay path
-    /// applies a kakan by handing the turn straight back to the caller, so it
-    /// reports `can_act = false` for our seat whether or not we could rob it —
-    /// an engine gap, not an answer, and one that would silently cost a
-    /// chankan.
+    /// A robbed kan is still the bot's call — but through the same door as
+    /// every other claim: the tracker opens the chankan window
+    /// (`native_bot::chankan`), so `can_act = true` is what flushes the ask.
+    /// Regression for the 2026-08-22 West 1 incident: the window used to be
+    /// invisible here too, and the bot was never asked at all.
     #[tokio::test]
-    async fn another_seats_kakan_is_asked_despite_the_engines_missing_window() {
+    async fn robable_kakan_is_asked_through_can_act() {
+        let (mut mgr, calls, _, _, _) = manager_with_mock(vec![]);
+        mgr.handle_tracked(tracked(
+            MjaiEvent::Kakan {
+                actor: 0,
+                pai: "1m".into(),
+                consumed: ["1m".into(), "1m".into(), "1m".into()],
+            },
+            Some(true),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(calls.lock().await.len(), 1, "chankan is the bot's call");
+    }
+
+    /// The other side of the door: a kakan our seat cannot rob is the
+    /// engine saying "not yours", exactly like an unclaimable discard, and
+    /// asking anyway would only produce a guaranteed `none`.
+    #[tokio::test]
+    async fn unrobable_kakan_is_not_our_question() {
         let (mut mgr, calls, _, _, _) = manager_with_mock(vec![]);
         mgr.handle_tracked(tracked(
             MjaiEvent::Kakan {
@@ -1011,11 +1029,7 @@ mod tests {
         ))
         .await
         .unwrap();
-        assert_eq!(
-            calls.lock().await.len(),
-            1,
-            "chankan is still the bot's call"
-        );
+        assert!(calls.lock().await.is_empty());
     }
 
     /// Round and game boundaries flush regardless: they open no decision, but

--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -62,6 +62,15 @@ pub fn calculate_score(
 /// rinshan from `is_rinshan_flag`, ippatsu from `players[actor].ippatsu_cycle`,
 /// chankan from `pending_kan.is_some()` (ron only).
 ///
+/// Known gap: `pending_kan` is never set on the tracker's replay path — only
+/// the live engine sets it, and `native_bot::chankan` deliberately leaves it
+/// unset when it opens the chankan window (nothing would clear it before the
+/// next start_kyoku, so setting it would tag every later ron of the hand as a
+/// chankan). Net effect: a chankan ron's preview under-reports by the chankan
+/// han (and, in the riichi-into-chankan corner, the ippatsu han too — the
+/// tracker's ippatsu patch retires the window on the kakan event before the
+/// chankan check runs; see `tracker.rs`).
+///
 /// `tsumo_first_turn` (tenhou/chiihou) is derived from observable state
 /// rather than `state.is_first_turn` — riichienv-core 0.4.8's mjai-event
 /// handler initializes that flag to `true` on `start_kyoku` and never
@@ -95,6 +104,7 @@ pub fn evaluate_hora_4p(state: &GameState, actor: u8, is_tsumo: bool) -> Option<
         haitei: is_tsumo && state.wall.drawable_count == 0 && !state.is_rinshan_flag,
         houtei: !is_tsumo && state.wall.drawable_count == 0 && !state.is_rinshan_flag,
         rinshan: is_tsumo && state.is_rinshan_flag,
+        // Always false on the replay path — see "Known gap" in the doc above.
         chankan: !is_tsumo && state.pending_kan.is_some(),
         tsumo_first_turn: first_turn,
         player_wind: Wind::from((actor + 4 - state.oya) % 4),
@@ -174,6 +184,7 @@ pub fn evaluate_hora_3p(state: &GameState3P, actor: u8, is_tsumo: bool) -> Optio
         haitei: is_tsumo && state.wall.drawable_count == 0 && !state.is_rinshan_flag,
         houtei: !is_tsumo && state.wall.drawable_count == 0 && !state.is_rinshan_flag,
         rinshan: is_tsumo && state.is_rinshan_flag,
+        // Always false on the replay path — see the 4p variant's doc comment.
         chankan: !is_tsumo && state.pending_kan.is_some(),
         tsumo_first_turn: first_turn,
         player_wind: Wind::from((actor + 3 - state.oya) % 3),

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -176,6 +176,12 @@ impl GameTracker {
                             m.from_who = target;
                         }
                     }
+                    // Runs after `apply_ippatsu_patch_4p`, which has already
+                    // retired every ippatsu window (a kakan is a call) — the
+                    // live path checks chankan with ippatsu still up. Harmless
+                    // for the window itself (chankan is a yaku, so han >= 1
+                    // regardless); only `evaluate_hora`'s preview of an
+                    // ippatsu-plus-chankan ron loses that han.
                     if let Some((actor, pai, seat)) = &opponent_kakan {
                         native_bot::chankan::open_on_kakan(s, *actor, pai, *seat);
                     }
@@ -201,6 +207,7 @@ impl GameTracker {
                             m.from_who = target;
                         }
                     }
+                    // Same ippatsu-ordering caveat as the 4p arm above.
                     if let Some((actor, pai, seat)) = &opponent_kakan {
                         native_bot::chankan::open_on_kakan_3p(s, *actor, pai, *seat);
                     }

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -133,6 +133,18 @@ impl GameTracker {
             None
         };
 
+        // The replay path also opens no chankan window: an opponent's kakan
+        // that our seat could rob must be turned into a real `WaitResponse`
+        // window after it is applied, or every downstream consumer (`can_act`,
+        // the bot's candidate set, autoplay's buttons) sees an empty legal set
+        // and the window hangs (`native_bot::chankan` has the story).
+        let opponent_kakan = match (ev, self.our_seat) {
+            (AkagiEvent::Kakan { actor, pai, .. }, Some(seat)) if *actor != seat => {
+                Some((*actor, pai.clone(), seat))
+            }
+            _ => None,
+        };
+
         let Some(ri) = convert::to_riichienv(ev)? else {
             return Ok(()); // Skipped (e.g. MjaiEvent::None).
         };
@@ -164,6 +176,9 @@ impl GameTracker {
                             m.from_who = target;
                         }
                     }
+                    if let Some((actor, pai, seat)) = &opponent_kakan {
+                        native_bot::chankan::open_on_kakan(s, *actor, pai, *seat);
+                    }
                 }
                 TrackedGame::Three(s) => {
                     s.apply_mjai_event(ri);
@@ -185,6 +200,9 @@ impl GameTracker {
                         if let Some(m) = s.players.get_mut(actor).and_then(|p| p.melds.last_mut()) {
                             m.from_who = target;
                         }
+                    }
+                    if let Some((actor, pai, seat)) = &opponent_kakan {
+                        native_bot::chankan::open_on_kakan_3p(s, *actor, pai, *seat);
                     }
                 }
             }
@@ -612,6 +630,107 @@ mod tests {
         })
         .unwrap();
         t.handle(&dahai(0, "5s")).unwrap();
+        assert_eq!(t.our_seat_can_act(), Some(false));
+    }
+
+    /// Drive a kyoku to just after seat 1 kakans the 5s it pon'd earlier.
+    /// `our_hand` seeds our seat (0); opponents' hands stay hidden exactly
+    /// as the bridge feeds them.
+    fn drive_to_kakan(our_hand: &[&str]) -> GameTracker {
+        let mut t = GameTracker::new();
+        t.handle(&start_game()).unwrap();
+        let ours: Vec<String> = our_hand.iter().map(|s| s.to_string()).collect();
+        let hidden: Vec<String> = (0..13).map(|_| "?".into()).collect();
+        t.handle(&AkagiEvent::StartKyoku {
+            bakaze: "E".into(),
+            dora_marker: "2m".into(),
+            kyoku: 1,
+            honba: 0,
+            kyotaku: 0,
+            oya: 0,
+            scores: vec![25_000, 25_000, 25_000, 25_000],
+            tehais: vec![ours, hidden.clone(), hidden.clone(), hidden.clone()],
+            num_players: 4,
+        })
+        .unwrap();
+        // Seat 2 throws a 5s; seat 1 pons it.
+        t.handle(&AkagiEvent::Tsumo {
+            actor: 2,
+            pai: "?".into(),
+        })
+        .unwrap();
+        t.handle(&dahai(2, "5s")).unwrap();
+        t.handle(&AkagiEvent::Pon {
+            actor: 1,
+            target: 2,
+            pai: "5s".into(),
+            consumed: ["5s".into(), "5s".into()],
+        })
+        .unwrap();
+        // Turn order reaches seat 1 again; it draws the last 5s and kakans.
+        // Hidden seats draw `?`; our own draw and every discard are real —
+        // that is exactly what the bridge feeds.
+        for (actor, draw, discard) in [(1u8, "?", "1z"), (2, "?", "3z"), (3, "?", "4z")] {
+            t.handle(&AkagiEvent::Tsumo {
+                actor,
+                pai: draw.into(),
+            })
+            .unwrap();
+            t.handle(&dahai(actor, discard)).unwrap();
+        }
+        t.handle(&AkagiEvent::Tsumo {
+            actor: 0,
+            pai: "2z".into(),
+        })
+        .unwrap();
+        t.handle(&dahai(0, "2z")).unwrap();
+        t.handle(&AkagiEvent::Tsumo {
+            actor: 1,
+            pai: "5s".into(),
+        })
+        .unwrap();
+        t.handle(&AkagiEvent::Kakan {
+            actor: 1,
+            pai: "5s".into(),
+            consumed: ["5s".into(), "5s".into(), "5s".into()],
+        })
+        .unwrap();
+        t
+    }
+
+    /// Regression (2026-08-22, West 1): an opponent's kakan that completes
+    /// our hand must surface as a real decision window — `can_act` true and
+    /// a legal Ron — not as engine silence that leaves the bot unasked and
+    /// autoplay with nothing to click until a human takes the ron.
+    #[test]
+    fn can_act_on_a_kakan_we_can_rob() {
+        // Menzen tanyao waiting on 5s (`234m 567m 234p 567p 5s`).
+        let t = drive_to_kakan(&[
+            "2m", "3m", "4m", "5m", "6m", "7m", "2p", "3p", "4p", "5p", "6p", "7p", "5s",
+        ]);
+        assert_eq!(t.our_seat_can_act(), Some(true));
+
+        let legal = t.state().unwrap()._get_legal_actions_internal(0);
+        assert!(
+            legal
+                .iter()
+                .any(|a| a.action_type == riichienv_core::action::ActionType::Ron),
+            "the robbed 5s must be a legal ron (legal: {legal:?})"
+        );
+        assert_eq!(
+            t.snapshot().unwrap().phase,
+            crate::game_state::snapshot::Phase::WaitResponse
+        );
+    }
+
+    /// A kakan our hand has no claim on is the engine saying "not yours" —
+    /// same as an unclaimable discard.
+    #[test]
+    fn cannot_act_on_a_kakan_we_cannot_rob() {
+        // Same shape but waiting on 8s.
+        let t = drive_to_kakan(&[
+            "2m", "3m", "4m", "5m", "6m", "7m", "2p", "3p", "4p", "5p", "6p", "7p", "8s",
+        ]);
         assert_eq!(t.our_seat_can_act(), Some(false));
     }
 


### PR DESCRIPTION
## Summary

A ron offered on an opponent's added kan (chankan, 槍槓) hung the client until the human pressed the button or the server timer declined it. Observed 2026-08-22, West 1: the server offered a type-9 Ron on an added 5p kan; the bot answered `none` in 0 ms, autoplay clicked nothing, and after 16 s of dead window the player took the ron manually (+3900). Without the manual click the server timer would have auto-declined the hand.

## Root cause

riichienv-core 0.4.8 models the chankan window only on its **live action** path. The mjai **replay** path — the one both `GameTracker` and the native bot's `Engine` drive via `apply_mjai_event` — applies an opponent's kakan by moving straight to `WaitAct` for the declarer and opens no response window. Every consumer of the engine's legal set then saw an empty set:

- the native bot's `decide()` returned `None` in 0 ms (no inference even ran),
- autoplay's Ron-button lookup (`legal_op_set`) found no Ron,
- autoplay's Pass gate (`pass_button_visible` + `Phase::WaitResponse`) was closed, so it could not even decline,
- the tracker reported `can_act = false`.

The server's wire `operation` (type 9) was only ever mined for the think-time budget. Tenhou got a dedicated fix for this bug class in 03b11fe (wire-driven decision window); the Majsoul side never did.

## Changes

- **`native_bot/src/chankan.rs`** (new): `open_on_kakan` (4p) and `open_on_kakan_3p` (sanma) re-apply the live path's own check after a replayed opponent kakan — win via `HandEvaluator` under `chankan: true` conditions, furiten via own river (the missed-agari flags are never set on the replay path, so the flag arms were dropped as dead code — `chankan.rs` has the note and a characterization test). When our seat can rob the kan, they open the same window the live path would: `Ron` in `current_claims`, `phase = WaitResponse`, our seat in `active_players`, and the robbed tile in `last_discard` (doubles as the hora target — the kan declarer pays — and the observation's claimable-tile plane). The window closes itself through the normal event stream; a later `Dahai` clears the claims.
- **`native_bot/src/engine.rs`**: `Engine::feed` calls the helper after an opponent kakan, so the bot sees `[Ron, Pass]` and the model ranks taking the ron versus passing.
- **`src/game_state/tracker.rs`**: `GameTracker::handle` does the same, feeding autoplay's button set and the `can_act` gate.
- **`src/bot/manager.rs`**: the now-redundant `Kakan` exemption in `is_decision_point` is removed — `can_act` flushes the ask on a robable kan like any other claim, and an unrobable one is the engine saying "not ours" like an unclaimable discard.

No changes to the bridge or the majsoul planner logic: once the legal set is right, the existing Ron/Pass click paths work unmodified. Tenhou and Riichi City benefit too, since the tracker and native engine are platform-agnostic — the fix is cross-platform, not Majsoul-specific.

## Scope notes

- Ankans intentionally open nothing: robbing one is kokushi-only and gated on `rule.allows_ron_on_ankan_for_kokushi_musou`, which Akagi's Tenhou-default rule set disables (enabling it platform-aware is a follow-up of its own).
- The training extractor (`native_bot/src/replay.rs`) is untouched.

## Testing

- [x] New unit tests: window opens with the kan declarer as target / unrobable, own, and furiten kans open nothing / window self-closes through the rinshan draw / sanma twin (7 tests in `chankan.rs`).
- [x] Tracker regression: `can_act` true + legal Ron on a robable kakan; false on an unrobable one (2 tests).
- [x] Bot manager: robable kakan asked via `can_act`; unrobable not asked (2 tests).
- [x] Majsoul planner: bot `hora` clicks the Ron button (slot 1) and a decline clicks Pass (rightmost) in that window (2 tests).
- [x] `cargo fmt` clean; clippy reports nothing new.
- [x] Full suites: `native_bot` 44/44; main crate 893 passed, 3 failures verified pre-existing on pristine `origin/v3` (delay-script and moved-venv tests, unrelated).

