### PR TITLE
feat(history): record match room, rank lobby and game id per game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "mlua",
  "native_bot",
  "opener",
+ "percent-encoding",
  "prost",
  "prost-build",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ rand = "0.9"
 http = "1"
 http-body-util = "0.1.4"
 form_urlencoded = "1.2.2"
+# Tenhou `<UN/>` roster names are bare percent-encoded UTF-8 (no `+`-as-space
+# form semantics, so `form_urlencoded` would be wrong for them).
+percent-encoding = "2.3"
 time = "0.3"
 self-replace = "1"
 semver = "1"

--- a/frontend/src/components/history/GameDetailDialog.tsx
+++ b/frontend/src/components/history/GameDetailDialog.tsx
@@ -3,7 +3,9 @@
 // Mirrors the GameRecord shape directly — no re-aggregation needed.
 
 import { useTranslation } from 'react-i18next'
+import { ExternalLink } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -19,6 +21,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { openExternal } from '@/lib/external'
+import { matchGameId, paifuUrl, roomLabelKey } from '@/lib/matchInfo'
 import type { GameRecord } from '@/types'
 
 const STARTING_4P = 25_000
@@ -34,6 +38,9 @@ export function GameDetailDialog({
   const { t } = useTranslation()
   const open = record !== null
   const start = record?.num_players === 3 ? STARTING_3P : STARTING_4P
+  const room = roomLabelKey(record?.match_info)
+  const gameId = matchGameId(record?.match_info)
+  const replayUrl = paifuUrl(record?.match_info)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -73,6 +80,29 @@ export function GameDetailDialog({
                     : t('history.filter.other')}
               </span>
             </Section>
+            {room && (
+              <Section title={t('history.detail.room')}>
+                <span className="text-sm">{t(room.key, room.params)}</span>
+              </Section>
+            )}
+            {gameId && (
+              <Section title={t('history.detail.game_id')}>
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-xs break-all">{gameId}</span>
+                  {replayUrl && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 shrink-0"
+                      onClick={() => openExternal(replayUrl)}
+                    >
+                      <ExternalLink className="h-3 w-3 mr-1" />
+                      {t('history.detail.open_paifu')}
+                    </Button>
+                  )}
+                </div>
+              </Section>
+            )}
 
             <Section title={t('history.detail.final')}>
               <Table>

--- a/frontend/src/components/history/GameDetailDialog.tsx
+++ b/frontend/src/components/history/GameDetailDialog.tsx
@@ -40,7 +40,7 @@ export function GameDetailDialog({
   const start = record?.num_players === 3 ? STARTING_3P : STARTING_4P
   const room = roomLabelKey(record?.match_info)
   const gameId = matchGameId(record?.match_info)
-  const replayUrl = paifuUrl(record?.match_info)
+  const replayUrl = paifuUrl(record?.match_info, record?.our_seat)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/history/GameList.tsx
+++ b/frontend/src/components/history/GameList.tsx
@@ -18,6 +18,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { invoke } from '@/lib/tauri'
+import { roomLabelKey } from '@/lib/matchInfo'
 import { computePt, type PtRule } from '@/lib/ptCalc'
 import { useHistoryStore } from '@/stores/historyStore'
 import type { GameRecord } from '@/types'
@@ -77,6 +78,7 @@ export function GameList({
               <TableRow>
                 <TableHead>{t('history.table.date')}</TableHead>
                 <TableHead>{t('history.table.platform')}</TableHead>
+                <TableHead>{t('history.table.room')}</TableHead>
                 <TableHead>{t('history.table.mode')}</TableHead>
                 <TableHead>{t('history.table.rank')}</TableHead>
                 <TableHead className="text-right">
@@ -91,6 +93,7 @@ export function GameList({
                 const pt = computePt(r, rule)
                 const score =
                   r.our_seat == null ? null : r.final_scores[r.our_seat]
+                const room = roomLabelKey(r.match_info)
                 return (
                   <TableRow
                     key={r.id}
@@ -102,6 +105,9 @@ export function GameList({
                     </TableCell>
                     <TableCell>
                       {t(`platform.${r.platform}`)}
+                    </TableCell>
+                    <TableCell>
+                      {room ? t(room.key, room.params) : '—'}
                     </TableCell>
                     <TableCell>{modeLabel(r, t)}</TableCell>
                     <TableCell>{r.our_rank ?? '—'}</TableCell>

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -107,11 +107,16 @@
       "tenhou_tokujou": "Expert",
       "tenhou_houou": "Phoenix",
       "tenhou_lobby": "Lobby {{lobby}}",
-      "rc_star": "Star Room",
-      "rc_moon": "Moon Room",
-      "rc_sun": "Sun Room",
-      "rc_galaxy": "Galaxy Room",
-      "raw": "Room #{{id}}"
+      "rc_star": "Star",
+      "rc_moon": "Moon",
+      "rc_sun": "Sun",
+      "rc_galaxy": "Galaxy",
+      "raw": "Room #{{id}}",
+      "rc_ranked": "Ranked Match",
+      "rc_tournament": "Tournament",
+      "rc_friendly": "Friendly Match",
+      "rc_one_round": "1-Round Challenge",
+      "rc_casual": "Casual Game"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -107,6 +107,10 @@
       "tenhou_tokujou": "Expert",
       "tenhou_houou": "Phoenix",
       "tenhou_lobby": "Lobby {{lobby}}",
+      "rc_star": "Star Room",
+      "rc_moon": "Moon Room",
+      "rc_sun": "Sun Room",
+      "rc_galaxy": "Galaxy Room",
       "raw": "Room #{{id}}"
     }
   },

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -102,6 +102,8 @@
       "majsoul_jade": "Jade Room",
       "majsoul_throne": "Throne Room",
       "majsoul_melee": "Melee Room",
+      "majsoul_friendly": "Friends Room #{{id}}",
+      "majsoul_contest": "Tournament #{{id}}",
       "tenhou_ippan": "General",
       "tenhou_joukyuu": "Advanced",
       "tenhou_tokujou": "Expert",

--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -43,6 +43,7 @@
     "table": {
       "date": "Date",
       "platform": "Platform",
+      "room": "Room",
       "mode": "Mode",
       "rank": "Rank",
       "end_score": "End Score",
@@ -83,6 +84,9 @@
       "ended_at": "End",
       "platform": "Platform",
       "mode": "Mode",
+      "room": "Room",
+      "game_id": "Game ID",
+      "open_paifu": "Open replay",
       "final": "Final standings",
       "stats": "Detailed stats",
       "open_log": "Open event stream",
@@ -90,7 +94,21 @@
       "seat_fallback": "Seat {{seat}}"
     },
     "delete_confirm": "Delete this game record permanently? This cannot be undone.",
-    "deleted": "Deleted"
+    "deleted": "Deleted",
+    "room": {
+      "majsoul_bronze": "Bronze Room",
+      "majsoul_silver": "Silver Room",
+      "majsoul_gold": "Gold Room",
+      "majsoul_jade": "Jade Room",
+      "majsoul_throne": "Throne Room",
+      "majsoul_melee": "Melee Room",
+      "tenhou_ippan": "General",
+      "tenhou_joukyuu": "Advanced",
+      "tenhou_tokujou": "Expert",
+      "tenhou_houou": "Phoenix",
+      "tenhou_lobby": "Lobby {{lobby}}",
+      "raw": "Room #{{id}}"
+    }
   },
   "logs": {
     "title": "Logs",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -102,6 +102,8 @@
       "majsoul_jade": "玉の間",
       "majsoul_throne": "王座の間",
       "majsoul_melee": "乱闘の間",
+      "majsoul_friendly": "友人対戦 #{{id}}",
+      "majsoul_contest": "大会 #{{id}}",
       "tenhou_ippan": "一般卓",
       "tenhou_joukyuu": "上級卓",
       "tenhou_tokujou": "特上卓",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -107,11 +107,16 @@
       "tenhou_tokujou": "特上卓",
       "tenhou_houou": "鳳凰卓",
       "tenhou_lobby": "個室 {{lobby}}",
-      "rc_star": "星の間",
-      "rc_moon": "月の間",
-      "rc_sun": "日の間",
-      "rc_galaxy": "銀河の間",
-      "raw": "ルーム #{{id}}"
+      "rc_star": "新星",
+      "rc_moon": "霞月",
+      "rc_sun": "炎陽",
+      "rc_galaxy": "銀河",
+      "raw": "ルーム #{{id}}",
+      "rc_ranked": "段位戦",
+      "rc_tournament": "大会戦",
+      "rc_friendly": "友人戦",
+      "rc_one_round": "一局戦",
+      "rc_casual": "娯楽戦"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -43,6 +43,7 @@
     "table": {
       "date": "日時",
       "platform": "プラットフォーム",
+      "room": "卓",
       "mode": "形式",
       "rank": "順位",
       "end_score": "終局点数",
@@ -83,6 +84,9 @@
       "ended_at": "終了時刻",
       "platform": "プラットフォーム",
       "mode": "形式",
+      "room": "卓",
+      "game_id": "対局ID",
+      "open_paifu": "牌譜を開く",
       "final": "最終順位",
       "stats": "詳細統計",
       "open_log": "イベント記録を開く",
@@ -90,7 +94,21 @@
       "seat_fallback": "席 {{seat}}"
     },
     "delete_confirm": "この対局記録を削除しますか？元に戻せません。",
-    "deleted": "削除しました"
+    "deleted": "削除しました",
+    "room": {
+      "majsoul_bronze": "銅の間",
+      "majsoul_silver": "銀の間",
+      "majsoul_gold": "金の間",
+      "majsoul_jade": "玉の間",
+      "majsoul_throne": "王座の間",
+      "majsoul_melee": "乱闘の間",
+      "tenhou_ippan": "一般卓",
+      "tenhou_joukyuu": "上級卓",
+      "tenhou_tokujou": "特上卓",
+      "tenhou_houou": "鳳凰卓",
+      "tenhou_lobby": "個室 {{lobby}}",
+      "raw": "ルーム #{{id}}"
+    }
   },
   "logs": {
     "title": "ログ",

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -107,6 +107,10 @@
       "tenhou_tokujou": "特上卓",
       "tenhou_houou": "鳳凰卓",
       "tenhou_lobby": "個室 {{lobby}}",
+      "rc_star": "星の間",
+      "rc_moon": "月の間",
+      "rc_sun": "日の間",
+      "rc_galaxy": "銀河の間",
       "raw": "ルーム #{{id}}"
     }
   },

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -43,6 +43,7 @@
     "table": {
       "date": "日期",
       "platform": "平台",
+      "room": "房间",
       "mode": "模式",
       "rank": "顺位",
       "end_score": "终局点数",
@@ -83,6 +84,9 @@
       "ended_at": "结束时间",
       "platform": "平台",
       "mode": "模式",
+      "room": "房间",
+      "game_id": "对局 ID",
+      "open_paifu": "打开牌谱",
       "final": "终局排名",
       "stats": "详细统计",
       "open_log": "打开事件流",
@@ -90,7 +94,21 @@
       "seat_fallback": "座位 {{seat}}"
     },
     "delete_confirm": "确定要删除这场对局记录吗？此操作无法撤销。",
-    "deleted": "已删除"
+    "deleted": "已删除",
+    "room": {
+      "majsoul_bronze": "铜之间",
+      "majsoul_silver": "银之间",
+      "majsoul_gold": "金之间",
+      "majsoul_jade": "玉之间",
+      "majsoul_throne": "王座之间",
+      "majsoul_melee": "乱斗之间",
+      "tenhou_ippan": "一般桌",
+      "tenhou_joukyuu": "上级桌",
+      "tenhou_tokujou": "特上桌",
+      "tenhou_houou": "凤凰桌",
+      "tenhou_lobby": "个室 {{lobby}}",
+      "raw": "房间 #{{id}}"
+    }
   },
   "logs": {
     "title": "日志",

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -107,6 +107,10 @@
       "tenhou_tokujou": "特上桌",
       "tenhou_houou": "凤凰桌",
       "tenhou_lobby": "个室 {{lobby}}",
+      "rc_star": "星之间",
+      "rc_moon": "月之间",
+      "rc_sun": "日之间",
+      "rc_galaxy": "银河之间",
       "raw": "房间 #{{id}}"
     }
   },

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -107,11 +107,16 @@
       "tenhou_tokujou": "特上桌",
       "tenhou_houou": "凤凰桌",
       "tenhou_lobby": "个室 {{lobby}}",
-      "rc_star": "星之间",
-      "rc_moon": "月之间",
-      "rc_sun": "日之间",
-      "rc_galaxy": "银河之间",
-      "raw": "房间 #{{id}}"
+      "rc_star": "新星",
+      "rc_moon": "霞月",
+      "rc_sun": "炎阳",
+      "rc_galaxy": "银河",
+      "raw": "房间 #{{id}}",
+      "rc_ranked": "段位战",
+      "rc_tournament": "大会战",
+      "rc_friendly": "友人战",
+      "rc_one_round": "一局战",
+      "rc_casual": "休闲场"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -102,6 +102,8 @@
       "majsoul_jade": "玉之间",
       "majsoul_throne": "王座之间",
       "majsoul_melee": "乱斗之间",
+      "majsoul_friendly": "好友房 #{{id}}",
+      "majsoul_contest": "比赛 #{{id}}",
       "tenhou_ippan": "一般桌",
       "tenhou_joukyuu": "上级桌",
       "tenhou_tokujou": "特上桌",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -102,6 +102,8 @@
       "majsoul_jade": "玉之間",
       "majsoul_throne": "王座之間",
       "majsoul_melee": "亂鬥之間",
+      "majsoul_friendly": "好友房 #{{id}}",
+      "majsoul_contest": "比賽 #{{id}}",
       "tenhou_ippan": "一般桌",
       "tenhou_joukyuu": "上級桌",
       "tenhou_tokujou": "特上桌",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -107,6 +107,10 @@
       "tenhou_tokujou": "特上桌",
       "tenhou_houou": "鳳凰桌",
       "tenhou_lobby": "個室 {{lobby}}",
+      "rc_star": "星之間",
+      "rc_moon": "月之間",
+      "rc_sun": "日之間",
+      "rc_galaxy": "銀河之間",
       "raw": "房間 #{{id}}"
     }
   },

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -43,6 +43,7 @@
     "table": {
       "date": "日期",
       "platform": "平台",
+      "room": "房間",
       "mode": "模式",
       "rank": "順位",
       "end_score": "終局點數",
@@ -83,6 +84,9 @@
       "ended_at": "結束時間",
       "platform": "平台",
       "mode": "模式",
+      "room": "房間",
+      "game_id": "對局 ID",
+      "open_paifu": "開啟牌譜",
       "final": "終局排名",
       "stats": "詳細統計",
       "open_log": "開啟事件流",
@@ -90,7 +94,21 @@
       "seat_fallback": "座位 {{seat}}"
     },
     "delete_confirm": "確定要刪除這場對局紀錄嗎？此動作無法還原。",
-    "deleted": "已刪除"
+    "deleted": "已刪除",
+    "room": {
+      "majsoul_bronze": "銅之間",
+      "majsoul_silver": "銀之間",
+      "majsoul_gold": "金之間",
+      "majsoul_jade": "玉之間",
+      "majsoul_throne": "王座之間",
+      "majsoul_melee": "亂鬥之間",
+      "tenhou_ippan": "一般桌",
+      "tenhou_joukyuu": "上級桌",
+      "tenhou_tokujou": "特上桌",
+      "tenhou_houou": "鳳凰桌",
+      "tenhou_lobby": "個室 {{lobby}}",
+      "raw": "房間 #{{id}}"
+    }
   },
   "logs": {
     "title": "日誌",

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -107,11 +107,16 @@
       "tenhou_tokujou": "特上桌",
       "tenhou_houou": "鳳凰桌",
       "tenhou_lobby": "個室 {{lobby}}",
-      "rc_star": "星之間",
-      "rc_moon": "月之間",
-      "rc_sun": "日之間",
-      "rc_galaxy": "銀河之間",
-      "raw": "房間 #{{id}}"
+      "rc_star": "新星",
+      "rc_moon": "霞月",
+      "rc_sun": "炎陽",
+      "rc_galaxy": "銀河",
+      "raw": "房間 #{{id}}",
+      "rc_ranked": "段位戰",
+      "rc_tournament": "大會戰",
+      "rc_friendly": "友人戰",
+      "rc_one_round": "一局戰",
+      "rc_casual": "休閒場"
     }
   },
   "logs": {

--- a/frontend/src/lib/matchInfo.test.ts
+++ b/frontend/src/lib/matchInfo.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { matchGameId, paifuUrl, roomLabelKey } from './matchInfo'
+import en from '@/i18n/resources/en.json'
+import ja from '@/i18n/resources/ja.json'
+import zhCN from '@/i18n/resources/zh-CN.json'
+import zhTW from '@/i18n/resources/zh-TW.json'
 
 describe('roomLabelKey', () => {
   it('maps Majsoul ranked mode ids to room tiers', () => {
@@ -22,6 +26,20 @@ describe('roomLabelKey', () => {
       params: { id: 99 },
     })
     expect(roomLabelKey({ platform: 'majsoul' })).toBeNull()
+  })
+
+  it('labels non-matchmade Majsoul tables by contest or friendly room', () => {
+    expect(
+      roomLabelKey({ platform: 'majsoul', contest_uid: 777, room_id: 33123 }),
+    ).toEqual({ key: 'history.room.majsoul_contest', params: { id: 777 } })
+    expect(roomLabelKey({ platform: 'majsoul', room_id: 33123 })).toEqual({
+      key: 'history.room.majsoul_friendly',
+      params: { id: 33123 },
+    })
+    // A ranked mode id wins over the room number.
+    expect(
+      roomLabelKey({ platform: 'majsoul', mode_id: 12, room_id: 33123 }),
+    ).toEqual({ key: 'history.room.majsoul_jade' })
   })
 
   it('decodes Tenhou GO type bits into room tiers', () => {
@@ -109,11 +127,52 @@ describe('matchGameId / paifuUrl', () => {
     ).toBe('tabletoken0001')
   })
 
-  it('builds replay links for Tenhou only', () => {
+  it('builds replay links for Tenhou only, with the viewer seat when known', () => {
     expect(
       paifuUrl({ platform: 'tenhou', log_id: '2026010100gm-00a9-0000-cafe0001' }),
     ).toBe('https://tenhou.net/0/?log=2026010100gm-00a9-0000-cafe0001')
-    expect(paifuUrl({ platform: 'majsoul', game_uuid: 'u' })).toBeNull()
+    expect(
+      paifuUrl(
+        { platform: 'tenhou', log_id: '2026010100gm-00a9-0000-cafe0001' },
+        2,
+      ),
+    ).toBe('https://tenhou.net/0/?log=2026010100gm-00a9-0000-cafe0001&tw=2')
+    expect(paifuUrl({ platform: 'majsoul', game_uuid: 'u' }, 0)).toBeNull()
     expect(paifuUrl({ platform: 'riichi_city', room_id: 'x' })).toBeNull()
+  })
+})
+
+describe('locale coverage', () => {
+  // Every key roomLabelKey can emit must resolve in every locale — a tier
+  // added to a map without its strings would otherwise ship a raw i18n key
+  // to the UI with no test failure.
+  const emittableKeys = [
+    ...['bronze', 'silver', 'gold', 'jade', 'throne', 'melee'].map(
+      (t) => `majsoul_${t}`,
+    ),
+    'majsoul_friendly',
+    'majsoul_contest',
+    ...['ippan', 'joukyuu', 'tokujou', 'houou'].map((t) => `tenhou_${t}`),
+    'tenhou_lobby',
+    ...['star', 'moon', 'sun', 'galaxy'].map((t) => `rc_${t}`),
+    'rc_ranked',
+    'rc_tournament',
+    'rc_friendly',
+    'rc_one_round',
+    'rc_casual',
+    'raw',
+  ]
+
+  it.each([
+    ['en', en],
+    ['ja', ja],
+    ['zh-CN', zhCN],
+    ['zh-TW', zhTW],
+  ])('%s has every emittable history.room key', (_name, locale) => {
+    const room = (locale as { history: { room: Record<string, string> } })
+      .history.room
+    for (const key of emittableKeys) {
+      expect(room[key], `history.room.${key}`).toBeTypeOf('string')
+    }
   })
 })

--- a/frontend/src/lib/matchInfo.test.ts
+++ b/frontend/src/lib/matchInfo.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchGameId, paifuUrl, roomLabelKey } from './matchInfo'
+
+describe('roomLabelKey', () => {
+  it('maps Majsoul ranked mode ids to room tiers', () => {
+    expect(
+      roomLabelKey({ platform: 'majsoul', mode_id: 9 }),
+    ).toEqual({ key: 'history.room.majsoul_gold' })
+    // 3p ids share the tier keys.
+    expect(
+      roomLabelKey({ platform: 'majsoul', mode_id: 17 }),
+    ).toEqual({ key: 'history.room.majsoul_bronze' })
+    expect(
+      roomLabelKey({ platform: 'majsoul', mode_id: 26 }),
+    ).toEqual({ key: 'history.room.majsoul_throne' })
+  })
+
+  it('falls back to the raw number for unknown Majsoul mode ids', () => {
+    expect(roomLabelKey({ platform: 'majsoul', mode_id: 99 })).toEqual({
+      key: 'history.room.raw',
+      params: { id: 99 },
+    })
+    expect(roomLabelKey({ platform: 'majsoul' })).toBeNull()
+  })
+
+  it('decodes Tenhou GO type bits into room tiers', () => {
+    // 0x80 alone = Joukyuu, 0x20 alone = Tokujou, both = Houou.
+    expect(
+      roomLabelKey({ platform: 'tenhou', go_type: 0x09, lobby: 0 }),
+    ).toEqual({ key: 'history.room.tenhou_ippan' })
+    expect(
+      roomLabelKey({ platform: 'tenhou', go_type: 0x89, lobby: 0 }),
+    ).toEqual({ key: 'history.room.tenhou_joukyuu' })
+    expect(
+      roomLabelKey({ platform: 'tenhou', go_type: 0x29, lobby: 0 }),
+    ).toEqual({ key: 'history.room.tenhou_tokujou' })
+    expect(
+      roomLabelKey({ platform: 'tenhou', go_type: 0xa9, lobby: 0 }),
+    ).toEqual({ key: 'history.room.tenhou_houou' })
+  })
+
+  it('labels non-zero Tenhou lobbies by number instead of tier', () => {
+    expect(
+      roomLabelKey({ platform: 'tenhou', go_type: 0x09, lobby: 7994 }),
+    ).toEqual({ key: 'history.room.tenhou_lobby', params: { lobby: 7994 } })
+  })
+
+  it('maps Riichi City stage types 1-4 to Star/Moon/Sun/Galaxy', () => {
+    expect(
+      roomLabelKey({ platform: 'riichi_city', stage_type: 1 }),
+    ).toEqual({ key: 'history.room.rc_star' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', stage_type: 4 }),
+    ).toEqual({ key: 'history.room.rc_galaxy' })
+    // 0/absent = not a ranked queue; unknown values degrade to the number.
+    expect(roomLabelKey({ platform: 'riichi_city', stage_type: 0 })).toBeNull()
+    expect(roomLabelKey({ platform: 'riichi_city' })).toBeNull()
+    expect(roomLabelKey({ platform: 'riichi_city', stage_type: 9 })).toEqual({
+      key: 'history.room.raw',
+      params: { id: 9 },
+    })
+  })
+
+  it('returns null for missing match info', () => {
+    expect(roomLabelKey(null)).toBeNull()
+    expect(roomLabelKey(undefined)).toBeNull()
+  })
+})
+
+describe('matchGameId / paifuUrl', () => {
+  it('surfaces each platform game id', () => {
+    expect(
+      matchGameId({ platform: 'majsoul', game_uuid: '240101-uuid' }),
+    ).toBe('240101-uuid')
+    expect(
+      matchGameId({ platform: 'tenhou', log_id: '2026010100gm-00a9-0000-cafe0001' }),
+    ).toBe('2026010100gm-00a9-0000-cafe0001')
+    expect(
+      matchGameId({ platform: 'riichi_city', room_id: 'tabletoken0001' }),
+    ).toBe('tabletoken0001')
+  })
+
+  it('builds replay links for Tenhou only', () => {
+    expect(
+      paifuUrl({ platform: 'tenhou', log_id: '2026010100gm-00a9-0000-cafe0001' }),
+    ).toBe('https://tenhou.net/0/?log=2026010100gm-00a9-0000-cafe0001')
+    expect(paifuUrl({ platform: 'majsoul', game_uuid: 'u' })).toBeNull()
+    expect(paifuUrl({ platform: 'riichi_city', room_id: 'x' })).toBeNull()
+  })
+})

--- a/frontend/src/lib/matchInfo.test.ts
+++ b/frontend/src/lib/matchInfo.test.ts
@@ -46,6 +46,34 @@ describe('roomLabelKey', () => {
     ).toEqual({ key: 'history.room.tenhou_lobby', params: { lobby: 7994 } })
   })
 
+  it('labels Riichi City games by game mode', () => {
+    // Ranked (1001): tier from stage_type, generic ranked label without one.
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1001, stage_type: 2 }),
+    ).toEqual({ key: 'history.room.rc_moon' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1001 }),
+    ).toEqual({ key: 'history.room.rc_ranked' })
+    // Non-ranked modes label by the GamePlayType mapping.
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1003 }),
+    ).toEqual({ key: 'history.room.rc_friendly' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1002 }),
+    ).toEqual({ key: 'history.room.rc_tournament' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1004 }),
+    ).toEqual({ key: 'history.room.rc_one_round' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1010 }),
+    ).toEqual({ key: 'history.room.rc_casual' })
+    // Unknown mode ids degrade to the raw number.
+    expect(roomLabelKey({ platform: 'riichi_city', game_play: 1099 })).toEqual({
+      key: 'history.room.raw',
+      params: { id: 1099 },
+    })
+  })
+
   it('maps Riichi City stage types 1-4 to Star/Moon/Sun/Galaxy', () => {
     expect(
       roomLabelKey({ platform: 'riichi_city', stage_type: 1 }),

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -7,8 +7,9 @@ import type { MatchInfo } from '@/types'
 
 /**
  * Majsoul ranked matchmode id → room tier key. From the game's own
- * matchmode table: each tier owns three 4p ids (best-of-one / East / South)
- * and two 3p ids (East / South); Melee has no best-of-one.
+ * matchmode table: Bronze–Jade own three 4p ids each (best-of-one / East /
+ * South) plus two 3p ids (East / South); Melee and Throne have no
+ * best-of-one.
  */
 const MAJSOUL_ROOM_TIERS: Record<number, string> = {
   1: 'bronze',
@@ -100,11 +101,21 @@ export function roomLabelKey(
   if (!info) return null
   switch (info.platform) {
     case 'majsoul': {
-      if (info.mode_id == null) return null
-      const tier = MAJSOUL_ROOM_TIERS[info.mode_id]
-      return tier
-        ? { key: `history.room.majsoul_${tier}` }
-        : { key: 'history.room.raw', params: { id: info.mode_id } }
+      if (info.mode_id != null) {
+        const tier = MAJSOUL_ROOM_TIERS[info.mode_id]
+        return tier
+          ? { key: `history.room.majsoul_${tier}` }
+          : { key: 'history.room.raw', params: { id: info.mode_id } }
+      }
+      // Non-matchmade tables (mode_id 0 → absent): tournament, then
+      // friendly/AI room, identified by their raw numbers.
+      if (info.contest_uid != null) {
+        return { key: 'history.room.majsoul_contest', params: { id: info.contest_uid } }
+      }
+      if (info.room_id != null) {
+        return { key: 'history.room.majsoul_friendly', params: { id: info.room_id } }
+      }
+      return null
     }
     case 'tenhou': {
       if (info.lobby != null && info.lobby !== 0) {
@@ -132,6 +143,9 @@ export function roomLabelKey(
         : { key: 'history.room.raw', params: { id: gp } }
     }
   }
+  // Unreachable for the current MatchInfo union; keeps the declared return
+  // type honest if a platform variant ships before this mirror learns it.
+  return null
 }
 
 /** The platform's own game (paifu) id, if the record carries one. */
@@ -147,16 +161,23 @@ export function matchGameId(info: MatchInfo | null | undefined): string | null {
       // offers to a per-game identifier.
       return info.room_id ?? null
   }
+  return null
 }
 
 /**
  * Replay URL, when one can be built without guessing. Tenhou log links are
  * region-independent; Majsoul replay hosts differ per region (which isn't
- * recorded), so Majsoul gets the copyable uuid only.
+ * recorded), so Majsoul gets the copyable uuid only. `ourSeat` (the
+ * record's `our_seat`, wire-absolute = Tenhou's `tw` index) opens the
+ * replay from the player's own perspective.
  */
-export function paifuUrl(info: MatchInfo | null | undefined): string | null {
+export function paifuUrl(
+  info: MatchInfo | null | undefined,
+  ourSeat?: number | null,
+): string | null {
   if (info?.platform === 'tenhou' && info.log_id) {
-    return `https://tenhou.net/0/?log=${encodeURIComponent(info.log_id)}`
+    const tw = ourSeat == null ? '' : `&tw=${ourSeat}`
+    return `https://tenhou.net/0/?log=${encodeURIComponent(info.log_id)}${tw}`
   }
   return null
 }

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -42,6 +42,19 @@ const MAJSOUL_ROOM_TIERS: Record<number, string> = {
 }
 
 /**
+ * Riichi City `options.stage_type` → ranked room tier, lowest to highest.
+ * From the client's ranked-queue protocol (`readStageClassifies`
+ * `stageType` 1–4), verified against live `cmd_stagematch_run` pushes in
+ * PR #268.
+ */
+const RIICHI_CITY_ROOM_TIERS: Record<number, string> = {
+  1: 'star',
+  2: 'moon',
+  3: 'sun',
+  4: 'galaxy',
+}
+
+/**
  * Tenhou `<GO type=…>` room bits → tier key. 0x80 alone = Joukyuu, 0x20
  * alone = Tokujou, both = Houou, neither = Ippan (ranked lobby 0 only —
  * private lobbies use the lobby number instead).
@@ -75,8 +88,15 @@ export function roomLabelKey(
       if (info.go_type == null) return null
       return { key: `history.room.tenhou_${tenhouTier(info.go_type)}` }
     }
-    case 'riichi_city':
-      return null
+    case 'riichi_city': {
+      // stage_type is only meaningful for ranked queues; 0/absent (friend
+      // rooms, events) shows nothing rather than a wrong tier.
+      if (!info.stage_type) return null
+      const tier = RIICHI_CITY_ROOM_TIERS[info.stage_type]
+      return tier
+        ? { key: `history.room.rc_${tier}` }
+        : { key: 'history.room.raw', params: { id: info.stage_type } }
+    }
   }
 }
 
@@ -94,10 +114,6 @@ export function matchGameId(info: MatchInfo | null | undefined): string | null {
       return info.room_id ?? null
   }
 }
-
-// Riichi City rooms stay unmapped in roomLabelKey until the stage_type /
-// game_play enumerations are confirmed from more captures — one observed
-// sample isn't enough to name tiers confidently.
 
 /**
  * Replay URL, when one can be built without guessing. Tenhou log links are

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -89,9 +89,15 @@ export function matchGameId(info: MatchInfo | null | undefined): string | null {
     case 'tenhou':
       return info.log_id ?? null
     case 'riichi_city':
-      return null
+      // Table-instance token — not a replay id, but the closest the wire
+      // offers to a per-game identifier.
+      return info.room_id ?? null
   }
 }
+
+// Riichi City rooms stay unmapped in roomLabelKey until the stage_type /
+// game_play enumerations are confirmed from more captures — one observed
+// sample isn't enough to name tiers confidently.
 
 /**
  * Replay URL, when one can be built without guessing. Tenhou log links are

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -1,0 +1,106 @@
+// Display helpers for `GameRecord.match_info` (room / rank-lobby labels and
+// paifu ids). The backend persists raw platform ids; the label mapping lives
+// here so an id this build doesn't know degrades to showing the number
+// instead of a wrong name.
+
+import type { MatchInfo } from '@/types'
+
+/**
+ * Majsoul ranked matchmode id → room tier key. From the game's own
+ * matchmode table: each tier owns three 4p ids (best-of-one / East / South)
+ * and two 3p ids (East / South); Melee has no best-of-one.
+ */
+const MAJSOUL_ROOM_TIERS: Record<number, string> = {
+  1: 'bronze',
+  2: 'bronze',
+  3: 'bronze',
+  4: 'silver',
+  5: 'silver',
+  6: 'silver',
+  7: 'gold',
+  8: 'gold',
+  9: 'gold',
+  10: 'jade',
+  11: 'jade',
+  12: 'jade',
+  13: 'melee',
+  14: 'melee',
+  15: 'throne',
+  16: 'throne',
+  17: 'bronze',
+  18: 'bronze',
+  19: 'silver',
+  20: 'silver',
+  21: 'gold',
+  22: 'gold',
+  23: 'jade',
+  24: 'jade',
+  25: 'throne',
+  26: 'throne',
+  27: 'melee',
+  28: 'melee',
+}
+
+/**
+ * Tenhou `<GO type=…>` room bits → tier key. 0x80 alone = Joukyuu, 0x20
+ * alone = Tokujou, both = Houou, neither = Ippan (ranked lobby 0 only —
+ * private lobbies use the lobby number instead).
+ */
+function tenhouTier(goType: number): string {
+  const idx = (goType & 0x20 ? 2 : 0) + (goType & 0x80 ? 1 : 0)
+  return ['ippan', 'joukyuu', 'tokujou', 'houou'][idx]
+}
+
+/**
+ * i18n key (+ params) for the room / rank lobby a game was played in, or
+ * null when the record carries nothing displayable. Callers render with
+ * `t(key, params)`.
+ */
+export function roomLabelKey(
+  info: MatchInfo | null | undefined,
+): { key: string; params?: Record<string, unknown> } | null {
+  if (!info) return null
+  switch (info.platform) {
+    case 'majsoul': {
+      if (info.mode_id == null) return null
+      const tier = MAJSOUL_ROOM_TIERS[info.mode_id]
+      return tier
+        ? { key: `history.room.majsoul_${tier}` }
+        : { key: 'history.room.raw', params: { id: info.mode_id } }
+    }
+    case 'tenhou': {
+      if (info.lobby != null && info.lobby !== 0) {
+        return { key: 'history.room.tenhou_lobby', params: { lobby: info.lobby } }
+      }
+      if (info.go_type == null) return null
+      return { key: `history.room.tenhou_${tenhouTier(info.go_type)}` }
+    }
+    case 'riichi_city':
+      return null
+  }
+}
+
+/** The platform's own game (paifu) id, if the record carries one. */
+export function matchGameId(info: MatchInfo | null | undefined): string | null {
+  if (!info) return null
+  switch (info.platform) {
+    case 'majsoul':
+      return info.game_uuid ?? null
+    case 'tenhou':
+      return info.log_id ?? null
+    case 'riichi_city':
+      return null
+  }
+}
+
+/**
+ * Replay URL, when one can be built without guessing. Tenhou log links are
+ * region-independent; Majsoul replay hosts differ per region (which isn't
+ * recorded), so Majsoul gets the copyable uuid only.
+ */
+export function paifuUrl(info: MatchInfo | null | undefined): string | null {
+  if (info?.platform === 'tenhou' && info.log_id) {
+    return `https://tenhou.net/0/?log=${encodeURIComponent(info.log_id)}`
+  }
+  return null
+}

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -43,15 +43,40 @@ const MAJSOUL_ROOM_TIERS: Record<number, string> = {
 
 /**
  * Riichi City `options.stage_type` → ranked room tier, lowest to highest.
- * From the client's ranked-queue protocol (`readStageClassifies`
- * `stageType` 1–4), verified against live `cmd_stagematch_run` pushes in
- * PR #268.
+ * Tier names follow the client's own strings (`MATCHING_VIEW_STATE_TYPE_*`:
+ * 新星/霞月/炎陽/銀河, EN Star/Moon/Sun/Galaxy); its replay list labels a
+ * ranked game exactly this way.
  */
 const RIICHI_CITY_ROOM_TIERS: Record<number, string> = {
   1: 'star',
   2: 'moon',
   3: 'sun',
   4: 'galaxy',
+}
+
+/**
+ * Riichi City `options.game_play` → mode label key, from the client's
+ * `GamePlayType` enum. 1001 (ranked) is handled separately via the stage
+ * tier above; 1021 is the tier-less Taiwan-rules ranked ladder. The
+ * 1007–1016/1022 block are the casual-hall variants (directive war,
+ * chinitsu trial, Taiwan rules, 17-steps, bleed, hidden war, …), labeled
+ * with the client's own "Casual Game" umbrella term.
+ */
+const RIICHI_CITY_MODES: Record<number, string> = {
+  1002: 'rc_tournament',
+  1003: 'rc_friendly',
+  1004: 'rc_one_round',
+  1005: 'rc_one_round',
+  1007: 'rc_casual',
+  1008: 'rc_casual',
+  1009: 'rc_casual',
+  1010: 'rc_casual',
+  1013: 'rc_casual',
+  1014: 'rc_casual',
+  1015: 'rc_casual',
+  1016: 'rc_casual',
+  1021: 'rc_ranked',
+  1022: 'rc_casual',
 }
 
 /**
@@ -89,13 +114,22 @@ export function roomLabelKey(
       return { key: `history.room.tenhou_${tenhouTier(info.go_type)}` }
     }
     case 'riichi_city': {
-      // stage_type is only meaningful for ranked queues; 0/absent (friend
-      // rooms, events) shows nothing rather than a wrong tier.
-      if (!info.stage_type) return null
-      const tier = RIICHI_CITY_ROOM_TIERS[info.stage_type]
-      return tier
-        ? { key: `history.room.rc_${tier}` }
-        : { key: 'history.room.raw', params: { id: info.stage_type } }
+      const gp = info.game_play
+      // Ranked queue: label by the stage tier (falling back to the generic
+      // "Ranked Match" when the tier is missing or unknown).
+      if (gp === 1001 || (gp == null && info.stage_type)) {
+        const tier = info.stage_type
+          ? RIICHI_CITY_ROOM_TIERS[info.stage_type]
+          : undefined
+        if (tier) return { key: `history.room.rc_${tier}` }
+        if (gp === 1001) return { key: 'history.room.rc_ranked' }
+        return { key: 'history.room.raw', params: { id: info.stage_type } }
+      }
+      if (gp == null) return null
+      const mode = RIICHI_CITY_MODES[gp]
+      return mode
+        ? { key: `history.room.${mode}` }
+        : { key: 'history.room.raw', params: { id: gp } }
     }
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -536,6 +536,39 @@ export type GameStats = {
   nagashi_mangan: number
 }
 
+/**
+ * Platform-specific match identity captured at `start_game` — which room /
+ * rank lobby the game was played in plus the platform's own game (paifu) id.
+ * Mirrors `crate::schema::history::MatchInfo`: internally tagged on
+ * `platform`, raw platform values, `None` fields omitted from the JSON.
+ */
+export type MatchInfo =
+  | {
+      platform: 'majsoul'
+      /** Raw `game_uuid` — the replay identifier. */
+      game_uuid?: string | null
+      /** Ranked matchmode id (1..=28 = Bronze..Throne / Melee, 4p+3p). */
+      mode_id?: number | null
+      /** Friendly/AI room number. */
+      room_id?: number | null
+      /** Tournament id. */
+      contest_uid?: number | null
+    }
+  | {
+      platform: 'tenhou'
+      /** Paifu id from `<TAIKYOKU log=…>`. */
+      log_id?: string | null
+      /** Raw `<GO type=…>` rule/room bitfield (tier in bits 0x20/0x80). */
+      go_type?: number | null
+      /** Lobby number; 0 = the public ranked lobby. */
+      lobby?: number | null
+    }
+  | {
+      platform: 'riichi_city'
+      /** Raw room identifier from `cmd_enter_room`. */
+      room_id?: number | null
+    }
+
 export type GameRecord = {
   id: string
   /** RFC3339 timestamp. */
@@ -553,6 +586,8 @@ export type GameRecord = {
   /** `final_score - starting_score` (4p:25000, 3p:35000). */
   our_delta: number | null
   stats: GameStats
+  /** Absent/null on records from before this field existed. */
+  match_info?: MatchInfo | null
   log_path: string
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -565,8 +565,14 @@ export type MatchInfo =
     }
   | {
       platform: 'riichi_city'
-      /** Raw room identifier from `cmd_enter_room`. */
-      room_id?: number | null
+      /** Table-instance token from the `cmd_enter_room` wrapper. */
+      room_id?: string | null
+      /** Matchmaking classification id (wire string). */
+      classify_id?: string | null
+      /** Rank stage tier of the matchmaking room. */
+      stage_type?: number | null
+      /** Game mode id (e.g. 1001). */
+      game_play?: number | null
     }
 
 export type GameRecord = {

--- a/src/analysis/runner.rs
+++ b/src/analysis/runner.rs
@@ -129,7 +129,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 

--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -1214,7 +1214,7 @@ mod tests {
             aka_flag: None,
             id: Some(1),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         });
         assert_eq!(
             m.state.cached_our_seat,
@@ -1246,7 +1246,7 @@ mod tests {
             aka_flag: None,
             id: Some(2),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         });
         assert_eq!(m.state.cached_our_seat, Some(2));
 
@@ -1293,7 +1293,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         });
         assert_eq!(m.state.dead_clicks, 0, "a new table is a fresh start");
     }
@@ -1444,7 +1444,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         });
         assert_eq!(m.state.cached_our_seat, Some(0));
 
@@ -1455,7 +1455,7 @@ mod tests {
             aka_flag: None,
             id: None,
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         });
         assert!(
             m.state.cached_our_seat.is_none(),

--- a/src/bot/manager.rs
+++ b/src/bot/manager.rs
@@ -1293,7 +1293,7 @@ mod tests {
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             })
             .await
             .unwrap_err();
@@ -1351,7 +1351,7 @@ mod tests {
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             })
             .await
             .unwrap_err();
@@ -1434,7 +1434,7 @@ mod tests {
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             })
             .await
             .unwrap_err();
@@ -1502,7 +1502,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         })
         .await
         .expect("handle returns Ok (analysis-only), not an error");
@@ -1559,7 +1559,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         })
         .await
         .expect("native bot must spawn without a Python runtime");

--- a/src/bot/native.rs
+++ b/src/bot/native.rs
@@ -1082,7 +1082,7 @@ mod tests {
             aka_flag: None,
             id: Some(seat),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 
@@ -1879,7 +1879,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 3,
-            majsoul_meta: None,
+            game_meta: None,
         };
         let v = to_api_event(&sg, 0, 3);
         assert_eq!(v["names"].as_array().unwrap().len(), 4);

--- a/src/bot/runner.rs
+++ b/src/bot/runner.rs
@@ -334,7 +334,7 @@ for line in sys.stdin:
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             }])
             .await
             .unwrap();
@@ -423,7 +423,7 @@ for line in sys.stdin:
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             }])
             .await
             .unwrap();

--- a/src/bridge/majsoul/README.md
+++ b/src/bridge/majsoul/README.md
@@ -21,8 +21,11 @@ discards, calls, agari/ryukyoku) are still TODO.
     seats live under `payload.robots[]` without a nickname, so they get
     `""`. **No length-4 padding** — sanma authGame emits a length-3 names
     array natively.
-  - `gameConfig.meta.mode_id` is logged for diagnostics but not gated on
-    (sanma AI rooms emit `mode_id = 0`; ranked sanma uses 21/22/26).
+  - `gameConfig.meta.mode_id` / `room_id` / `contest_uid` are captured (zero
+    = "not applicable" → `None`) into the StartGame `game_meta.match_info`,
+    together with the raw `game_uuid` from the authGame request; history
+    persists them as `GameRecord.match_info`. Sanma AI rooms emit
+    `mode_id = 0`; ranked sanma uses 21/22/26. Never gated on.
 - Emits `MjaiEvent::StartGame { id: Some(seat), names, num_players, .. }`.
 
 `aka_flag` / `kyoku_first` aren't known yet at authGame time, so they stay

--- a/src/bridge/majsoul/mod.rs
+++ b/src/bridge/majsoul/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     autoplay::budget::{BudgetSource, SharedTimeBudget, TimeBudget},
     config::Platform,
     logger::{FlowLogger, Session},
-    schema::{mjai::Actor, MajsoulGameMeta, MjaiEvent},
+    schema::{mjai::Actor, GameMeta, MatchInfo, MjaiEvent},
 };
 use anyhow::{bail, Context, Result};
 use chrono::Local;
@@ -113,6 +113,10 @@ pub struct MajsoulBridge {
     mjai_log: Option<Arc<FlowLogger>>,
     account_id: Option<u64>,
     game_id: Option<u64>,
+    /// Raw `ReqAuthGame.game_uuid` — the paifu identifier, persisted into
+    /// history's `MatchInfo` so the frontend can link to the replay.
+    /// `game_id` above stays the FNV hash used for reconnect detection.
+    game_uuid: Option<String>,
     seat: Option<Actor>,
     /// Mjai-mapped dora indicators seen so far this kyoku. Compared
     /// against the `doras` array that any action payload may carry
@@ -179,6 +183,7 @@ impl MajsoulBridge {
             mjai_log: None,
             account_id: None,
             game_id: None,
+            game_uuid: None,
             seat: None,
             doras: Vec::new(),
             dora_timing: None,
@@ -255,11 +260,12 @@ impl MajsoulBridge {
         match (&msg.msg_type, msg.method_name.as_ref()) {
             (MessageType::Request, METHOD_AUTH_GAME) => {
                 self.account_id = msg.payload.get("account_id").and_then(JsonValue::as_u64);
-                self.game_id = msg
+                self.game_uuid = msg
                     .payload
                     .get("game_uuid")
                     .and_then(JsonValue::as_str)
-                    .map(stable_game_id);
+                    .map(str::to_string);
+                self.game_id = self.game_uuid.as_deref().map(stable_game_id);
                 if self.account_id.is_none() {
                     warn!(
                         target: "akagi::bridge::majsoul",
@@ -1234,9 +1240,16 @@ impl MajsoulBridge {
         } else {
             self.num_players = detected;
         }
-        let mode_id = payload
-            .pointer("/game_config/meta/mode_id")
-            .and_then(JsonValue::as_u64);
+        let meta_u32 = |key: &str| {
+            payload
+                .pointer(&format!("/game_config/meta/{key}"))
+                .and_then(JsonValue::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .filter(|&value| value != 0)
+        };
+        let mode_id = meta_u32("mode_id");
+        let room_id = meta_u32("room_id");
+        let contest_uid = meta_u32("contest_uid");
         let match_mode = payload
             .pointer("/game_config/mode/mode")
             .and_then(JsonValue::as_u64)
@@ -1253,9 +1266,15 @@ impl MajsoulBridge {
             aka_flag: None,
             id: Some(seat),
             num_players: self.num_players,
-            majsoul_meta: Some(MajsoulGameMeta {
+            game_meta: Some(GameMeta {
                 game_id: self.game_id,
                 match_mode,
+                match_info: Some(MatchInfo::Majsoul {
+                    game_uuid: self.game_uuid.clone(),
+                    mode_id,
+                    room_id,
+                    contest_uid,
+                }),
             }),
         }]
     }
@@ -1962,16 +1981,30 @@ mod tests {
             }),
         ));
         match &events[0] {
-            MjaiEvent::StartGame { majsoul_meta, .. } => {
-                let meta = majsoul_meta.expect("Mahjong Soul metadata");
+            MjaiEvent::StartGame { game_meta, .. } => {
+                let meta = game_meta.as_ref().expect("Mahjong Soul metadata");
                 assert_eq!(meta.game_id, Some(stable_game_id(game_uuid)));
                 assert_eq!(meta.match_mode, Some(2));
+                match &meta.match_info {
+                    Some(MatchInfo::Majsoul {
+                        game_uuid: uuid,
+                        mode_id,
+                        room_id,
+                        contest_uid,
+                    }) => {
+                        assert_eq!(uuid.as_deref(), Some(game_uuid));
+                        assert_eq!(*mode_id, Some(12));
+                        assert_eq!(*room_id, None);
+                        assert_eq!(*contest_uid, None);
+                    }
+                    other => panic!("expected Majsoul match_info, got {other:?}"),
+                }
             }
             other => panic!("expected StartGame, got {other:?}"),
         }
         assert!(serde_json::to_value(&events[0])
             .unwrap()
-            .get("majsoul_meta")
+            .get("game_meta")
             .is_none());
     }
 
@@ -2041,6 +2074,7 @@ mod tests {
                 id,
                 names,
                 num_players,
+                game_meta,
                 ..
             } => {
                 assert_eq!(*id, Some(1));
@@ -2049,6 +2083,21 @@ mod tests {
                     names,
                     &vec!["".to_string(), "player_a".to_string(), "".to_string()]
                 );
+                // Zero-valued meta ids mean "not applicable" and are dropped;
+                // the friendly/AI room number is kept as-is.
+                match &game_meta.as_ref().expect("game meta").match_info {
+                    Some(MatchInfo::Majsoul {
+                        mode_id,
+                        room_id,
+                        contest_uid,
+                        ..
+                    }) => {
+                        assert_eq!(*mode_id, None);
+                        assert_eq!(*room_id, Some(33123));
+                        assert_eq!(*contest_uid, None);
+                    }
+                    other => panic!("expected Majsoul match_info, got {other:?}"),
+                }
             }
             other => panic!("expected StartGame, got {other:?}"),
         }

--- a/src/bridge/majsoul/mod.rs
+++ b/src/bridge/majsoul/mod.rs
@@ -1281,7 +1281,9 @@ impl MajsoulBridge {
 }
 
 fn stable_game_id(game_uuid: &str) -> u64 {
-    // FNV-1a keeps the UUID private while providing a stable reconnect key.
+    // FNV-1a gives a compact, stable reconnect key for the recorder's dedup.
+    // The raw UUID is kept separately on the bridge and persisted via
+    // `MatchInfo` into the local history index (never uploaded).
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in game_uuid.bytes() {
         hash ^= u64::from(byte);

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -148,7 +148,14 @@ impl RiichiCityBridge {
                 }
                 Vec::new()
             }
-            "cmd_enter_room" => self.on_enter_room(data),
+            "cmd_enter_room" => {
+                let room_id = pkt
+                    .body
+                    .get("room_id")
+                    .and_then(JsonValue::as_str)
+                    .map(str::to_string);
+                self.on_enter_room(room_id, data)
+            }
             "cmd_game_start" => self.on_game_start(data),
             "cmd_in_card_brc" => self.on_in_card_brc(data),
             "cmd_send_current_action" => self.on_send_current_action(data),
@@ -161,12 +168,22 @@ impl RiichiCityBridge {
     }
 
     /// `cmd_enter_room` — collect players + table size; emits nothing. Dedups
-    /// repeated messages for the same room by `classify_id` (a latent no-op in
-    /// v2, where `classify_id` was never stored).
-    fn on_enter_room(&mut self, data: Option<&JsonValue>) -> Vec<MjaiEvent> {
+    /// repeated messages for the same room by `classify_id`. The wire sends
+    /// `classify_id` as a string; tolerate a number for older payloads.
+    fn on_enter_room(
+        &mut self,
+        room_id: Option<String>,
+        data: Option<&JsonValue>,
+    ) -> Vec<MjaiEvent> {
         let Some(data) = data else { return Vec::new() };
-        let classify_id = data.pointer("/options/classify_id").and_then(json_i64);
-        if let (Some(prev), Some(now)) = (self.status.classify_id, classify_id) {
+        let classify_id = data.pointer("/options/classify_id").and_then(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .or_else(|| json_i64(v).map(|n| n.to_string()))
+        });
+        if let (Some(prev), Some(now)) =
+            (self.status.classify_id.as_deref(), classify_id.as_deref())
+        {
             if prev == now {
                 warn!(target: LOG, "duplicate cmd_enter_room for active room, ignored");
                 return Vec::new();
@@ -182,6 +199,9 @@ impl RiichiCityBridge {
             is_3p,
             num_players: if is_3p { 3 } else { 4 },
             classify_id,
+            room_id,
+            stage_type: data.pointer("/options/stage_type").and_then(json_i64),
+            game_play: data.pointer("/options/game_play").and_then(json_i64),
             ..GameStatus::default()
         };
         if let Some(players) = data.get("players").and_then(JsonValue::as_array) {
@@ -239,7 +259,10 @@ impl RiichiCityBridge {
                     game_id: None,
                     match_mode: None,
                     match_info: Some(MatchInfo::RiichiCity {
-                        room_id: self.status.classify_id,
+                        room_id: self.status.room_id.clone(),
+                        classify_id: self.status.classify_id.clone(),
+                        stage_type: self.status.stage_type,
+                        game_play: self.status.game_play,
                     }),
                 }),
             });
@@ -774,13 +797,20 @@ mod tests {
     }
 
     fn enter_room_4p(b: &mut RiichiCityBridge) {
+        // Mirrors the real wire shape: string ids, room token on the wrapper.
         feed(
             b,
             18,
             json!({
                 "cmd": "cmd_enter_room",
+                "room_id": "tabletoken0001",
                 "data": {
-                    "options": { "classify_id": 555, "player_count": 4 },
+                    "options": {
+                        "classify_id": "classifytoken0001",
+                        "player_count": 4,
+                        "stage_type": 1,
+                        "game_play": 1001
+                    },
                     "players": [
                         {"user": {"user_id": 1001}},
                         {"user": {"user_id": 1002}},
@@ -826,11 +856,26 @@ mod tests {
                 id,
                 num_players,
                 names,
+                game_meta,
                 ..
             } => {
                 assert_eq!(*id, Some(0));
                 assert_eq!(*num_players, 4);
                 assert_eq!(names.len(), 4);
+                match &game_meta.as_ref().expect("riichi city meta").match_info {
+                    Some(MatchInfo::RiichiCity {
+                        room_id,
+                        classify_id,
+                        stage_type,
+                        game_play,
+                    }) => {
+                        assert_eq!(room_id.as_deref(), Some("tabletoken0001"));
+                        assert_eq!(classify_id.as_deref(), Some("classifytoken0001"));
+                        assert_eq!(*stage_type, Some(1));
+                        assert_eq!(*game_play, Some(1001));
+                    }
+                    other => panic!("expected RiichiCity match_info, got {other:?}"),
+                }
             }
             other => panic!("expected StartGame, got {other:?}"),
         }

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -149,11 +149,12 @@ impl RiichiCityBridge {
                 Vec::new()
             }
             "cmd_enter_room" => {
-                let room_id = pkt
-                    .body
-                    .get("room_id")
-                    .and_then(JsonValue::as_str)
-                    .map(str::to_string);
+                // Wire sends the table token as a string; tolerate a number.
+                let room_id = pkt.body.get("room_id").and_then(|v| {
+                    v.as_str()
+                        .map(str::to_string)
+                        .or_else(|| json_i64(v).map(|n| n.to_string()))
+                });
                 self.on_enter_room(room_id, data)
             }
             "cmd_game_start" => self.on_game_start(data),
@@ -168,8 +169,12 @@ impl RiichiCityBridge {
     }
 
     /// `cmd_enter_room` — collect players + table size; emits nothing. Dedups
-    /// repeated messages for the same room by `classify_id`. The wire sends
-    /// `classify_id` as a string; tolerate a number for older payloads.
+    /// a repeated announcement of the *same table* by the wrapper's
+    /// `room_id` (the per-table instance token) — NOT by `classify_id`,
+    /// which names the matchmaking queue class and so repeats across
+    /// consecutive games in the same room tier. The dedup also requires an
+    /// already-collected roster, so a fuller re-announcement can still
+    /// replace an empty one.
     fn on_enter_room(
         &mut self,
         room_id: Option<String>,
@@ -181,10 +186,8 @@ impl RiichiCityBridge {
                 .map(str::to_string)
                 .or_else(|| json_i64(v).map(|n| n.to_string()))
         });
-        if let (Some(prev), Some(now)) =
-            (self.status.classify_id.as_deref(), classify_id.as_deref())
-        {
-            if prev == now {
+        if let (Some(prev), Some(now)) = (self.status.room_id.as_deref(), room_id.as_deref()) {
+            if prev == now && !self.status.player_list.is_empty() {
                 warn!(target: LOG, "duplicate cmd_enter_room for active room, ignored");
                 return Vec::new();
             }
@@ -832,6 +835,95 @@ mod tests {
         );
     }
 
+    /// Consecutive games in the same matchmaking queue share a
+    /// `classify_id` but get distinct table tokens. The dedup must key on
+    /// the table token: the second game's `cmd_enter_room` must be honored
+    /// (fresh `start_game`) even without an intervening `cmd_room_end`.
+    #[test]
+    fn same_queue_new_table_is_not_deduped() {
+        let mut b = RiichiCityBridge::new(None, None);
+        auth(&mut b);
+        enter_room_4p(&mut b);
+        let start = json!({
+            "cmd": "cmd_game_start",
+            "data": {
+                "quan_feng": 0x31, "bao_pai_card": 0x21, "dealer_pos": 0,
+                "ben_chang_num": 0, "li_zhi_bang_num": 0,
+                "user_info_list": [
+                    {"user_id": 1001, "hand_points": 25000},
+                    {"user_id": 1002, "hand_points": 25000},
+                    {"user_id": 1003, "hand_points": 25000},
+                    {"user_id": 1004, "hand_points": 25000}
+                ],
+                "hand_cards": [0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x01,0x02,0x03,0x04,0x05]
+            }
+        });
+        let events = feed(&mut b, 18, start.clone());
+        assert!(matches!(events[0], MjaiEvent::StartGame { .. }));
+
+        // Next game, same queue class, new table token.
+        feed(
+            &mut b,
+            18,
+            json!({
+                "cmd": "cmd_enter_room",
+                "room_id": "tabletoken0002",
+                "data": {
+                    "options": {
+                        "classify_id": "classifytoken0001",
+                        "player_count": 4,
+                        "stage_type": 1,
+                        "game_play": 1001
+                    },
+                    "players": [
+                        {"user": {"user_id": 1001, "nickname": "alice"}},
+                        {"user": {"user_id": 1002, "nickname": "bob"}},
+                        {"user": {"user_id": 1003, "nickname": "carol"}},
+                        {"user": {"user_id": 1004, "nickname": "dave"}}
+                    ]
+                }
+            }),
+        );
+        let events = feed(&mut b, 18, start);
+        match &events[0] {
+            MjaiEvent::StartGame { game_meta, .. } => {
+                match &game_meta.as_ref().expect("meta").match_info {
+                    Some(MatchInfo::RiichiCity { room_id, .. }) => {
+                        assert_eq!(room_id.as_deref(), Some("tabletoken0002"));
+                    }
+                    other => panic!("expected RiichiCity match_info, got {other:?}"),
+                }
+            }
+            other => panic!("expected StartGame for the second game, got {other:?}"),
+        }
+    }
+
+    /// A re-announcement of the *same* table (reconnect) is ignored, so a
+    /// partial payload can't clobber the collected roster.
+    #[test]
+    fn duplicate_same_table_enter_room_keeps_the_roster() {
+        let mut b = RiichiCityBridge::new(None, None);
+        auth(&mut b);
+        enter_room_4p(&mut b);
+        feed(
+            &mut b,
+            18,
+            json!({
+                "cmd": "cmd_enter_room",
+                "room_id": "tabletoken0001",
+                "data": {
+                    "options": { "classify_id": "classifytoken0001", "player_count": 4 },
+                    "players": []
+                }
+            }),
+        );
+        assert_eq!(b.status.player_list, vec![1001, 1002, 1003, 1004]);
+        assert_eq!(
+            b.status.nicknames.get(&1001).map(String::as_str),
+            Some("alice")
+        );
+    }
+
     #[test]
     fn yonma_game_start_emits_start_game_kyoku_tsumo() {
         let mut b = RiichiCityBridge::new(None, None);
@@ -967,6 +1059,22 @@ mod tests {
             _ => None,
         });
         assert_eq!(scores, Some(&vec![33300, 44400, 11100, 22200]));
+
+        // Names follow the same dealer rotation: enter-room order
+        // [alice, bob, carol, dave] rotated by dealer_pos 2.
+        let names = events.iter().find_map(|event| match event {
+            MjaiEvent::StartGame { names, .. } => Some(names),
+            _ => None,
+        });
+        assert_eq!(
+            names,
+            Some(&vec![
+                "carol".to_string(),
+                "dave".to_string(),
+                "alice".to_string(),
+                "bob".to_string(),
+            ])
+        );
     }
 
     #[test]

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -37,7 +37,7 @@ use super::{Bridge, Direction, ParseResult};
 use crate::{
     config::Platform,
     logger::{FlowLogger, Session},
-    schema::{MjaiEvent, ParsedFrame},
+    schema::{GameMeta, MatchInfo, MjaiEvent, ParsedFrame},
 };
 use chrono::Local;
 use consts::card_to_mjai;
@@ -235,7 +235,13 @@ impl RiichiCityBridge {
                 aka_flag: None,
                 id: Some(seat),
                 num_players: self.status.num_players,
-                majsoul_meta: None,
+                game_meta: Some(GameMeta {
+                    game_id: None,
+                    match_mode: None,
+                    match_info: Some(MatchInfo::RiichiCity {
+                        room_id: self.status.classify_id,
+                    }),
+                }),
             });
             self.status.game_start = false;
         }

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -208,6 +208,9 @@ impl RiichiCityBridge {
             for p in players {
                 if let Some(uid) = p.pointer("/user/user_id").and_then(json_i64) {
                     status.player_list.push(uid);
+                    if let Some(name) = p.pointer("/user/nickname").and_then(JsonValue::as_str) {
+                        status.nicknames.insert(uid, name.to_string());
+                    }
                 }
             }
         }
@@ -246,9 +249,16 @@ impl RiichiCityBridge {
             self.status.seat = seat;
             self.status.shift = dealer_pos;
             self.rotate_mjai_log();
-            let names: Vec<String> = (0..self.status.num_players)
-                .map(|i| i.to_string())
+            // Display names in mjai-actor order (player_list is already
+            // dealer-rotated). A missing nickname becomes "" so the frontend
+            // falls back to its localized "Seat N" label.
+            let mut names: Vec<String> = self
+                .status
+                .player_list
+                .iter()
+                .map(|uid| self.status.nicknames.get(uid).cloned().unwrap_or_default())
                 .collect();
+            names.resize(self.status.num_players as usize, String::new());
             events.push(MjaiEvent::StartGame {
                 names,
                 kyoku_first: None,
@@ -812,10 +822,10 @@ mod tests {
                         "game_play": 1001
                     },
                     "players": [
-                        {"user": {"user_id": 1001}},
-                        {"user": {"user_id": 1002}},
-                        {"user": {"user_id": 1003}},
-                        {"user": {"user_id": 1004}}
+                        {"user": {"user_id": 1001, "nickname": "alice"}},
+                        {"user": {"user_id": 1002, "nickname": "bob"}},
+                        {"user": {"user_id": 1003, "nickname": "carol"}},
+                        {"user": {"user_id": 1004, "nickname": "dave"}}
                     ]
                 }
             }),
@@ -861,7 +871,17 @@ mod tests {
             } => {
                 assert_eq!(*id, Some(0));
                 assert_eq!(*num_players, 4);
-                assert_eq!(names.len(), 4);
+                // dealer_pos 0 → no rotation, so names stay in enter-room
+                // order.
+                assert_eq!(
+                    names,
+                    &vec![
+                        "alice".to_string(),
+                        "bob".to_string(),
+                        "carol".to_string(),
+                        "dave".to_string(),
+                    ]
+                );
                 match &game_meta.as_ref().expect("riichi city meta").match_info {
                     Some(MatchInfo::RiichiCity {
                         room_id,

--- a/src/bridge/riichi_city/state.rs
+++ b/src/bridge/riichi_city/state.rs
@@ -29,10 +29,12 @@ pub struct GameStatus {
     /// later rounds: `(dealer_pos - shift) mod num_players`.
     pub shift: i64,
     /// Matchmaking classification id from `cmd_enter_room.options` (a wire
-    /// string of ~22 base32-ish chars). Used to dedup repeated
-    /// `cmd_enter_room` and persisted into history's `MatchInfo`.
+    /// string of ~22 base32-ish chars). Names the queue class — repeats
+    /// across games in the same room tier. Persisted into `MatchInfo`.
     pub classify_id: Option<String>,
     /// Table-instance token from the `cmd_enter_room` wrapper (`room_id`).
+    /// Unique per table, so it (not `classify_id`) keys the duplicate-
+    /// `cmd_enter_room` dedup.
     pub room_id: Option<String>,
     /// `options.stage_type` — rank stage tier of the matchmaking room.
     pub stage_type: Option<i64>,

--- a/src/bridge/riichi_city/state.rs
+++ b/src/bridge/riichi_city/state.rs
@@ -38,6 +38,9 @@ pub struct GameStatus {
     pub stage_type: Option<i64>,
     /// `options.game_play` — game mode id (e.g. 1001).
     pub game_play: Option<i64>,
+    /// `user_id → nickname` from `cmd_enter_room.players[].user`, used to
+    /// stamp real display names onto `start_game`.
+    pub nicknames: std::collections::HashMap<i64, String>,
     /// Actor of the most recent discard — the ron/pon/kan target.
     pub last_dahai_actor: Option<u8>,
     /// Deferred `reach_accepted`, emitted just before the next action so a
@@ -62,6 +65,7 @@ impl Default for GameStatus {
             room_id: None,
             stage_type: None,
             game_play: None,
+            nicknames: std::collections::HashMap::new(),
             last_dahai_actor: None,
             pending_reach: None,
             pending_dora: Vec::new(),

--- a/src/bridge/riichi_city/state.rs
+++ b/src/bridge/riichi_city/state.rs
@@ -28,8 +28,16 @@ pub struct GameStatus {
     /// Dealer position at the first kyoku, used to derive `kyoku`/`oya` for
     /// later rounds: `(dealer_pos - shift) mod num_players`.
     pub shift: i64,
-    /// Room identifier, used to dedup repeated `cmd_enter_room`.
-    pub classify_id: Option<i64>,
+    /// Matchmaking classification id from `cmd_enter_room.options` (a wire
+    /// string of ~22 base32-ish chars). Used to dedup repeated
+    /// `cmd_enter_room` and persisted into history's `MatchInfo`.
+    pub classify_id: Option<String>,
+    /// Table-instance token from the `cmd_enter_room` wrapper (`room_id`).
+    pub room_id: Option<String>,
+    /// `options.stage_type` — rank stage tier of the matchmaking room.
+    pub stage_type: Option<i64>,
+    /// `options.game_play` — game mode id (e.g. 1001).
+    pub game_play: Option<i64>,
     /// Actor of the most recent discard — the ron/pon/kan target.
     pub last_dahai_actor: Option<u8>,
     /// Deferred `reach_accepted`, emitted just before the next action so a
@@ -51,6 +59,9 @@ impl Default for GameStatus {
             num_players: 4,
             shift: 0,
             classify_id: None,
+            room_id: None,
+            stage_type: None,
+            game_play: None,
             last_dahai_actor: None,
             pending_reach: None,
             pending_dora: Vec::new(),

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     autoplay::tenhou_state::{SharedTenhouState, TenhouState},
     config::Platform,
     logger::{FlowLogger, Session},
-    schema::{mjai::Actor, MjaiEvent},
+    schema::{mjai::Actor, GameMeta, MatchInfo, MjaiEvent},
 };
 use chrono::Local;
 use meld::{Meld, MeldKind};
@@ -127,10 +127,16 @@ impl TenhouBridge {
         // Tags that contribute no mjai events — silently ignored. The Python
         // reference does the same in `_convert_helo`, `_convert_rejoin`, etc.
         match tag {
-            "HELO" | "REJOIN" | "GO" | "UN" | "BYE" | "SHUFFLE" => return Vec::new(),
+            "HELO" | "REJOIN" | "BYE" | "SHUFFLE" => return Vec::new(),
             _ => {}
         }
 
+        if tag == "GO" {
+            return self.on_go(msg);
+        }
+        if tag == "UN" {
+            return self.on_un(msg);
+        }
         if tag == "TAIKYOKU" {
             return self.on_taikyoku(msg);
         }
@@ -162,14 +168,49 @@ impl TenhouBridge {
         Vec::new()
     }
 
-    /// `<TAIKYOKU oya="N" .../>` — start of game. Resolves our wire-absolute
-    /// seat but defers `start_game` emission until the first `<INIT/>`, where
-    /// the 0-score slot reveals whether the game is sanma. Without that wait
-    /// we'd stamp `start_game.num_players = 4` on every sanma game (Tenhou's
-    /// TAIKYOKU itself carries no player-count signal — only the dealer's
-    /// relative seat).
+    /// `<GO type="…" lobby="…"/>` — rules/room announcement, sent before
+    /// `<TAIKYOKU/>`. No mjai events; the raw bitfield is stashed for
+    /// history's `MatchInfo` (room tier lives in bits 0x20 / 0x80).
+    fn on_go(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
+        self.state.go_type = parse_u32(msg, "type");
+        self.state.lobby = parse_u32(msg, "lobby");
+        Vec::new()
+    }
+
+    /// `<UN n0=… n1=… …/>` — player roster, names percent-encoded UTF-8 in
+    /// wire-*relative* order (n0 = us). A reconnect `<UN/>` carries only the
+    /// returning player's name, so only the roster form (n0 and n1 both
+    /// present) is accepted — a partial update must not clobber good names.
+    /// No mjai events; consumed at `start_game` emission.
+    fn on_un(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
+        let name = |key: &str| {
+            msg.get(key).and_then(JsonValue::as_str).map(|raw| {
+                percent_encoding::percent_decode_str(raw)
+                    .decode_utf8_lossy()
+                    .into_owned()
+            })
+        };
+        let (Some(n0), Some(n1)) = (name("n0"), name("n1")) else {
+            return Vec::new();
+        };
+        let n2 = name("n2").unwrap_or_default();
+        let n3 = name("n3").unwrap_or_default();
+        self.state.un_names = Some([n0, n1, n2, n3]);
+        Vec::new()
+    }
+
+    /// `<TAIKYOKU oya="N" log="…"/>` — start of game. Resolves our
+    /// wire-absolute seat but defers `start_game` emission until the first
+    /// `<INIT/>`, where the 0-score slot reveals whether the game is sanma.
+    /// Without that wait we'd stamp `start_game.num_players = 4` on every
+    /// sanma game (Tenhou's TAIKYOKU itself carries no player-count signal —
+    /// only the dealer's relative seat). The `log` attribute is the paifu id.
     fn on_taikyoku(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
         let oya_rel = parse_u8(msg, "oya").unwrap_or(0);
+        self.state.log_id = msg
+            .get("log")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string);
         // oya is dealer's *relative* seat in the 4-cycle wire frame. Our
         // wire-abs seat is the inverse: (-oya_rel) mod 4. For sanma our
         // wire-abs is always in {0, 1, 2} because we are a real player —
@@ -180,6 +221,31 @@ impl TenhouBridge {
         self.state.pending_start_game = true;
         self.rotate_mjai_log();
         Vec::new()
+    }
+
+    /// Seat-ordered display names for `start_game`. `<UN/>` roster names are
+    /// wire-relative (index 0 = us) and arrive before `<TAIKYOKU/>` resolves
+    /// our seat, so the remap to wire-absolute happens here (sanma ghost slot
+    /// skipped). Falls back to the historical seat-number placeholders when
+    /// no roster `<UN/>` was seen.
+    fn build_start_names(&mut self) -> Vec<String> {
+        let n = self.state.num_players as usize;
+        let mut names: Vec<String> = (0..n).map(|i| i.to_string()).collect();
+        if let Some(un) = self.state.un_names.take() {
+            for (rel, name) in un.into_iter().enumerate() {
+                if name.is_empty() {
+                    continue;
+                }
+                let abs = self.state.rel_to_abs(rel as u8);
+                if self.state.is_ghost_abs(abs) {
+                    continue;
+                }
+                if let Some(slot) = names.get_mut(abs as usize) {
+                    *slot = name;
+                }
+            }
+        }
+        names
     }
 
     /// `<INIT seed="..." ten="..." oya="..." hai0="..."/>` — start of kyoku.
@@ -251,14 +317,25 @@ impl TenhouBridge {
         let mut events = Vec::with_capacity(2);
         if self.state.pending_start_game {
             self.state.pending_start_game = false;
-            let names: Vec<String> = (0..self.state.num_players).map(|i| i.to_string()).collect();
+            let names = self.build_start_names();
+            // `take()` so a following game that somehow skips GO/UN/TAIKYOKU
+            // attributes falls back to None instead of stale values.
+            let match_info = MatchInfo::Tenhou {
+                log_id: self.state.log_id.take(),
+                go_type: self.state.go_type.take(),
+                lobby: self.state.lobby.take(),
+            };
             events.push(MjaiEvent::StartGame {
                 names,
                 kyoku_first: None,
                 aka_flag: None,
                 id: Some(self.state.seat as Actor),
                 num_players: self.state.num_players,
-                majsoul_meta: None,
+                game_meta: Some(GameMeta {
+                    game_id: None,
+                    match_mode: None,
+                    match_info: Some(match_info),
+                }),
             });
         }
         events.push(MjaiEvent::StartKyoku {
@@ -853,6 +930,124 @@ mod tests {
         // start_game is emitted at the first INIT (when sanma is known).
         let events = parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#);
         assert!(events.is_empty(), "start_game must be deferred to INIT");
+    }
+
+    /// GO / UN / TAIKYOKU metadata surfaces on `start_game`: real roster
+    /// names (percent-decoded, remapped from wire-relative to wire-absolute
+    /// seats) plus `MatchInfo::Tenhou` with the room bitfield, lobby and
+    /// paifu id.
+    #[test]
+    fn go_un_taikyoku_metadata_reaches_start_game() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"GO","type":"169","lobby":"0"}"#);
+        // n0 is *us* (wire-relative); "%E3%81%82" decodes to "あ".
+        parse_one(
+            &mut b,
+            r#"{"tag":"UN","n0":"%E3%81%82","n1":"bob","n2":"carol","n3":"dave","dan":"16,15,14,13","rate":"2100.00,2000.00,1900.00,1800.00"}"#,
+        );
+        // Dealer at rel 1 → our wire-abs seat = (4-1)%4 = 3.
+        parse_one(
+            &mut b,
+            r#"{"tag":"TAIKYOKU","oya":"1","log":"2026082300gm-00a9-0000-deadbeef"}"#,
+        );
+        let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"1","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
+        let events = parse_one(&mut b, init);
+        match &events[0] {
+            MjaiEvent::StartGame {
+                id,
+                names,
+                game_meta,
+                ..
+            } => {
+                assert_eq!(*id, Some(3));
+                // rel [us, shimocha, toimen, kamicha] → abs [3, 0, 1, 2].
+                assert_eq!(
+                    names,
+                    &vec![
+                        "bob".to_string(),
+                        "carol".to_string(),
+                        "dave".to_string(),
+                        "あ".to_string(),
+                    ]
+                );
+                let meta = game_meta.as_ref().expect("tenhou game meta");
+                match &meta.match_info {
+                    Some(MatchInfo::Tenhou {
+                        log_id,
+                        go_type,
+                        lobby,
+                    }) => {
+                        assert_eq!(log_id.as_deref(), Some("2026082300gm-00a9-0000-deadbeef"));
+                        assert_eq!(*go_type, Some(169));
+                        assert_eq!(*lobby, Some(0));
+                    }
+                    other => panic!("expected Tenhou match_info, got {other:?}"),
+                }
+            }
+            other => panic!("expected StartGame first, got {other:?}"),
+        }
+    }
+
+    /// A reconnect `<UN/>` carries a single player's name — it must not
+    /// clobber a full roster (or install a mostly-empty one).
+    #[test]
+    fn partial_un_does_not_replace_roster() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(
+            &mut b,
+            r#"{"tag":"UN","n0":"alice","n1":"bob","n2":"carol","n3":"dave"}"#,
+        );
+        parse_one(&mut b, r#"{"tag":"UN","n2":"carol"}"#);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"0"}"#);
+        let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
+        let events = parse_one(&mut b, init);
+        match &events[0] {
+            MjaiEvent::StartGame { names, .. } => {
+                // oya rel 0 → our seat 0, so rel order == abs order here.
+                assert_eq!(
+                    names,
+                    &vec![
+                        "alice".to_string(),
+                        "bob".to_string(),
+                        "carol".to_string(),
+                        "dave".to_string(),
+                    ]
+                );
+            }
+            other => panic!("expected StartGame first, got {other:?}"),
+        }
+    }
+
+    /// Sanma roster: the wire stays 4-positional and relative, so the ghost
+    /// slot's empty name sits at the ghost's *relative* index (here rel 1:
+    /// our seat is 2, ghost wire-abs is 3). Real names land on their real
+    /// seats and the emitted vector stays length 3.
+    #[test]
+    fn sanma_un_names_skip_the_ghost_slot() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(
+            &mut b,
+            r#"{"tag":"UN","n0":"alice","n1":"","n2":"bob","n3":"carol"}"#,
+        );
+        // Dealer at rel 2 → our wire-abs = (4-2)%4 = 2.
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"2"}"#);
+        // 0-score 4th slot at E1H0 marks sanma.
+        let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"350,350,350,0","oya":"2","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
+        let events = parse_one(&mut b, init);
+        match &events[0] {
+            MjaiEvent::StartGame {
+                names, num_players, ..
+            } => {
+                assert_eq!(*num_players, 3);
+                // rel→abs with seat 2: rel0→2 (alice), rel1→3 ghost (empty,
+                // skipped), rel2→0 (bob), rel3→1 (carol).
+                assert_eq!(
+                    names,
+                    &vec!["bob".to_string(), "carol".to_string(), "alice".to_string()]
+                );
+            }
+            other => panic!("expected StartGame first, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -318,12 +318,17 @@ impl TenhouBridge {
         if self.state.pending_start_game {
             self.state.pending_start_game = false;
             let names = self.build_start_names();
-            // `take()` so a following game that somehow skips GO/UN/TAIKYOKU
-            // attributes falls back to None instead of stale values.
+            // Read non-destructively: a reconnect can replay TAIKYOKU+INIT
+            // without a fresh <GO/>, and the re-emitted start_game must
+            // keep the room bitfield. A *new* game always sends its own
+            // <GO/> (and every TAIKYOKU reassigns log_id), so staleness
+            // across games isn't a concern. Names ARE consumed (in
+            // `build_start_names`): a stale roster is worse than a missing
+            // one, and reconnects resend the full <UN/>.
             let match_info = MatchInfo::Tenhou {
-                log_id: self.state.log_id.take(),
-                go_type: self.state.go_type.take(),
-                lobby: self.state.lobby.take(),
+                log_id: self.state.log_id.clone(),
+                go_type: self.state.go_type,
+                lobby: self.state.lobby,
             };
             events.push(MjaiEvent::StartGame {
                 names,
@@ -997,7 +1002,9 @@ mod tests {
             &mut b,
             r#"{"tag":"UN","n0":"alice","n1":"bob","n2":"carol","n3":"dave"}"#,
         );
-        parse_one(&mut b, r#"{"tag":"UN","n2":"carol"}"#);
+        // A different name in the partial update proves the guard rejected
+        // the whole message rather than merging the one field.
+        parse_one(&mut b, r#"{"tag":"UN","n2":"INTRUDER"}"#);
         parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"0"}"#);
         let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
         let events = parse_one(&mut b, init);
@@ -1031,8 +1038,9 @@ mod tests {
         );
         // Dealer at rel 2 → our wire-abs = (4-2)%4 = 2.
         parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"2"}"#);
-        // 0-score 4th slot at E1H0 marks sanma.
-        let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"350,350,350,0","oya":"2","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
+        // 0-score slot at E1H0 marks sanma; like the UN names, `ten` is
+        // relative, so the ghost's 0 sits at rel 1 (wire-abs 3) here.
+        let init = r#"{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"350,0,350,350","oya":"2","hai":"0,4,8,36,40,44,72,76,80,108,112,116,120"}"#;
         let events = parse_one(&mut b, init);
         match &events[0] {
             MjaiEvent::StartGame {
@@ -1047,6 +1055,14 @@ mod tests {
                 );
             }
             other => panic!("expected StartGame first, got {other:?}"),
+        }
+        // The ghost's rel-1 zero is skipped; all three real seats carry
+        // their 35000.
+        match &events[1] {
+            MjaiEvent::StartKyoku { scores, .. } => {
+                assert_eq!(scores, &vec![35000, 35000, 35000]);
+            }
+            other => panic!("expected StartKyoku second, got {other:?}"),
         }
     }
 

--- a/src/bridge/tenhou/state.rs
+++ b/src/bridge/tenhou/state.rs
@@ -45,6 +45,17 @@ pub struct State {
     /// next `<INIT/>`. We defer emission so we know yonma vs sanma (via INIT's
     /// 0-score slot) and can stamp `num_players` correctly on `start_game`.
     pub pending_start_game: bool,
+    /// `<GO type=…/>` rule/room bitfield (room tier in bits 0x20/0x80),
+    /// stashed until `start_game` emission consumes it into `MatchInfo`.
+    pub go_type: Option<u32>,
+    /// `<GO lobby=…/>` lobby number, stashed like `go_type`.
+    pub lobby: Option<u32>,
+    /// `<TAIKYOKU log=…/>` paifu id, stashed like `go_type`.
+    pub log_id: Option<String>,
+    /// `<UN/>` roster names, percent-decoded, in wire-*relative* order
+    /// (index 0 = us). `<UN/>` arrives before `<TAIKYOKU/>` resolves our
+    /// seat, so the remap to wire-absolute happens at `start_game` emission.
+    pub un_names: Option<[String; 4]>,
     /// Decision window currently open for *our* seat, if any. Only consumed by
     /// autoplay (see [`crate::autoplay::tenhou_state`]); parsing keeps it up to
     /// date unconditionally because it is cheap and a stale window is worse
@@ -66,6 +77,10 @@ impl Default for State {
             num_players: 4,
             last_revealed_tile_actor: None,
             pending_start_game: false,
+            go_type: None,
+            lobby: None,
+            log_id: None,
+            un_names: None,
             window: None,
         }
     }

--- a/src/bridge/tenhou/state.rs
+++ b/src/bridge/tenhou/state.rs
@@ -46,11 +46,13 @@ pub struct State {
     /// 0-score slot) and can stamp `num_players` correctly on `start_game`.
     pub pending_start_game: bool,
     /// `<GO type=…/>` rule/room bitfield (room tier in bits 0x20/0x80),
-    /// stashed until `start_game` emission consumes it into `MatchInfo`.
+    /// stashed for `start_game` emission. Read non-destructively so a
+    /// reconnect's re-emitted `start_game` (TAIKYOKU+INIT with no fresh
+    /// `<GO/>`) keeps the room; every new game sends its own `<GO/>`.
     pub go_type: Option<u32>,
     /// `<GO lobby=…/>` lobby number, stashed like `go_type`.
     pub lobby: Option<u32>,
-    /// `<TAIKYOKU log=…/>` paifu id, stashed like `go_type`.
+    /// `<TAIKYOKU log=…/>` paifu id; reassigned by every `<TAIKYOKU/>`.
     pub log_id: Option<String>,
     /// `<UN/>` roster names, percent-decoded, in wire-*relative* order
     /// (index 0 = us). `<UN/>` arrives before `<TAIKYOKU/>` resolves our

--- a/src/game_state/convert.rs
+++ b/src/game_state/convert.rs
@@ -85,7 +85,7 @@ mod tests {
             aka_flag: None,
             id: Some(2),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         };
         let out = to_riichienv(&ev).unwrap().unwrap();
         match out {
@@ -104,7 +104,7 @@ mod tests {
             aka_flag: None,
             id: None,
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         };
         let out = to_riichienv(&ev).unwrap().unwrap();
         assert!(matches!(out, RiEvent::StartGame { id: None, .. }));

--- a/src/game_state/score.rs
+++ b/src/game_state/score.rs
@@ -530,7 +530,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         })
         .unwrap();
         t.handle(&E::StartKyoku {

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -489,7 +489,7 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 
@@ -566,7 +566,7 @@ mod tests {
             aka_flag: None,
             id: None, // observer / replay: no seat of ours
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         })
         .unwrap();
         assert_eq!(t.our_seat_can_act(), None, "no seat, no opinion");
@@ -796,7 +796,7 @@ mod tests {
             aka_flag: None,
             id: seat,
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 
@@ -1010,7 +1010,7 @@ mod tests {
             aka_flag: None,
             id: Some(1),
             num_players: 3,
-            majsoul_meta: None,
+            game_meta: None,
         };
         t.handle(&ev).unwrap();
         assert!(t.state().is_none(), "state() returns None for 3p");

--- a/src/history/README.md
+++ b/src/history/README.md
@@ -64,6 +64,24 @@ When a non-Majsoul bridge lands (Tenhou, RiichiCity, ...):
 4. Older `index.jsonl` lines will deserialise with the new field defaulting;
    no migration step is required so long as the new field has a `Default`.
 
+## Match identity (`GameRecord.match_info`)
+
+`schema::history::MatchInfo` is a platform-tagged enum carrying the raw room
+/ rank-lobby ids and the platform's own game (paifu) id — e.g. Majsoul
+`mode_id` + `game_uuid`, Tenhou `<GO type>` bitfield + log id. Bridges attach
+it to `StartGame.game_meta` (a `#[serde(skip)]` field, so mjai logs and the
+inference API never see it) and the aggregator copies it into the record.
+
+Rules of the road:
+
+- Store **raw platform values**; label mapping lives in the frontend
+  (`frontend/src/lib/matchInfo.ts` + `history.room.*` locale keys) so an
+  unknown id shows as a number instead of a wrong name.
+- Every field is `Option` + `#[serde(default)]` — bridges fill what their
+  wire carried, old index lines deserialise with `match_info: None`.
+- To extend: add fields/variants in `schema/history.rs`, fill them in the
+  bridge's StartGame emission, mirror in `frontend/src/types.ts`.
+
 ## Adding a filter dimension
 
 1. Add the field to `HistoryFilter` (in `schema/history.rs`).

--- a/src/history/aggregator.rs
+++ b/src/history/aggregator.rs
@@ -52,14 +52,14 @@ pub fn aggregate(input: AggregateInput<'_>) -> Option<GameRecord> {
     } = input;
 
     // ----- Bootstrap: pull num_players + names + our_seat from start_game -----
-    let (num_players, names, our_seat, majsoul_meta) = events.iter().find_map(|ev| match ev {
+    let (num_players, names, our_seat, game_meta) = events.iter().find_map(|ev| match ev {
         MjaiEvent::StartGame {
             names,
             id,
             num_players,
-            majsoul_meta,
+            game_meta,
             ..
-        } => Some((*num_players, names.clone(), *id, *majsoul_meta)),
+        } => Some((*num_players, names.clone(), *id, game_meta.clone())),
         _ => None,
     })?;
 
@@ -77,7 +77,7 @@ pub fn aggregate(input: AggregateInput<'_>) -> Option<GameRecord> {
     let mut cur_scores = vec![0i32; n];
     let mut stats = GameStats::default();
 
-    let mut kyoku_mode = match majsoul_meta.and_then(|meta| meta.match_mode) {
+    let mut kyoku_mode = match game_meta.as_ref().and_then(|meta| meta.match_mode) {
         // 2 = 4p East-South, 12 = 3p East-South.
         Some(2) | Some(12) => KyokuMode::EastSouth,
         _ => KyokuMode::EastOnly,
@@ -348,6 +348,7 @@ pub fn aggregate(input: AggregateInput<'_>) -> Option<GameRecord> {
         our_rank,
         our_delta,
         stats,
+        match_info: game_meta.and_then(|meta| meta.match_info),
         log_path: format!("games/{id}.mjai.jsonl"),
     })
 }
@@ -405,7 +406,7 @@ fn ranks_from_scores(scores: &[i32]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::MajsoulGameMeta;
+    use crate::schema::{GameMeta, MatchInfo};
 
     fn ts() -> DateTime<Utc> {
         DateTime::parse_from_rfc3339("2026-05-01T10:00:00Z")
@@ -420,7 +421,7 @@ mod tests {
             aka_flag: Some(true),
             id: Some(seat),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 
@@ -436,6 +437,43 @@ mod tests {
             tehais: vec![vec![]; 4],
             num_players: 4,
         }
+    }
+
+    /// `match_info` rides the in-process StartGame meta into the persisted
+    /// record.
+    #[test]
+    fn match_info_is_copied_into_the_record() {
+        let info = MatchInfo::Majsoul {
+            game_uuid: Some("240101-uuid".into()),
+            mode_id: Some(11),
+            room_id: None,
+            contest_uid: None,
+        };
+        let mut start = start_game_4p(0);
+        if let MjaiEvent::StartGame { game_meta, .. } = &mut start {
+            *game_meta = Some(GameMeta {
+                game_id: Some(1),
+                match_mode: Some(1),
+                match_info: Some(info.clone()),
+            });
+        }
+        let events = vec![
+            start,
+            start_kyoku("E", 0, vec![25000; 4]),
+            MjaiEvent::confirmed_game(
+                Some(vec![30000, 25000, 25000, 20000]),
+                Some(vec![1, 2, 3, 4]),
+            ),
+        ];
+        let rec = aggregate(AggregateInput {
+            events: &events,
+            platform: Platform::Majsoul,
+            started_at: ts(),
+            ended_at: ts(),
+            id: "MATCHINFO".into(),
+        })
+        .unwrap();
+        assert_eq!(rec.match_info, Some(info));
     }
 
     #[test]
@@ -545,10 +583,11 @@ mod tests {
     #[test]
     fn planned_hanchan_stays_hanchan_when_bankruptcy_ends_it_in_east() {
         let mut start = start_game_4p(1);
-        if let MjaiEvent::StartGame { majsoul_meta, .. } = &mut start {
-            *majsoul_meta = Some(MajsoulGameMeta {
+        if let MjaiEvent::StartGame { game_meta, .. } = &mut start {
+            *game_meta = Some(GameMeta {
                 game_id: Some(7),
                 match_mode: Some(2),
+                match_info: None,
             });
         }
         let events = vec![
@@ -580,9 +619,10 @@ mod tests {
                 aka_flag: Some(true),
                 id: Some(0),
                 num_players: 3,
-                majsoul_meta: Some(MajsoulGameMeta {
+                game_meta: Some(GameMeta {
                     game_id: Some(7),
                     match_mode: Some(12),
+                    match_info: None,
                 }),
             },
             MjaiEvent::StartKyoku {
@@ -633,7 +673,7 @@ mod tests {
                 aka_flag: Some(true),
                 id: None,
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             },
             start_kyoku("E", 0, vec![25000, 25000, 25000, 25000]),
             MjaiEvent::Hora {
@@ -668,7 +708,7 @@ mod tests {
                 aka_flag: Some(true),
                 id: Some(0),
                 num_players: 3,
-                majsoul_meta: None,
+                game_meta: None,
             },
             MjaiEvent::StartKyoku {
                 bakaze: "E".into(),

--- a/src/history/recorder.rs
+++ b/src/history/recorder.rs
@@ -114,8 +114,8 @@ impl RecorderState {
 
     fn handle(&mut self, ev: MjaiEvent, store: &HistoryStore, bus: &HistoryBus) {
         match &ev {
-            MjaiEvent::StartGame { majsoul_meta, .. } => {
-                let incoming_game_id = majsoul_meta.and_then(|meta| meta.game_id);
+            MjaiEvent::StartGame { game_meta, .. } => {
+                let incoming_game_id = game_meta.as_ref().and_then(|meta| meta.game_id);
                 let reconnecting_same_game = incoming_game_id.is_some()
                     && incoming_game_id == self.game_id
                     && self.buf.is_some()
@@ -268,16 +268,17 @@ mod tests {
             aka_flag: Some(true),
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }
     }
 
     fn start_game_with_id(game_id: u64) -> MjaiEvent {
         let mut event = start_game();
-        if let MjaiEvent::StartGame { majsoul_meta, .. } = &mut event {
-            *majsoul_meta = Some(crate::schema::MajsoulGameMeta {
+        if let MjaiEvent::StartGame { game_meta, .. } = &mut event {
+            *game_meta = Some(crate::schema::GameMeta {
                 game_id: Some(game_id),
                 match_mode: Some(2),
+                match_info: None,
             });
         }
         event

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -250,6 +250,7 @@ mod tests {
             our_rank: Some(1),
             our_delta: Some(5000),
             stats: GameStats::default(),
+            match_info: None,
             log_path: format!("games/{id}.mjai.jsonl"),
         }
     }
@@ -262,7 +263,7 @@ mod tests {
                 aka_flag: Some(true),
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             },
             MjaiEvent::end_game(),
         ]

--- a/src/schema/history.rs
+++ b/src/schema/history.rs
@@ -86,10 +86,12 @@ pub enum MatchInfo {
     },
     /// Riichi City. `stage_type` / `game_play` / `classify_id` come from
     /// `cmd_enter_room.options` and identify the matchmaking room;
-    /// `stage_type` 1..=4 = Star / Moon / Sun / Galaxy (the ranked room
-    /// tiers, per the client's `readStageClassifies` protocol). `room_id`
-    /// is the table-instance token from the `cmd_enter_room` wrapper. All
-    /// raw wire values.
+    /// `stage_type` 1..=4 = Star / Moon / Sun / Galaxy (新星/霞月/炎陽/銀河,
+    /// the ranked room tiers) and `game_play` is the client's `GamePlayType`
+    /// (1001 ranked, 1002 tournament, 1003 friendly, 1004/1005 one-round,
+    /// 1021 Taiwan-rules ranked, 1007..=1016/1022 casual-hall variants).
+    /// `room_id` is the table-instance token from the `cmd_enter_room`
+    /// wrapper. All raw wire values.
     RiichiCity {
         #[serde(default)]
         room_id: Option<String>,

--- a/src/schema/history.rs
+++ b/src/schema/history.rs
@@ -84,11 +84,19 @@ pub enum MatchInfo {
         #[serde(default)]
         lobby: Option<u32>,
     },
-    /// Riichi City. Skeleton until the room/rank payload fields are mapped —
-    /// `room_id` is the raw room identifier from `cmd_enter_room`.
+    /// Riichi City. `stage_type` / `game_play` / `classify_id` come from
+    /// `cmd_enter_room.options` and identify the matchmaking room (rank
+    /// stage tier, game mode); `room_id` is the table-instance token from
+    /// the `cmd_enter_room` wrapper. All raw wire values.
     RiichiCity {
         #[serde(default)]
-        room_id: Option<i64>,
+        room_id: Option<String>,
+        #[serde(default)]
+        classify_id: Option<String>,
+        #[serde(default)]
+        stage_type: Option<i64>,
+        #[serde(default)]
+        game_play: Option<i64>,
     },
 }
 
@@ -316,7 +324,12 @@ mod tests {
                 go_type: Some(169),
                 lobby: Some(0),
             },
-            MatchInfo::RiichiCity { room_id: Some(4) },
+            MatchInfo::RiichiCity {
+                room_id: Some("tabletoken0001".into()),
+                classify_id: Some("classifytoken0001".into()),
+                stage_type: Some(1),
+                game_play: Some(1001),
+            },
         ];
         for info in infos {
             let j = serde_json::to_value(&info).unwrap();

--- a/src/schema/history.rs
+++ b/src/schema/history.rs
@@ -11,6 +11,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::schema::MjaiEvent;
 
@@ -40,6 +41,55 @@ pub enum KyokuMode {
     /// Saw `"W"` or `"N"` — west / north overtime, treated as hanchan
     /// for scoring (Majsoul never uses these except as continuation).
     Other,
+}
+
+// ---------- MatchInfo ----------
+
+/// Platform-specific match identity captured at `start_game`: which room /
+/// rank lobby the game was played in, plus the platform's own game id.
+///
+/// Values are stored **raw** (numeric ids, wire strings). Mapping them to
+/// display labels ("Gold Room East", "Houou") is a frontend concern so an
+/// id the app doesn't know yet degrades to showing the number instead of a
+/// wrong label. Tagged like [`Platform`] so the JSON is self-describing;
+/// every field is optional because each bridge fills only what its wire
+/// actually carried.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "platform", rename_all = "snake_case")]
+pub enum MatchInfo {
+    /// Mahjong Soul. `mode_id` is `game_config.meta.mode_id` — the ranked
+    /// matchmaking mode (1..=28 covers Bronze..Throne and Melee, 4p and 3p);
+    /// 0 for non-matchmade tables. `room_id` is the friendly-room number and
+    /// `contest_uid` the tournament id, when applicable.
+    Majsoul {
+        /// Raw `ReqAuthGame.game_uuid` — the paifu (replay) identifier.
+        #[serde(default)]
+        game_uuid: Option<String>,
+        #[serde(default)]
+        mode_id: Option<u32>,
+        #[serde(default)]
+        room_id: Option<u32>,
+        #[serde(default)]
+        contest_uid: Option<u32>,
+    },
+    /// Tenhou. `log_id` is the paifu id from `<TAIKYOKU log=…>`; `go_type`
+    /// is the raw `<GO type=…>` rule/room bitfield (room tier in bits 0x20 /
+    /// 0x80); `lobby` is the lobby number from the same message.
+    Tenhou {
+        #[serde(default)]
+        log_id: Option<String>,
+        #[serde(default)]
+        go_type: Option<u32>,
+        #[serde(default)]
+        lobby: Option<u32>,
+    },
+    /// Riichi City. Skeleton until the room/rank payload fields are mapped —
+    /// `room_id` is the raw room identifier from `cmd_enter_room`.
+    RiichiCity {
+        #[serde(default)]
+        room_id: Option<i64>,
+    },
 }
 
 // ---------- GameStats ----------
@@ -150,6 +200,12 @@ pub struct GameRecord {
 
     pub stats: GameStats,
 
+    /// Platform-specific match identity (rank room, game/paifu id). `None`
+    /// for records written before this field existed and for bridges that
+    /// don't provide it.
+    #[serde(default)]
+    pub match_info: Option<MatchInfo>,
+
     /// Path of the mjai.jsonl copy, relative to the history root —
     /// always `"games/<id>.mjai.jsonl"`.
     pub log_path: String,
@@ -247,6 +303,84 @@ mod tests {
     }
 
     #[test]
+    fn match_info_round_trips_and_omits_none_fields() {
+        let infos = [
+            MatchInfo::Majsoul {
+                game_uuid: Some("240101-abcd".into()),
+                mode_id: Some(9),
+                room_id: None,
+                contest_uid: None,
+            },
+            MatchInfo::Tenhou {
+                log_id: Some("2026082300gm-00a9-0000-deadbeef".into()),
+                go_type: Some(169),
+                lobby: Some(0),
+            },
+            MatchInfo::RiichiCity { room_id: Some(4) },
+        ];
+        for info in infos {
+            let j = serde_json::to_value(&info).unwrap();
+            let back: MatchInfo = serde_json::from_value(j).unwrap();
+            assert_eq!(back, info);
+        }
+
+        let j = serde_json::to_value(MatchInfo::Majsoul {
+            game_uuid: None,
+            mode_id: Some(12),
+            room_id: None,
+            contest_uid: None,
+        })
+        .unwrap();
+        assert_eq!(j["platform"], "majsoul");
+        assert_eq!(j["mode_id"], 12);
+        assert!(j.get("game_uuid").is_none(), "None fields must be omitted");
+
+        // A stored variant missing optional fields entirely still parses.
+        let back: MatchInfo = serde_json::from_str(r#"{"platform":"tenhou"}"#).unwrap();
+        assert_eq!(
+            back,
+            MatchInfo::Tenhou {
+                log_id: None,
+                go_type: None,
+                lobby: None
+            }
+        );
+    }
+
+    /// Records written before `match_info` existed (no such key in the JSON
+    /// line) keep parsing, defaulting to `None`.
+    #[test]
+    fn game_record_without_match_info_still_parses() {
+        let r = GameRecord {
+            id: "OLD".into(),
+            started_at: Utc::now(),
+            ended_at: Utc::now(),
+            platform: Platform::Majsoul,
+            num_players: 4,
+            kyoku_mode: KyokuMode::EastSouth,
+            names: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            our_seat: Some(0),
+            final_scores: vec![30000, 25000, 25000, 20000],
+            final_ranks: vec![1, 2, 3, 4],
+            our_rank: Some(1),
+            our_delta: Some(5000),
+            stats: GameStats::default(),
+            match_info: Some(MatchInfo::Majsoul {
+                game_uuid: Some("u".into()),
+                mode_id: Some(8),
+                room_id: None,
+                contest_uid: None,
+            }),
+            log_path: "games/OLD.mjai.jsonl".into(),
+        };
+        let mut j = serde_json::to_value(&r).unwrap();
+        j.as_object_mut().unwrap().remove("match_info");
+        let back: GameRecord = serde_json::from_value(j).unwrap();
+        assert_eq!(back.match_info, None);
+        assert_eq!(back.id, r.id);
+    }
+
+    #[test]
     fn history_filter_default_matches_everything() {
         let r = GameRecord {
             id: "01ARZ".into(),
@@ -262,6 +396,7 @@ mod tests {
             our_rank: Some(1),
             our_delta: Some(5000),
             stats: GameStats::default(),
+            match_info: None,
             log_path: "games/01ARZ.mjai.jsonl".into(),
         };
         assert!(HistoryFilter::default().matches(&r));
@@ -283,6 +418,7 @@ mod tests {
             our_rank: None,
             our_delta: None,
             stats: GameStats::default(),
+            match_info: None,
             log_path: "x".into(),
         };
         let f = HistoryFilter {
@@ -308,6 +444,7 @@ mod tests {
             our_rank: Some(3),
             our_delta: Some(0),
             stats: GameStats::default(),
+            match_info: None,
             log_path: "games/rec1.mjai.jsonl".into(),
         };
         let ev = HistoryEvent::Recorded {

--- a/src/schema/history.rs
+++ b/src/schema/history.rs
@@ -85,9 +85,11 @@ pub enum MatchInfo {
         lobby: Option<u32>,
     },
     /// Riichi City. `stage_type` / `game_play` / `classify_id` come from
-    /// `cmd_enter_room.options` and identify the matchmaking room (rank
-    /// stage tier, game mode); `room_id` is the table-instance token from
-    /// the `cmd_enter_room` wrapper. All raw wire values.
+    /// `cmd_enter_room.options` and identify the matchmaking room;
+    /// `stage_type` 1..=4 = Star / Moon / Sun / Galaxy (the ranked room
+    /// tiers, per the client's `readStageClassifies` protocol). `room_id`
+    /// is the table-instance token from the `cmd_enter_room` wrapper. All
+    /// raw wire values.
     RiichiCity {
         #[serde(default)]
         room_id: Option<String>,

--- a/src/schema/mjai/mod.rs
+++ b/src/schema/mjai/mod.rs
@@ -27,8 +27,10 @@ pub type Actor = u8;
 /// cloud inference API continue to receive the standard protocol shape.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GameMeta {
-    /// Stable hash of `ReqAuthGame.game_uuid` (Majsoul), used to recognize a
-    /// reconnect of the same table without comparing the UUID itself.
+    /// Stable hash of `ReqAuthGame.game_uuid` (Majsoul) — the reconnect key
+    /// the history recorder dedups on. The raw UUID itself travels
+    /// separately in `match_info` (persisted to the local history index,
+    /// never uploaded).
     pub game_id: Option<u64>,
     /// `game_config.mode.mode` (Majsoul): 1/2 = 4p East / East-South,
     /// 11/12 = 3p East / East-South.

--- a/src/schema/mjai/mod.rs
+++ b/src/schema/mjai/mod.rs
@@ -14,23 +14,28 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::schema::history::MatchInfo;
+
 /// mjai tile string. Examples: `"1m"`, `"5mr"` (red 5), `"E"`, `"P"`, `"?"`.
 pub type Tile = String;
 
 /// Seat index, 0..=3 (4p) or 0..=2 (3p).
 pub type Actor = u8;
 
-/// Mahjong Soul data kept inside Akagi's typed event bus. These fields are
-/// deliberately excluded from mjai JSON so subprocess bots, logs and the cloud
-/// inference API continue to receive the standard protocol shape.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct MajsoulGameMeta {
-    /// Stable hash of `ReqAuthGame.game_uuid`, used to recognize a reconnect of
-    /// the same table without persisting the UUID itself.
+/// In-process game metadata kept inside Akagi's typed event bus. These fields
+/// are deliberately excluded from mjai JSON so subprocess bots, logs and the
+/// cloud inference API continue to receive the standard protocol shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GameMeta {
+    /// Stable hash of `ReqAuthGame.game_uuid` (Majsoul), used to recognize a
+    /// reconnect of the same table without comparing the UUID itself.
     pub game_id: Option<u64>,
-    /// `game_config.mode.mode`: 1/2 = 4p East / East-South,
+    /// `game_config.mode.mode` (Majsoul): 1/2 = 4p East / East-South,
     /// 11/12 = 3p East / East-South.
     pub match_mode: Option<u8>,
+    /// Persisted match identity (rank room, game/paifu id) copied into
+    /// `GameRecord.match_info` by the history aggregator.
+    pub match_info: Option<MatchInfo>,
 }
 
 /// Why an in-process game-end event was emitted. The reason and standings are
@@ -70,7 +75,7 @@ pub enum MjaiEvent {
         #[serde(default = "default_num_players")]
         num_players: u8,
         #[serde(skip, default)]
-        majsoul_meta: Option<MajsoulGameMeta>,
+        game_meta: Option<GameMeta>,
     },
     StartKyoku {
         bakaze: Tile,
@@ -390,13 +395,19 @@ mod tests {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: Some(MajsoulGameMeta {
+            game_meta: Some(GameMeta {
                 game_id: Some(7),
                 match_mode: Some(2),
+                match_info: Some(MatchInfo::Majsoul {
+                    game_uuid: Some("240101-uuid".into()),
+                    mode_id: Some(12),
+                    room_id: None,
+                    contest_uid: None,
+                }),
             }),
         };
         let start_json = serde_json::to_value(start).unwrap();
-        assert!(start_json.get("majsoul_meta").is_none());
+        assert!(start_json.get("game_meta").is_none());
 
         let end = MjaiEvent::confirmed_game(
             Some(vec![12000, 41000, 27000, 20000]),

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -10,7 +10,8 @@ pub mod ipc;
 pub mod mjai;
 
 pub use history::{
-    GameRecord, GameStats, HistoryEvent, HistoryEventLog, HistoryFilter, KyokuMode, Platform,
+    GameRecord, GameStats, HistoryEvent, HistoryEventLog, HistoryFilter, KyokuMode, MatchInfo,
+    Platform,
 };
 pub use inspector::{
     BotReaction, CaptureSource, FrameDirection, FrameRaw, HttpAnnotation, HttpBody, HttpExchange,
@@ -21,4 +22,4 @@ pub use ipc::{
     LogEntry, LogSessionInfo, Notification, NotifyLevel, ReadInspectorRequest,
     ReadInspectorResponse, ReadLogRequest, ReadLogResponse, Snapshot,
 };
-pub use mjai::{GameEndReason, MajsoulGameMeta, MjaiEvent};
+pub use mjai::{GameEndReason, GameMeta, MjaiEvent};

--- a/tests/analysis_pipeline.rs
+++ b/tests/analysis_pipeline.rs
@@ -24,7 +24,7 @@ fn start_game(seat: u8) -> MjaiEvent {
         aka_flag: None,
         id: Some(seat),
         num_players: 4,
-        majsoul_meta: None,
+        game_meta: None,
     }
 }
 

--- a/tests/bot_lifecycle.rs
+++ b/tests/bot_lifecycle.rs
@@ -140,7 +140,7 @@ async fn loading_emits_syncing_then_spawning_then_ready() {
             aka_flag: None,
             id: Some(0),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }),
     )
     .await
@@ -228,7 +228,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
                 aka_flag: None,
                 id: Some(0),
                 num_players: 4,
-                majsoul_meta: None,
+                game_meta: None,
             }),
         )
         .await
@@ -262,7 +262,7 @@ async fn second_spawn_skips_uv_sync_via_stamp() {
             aka_flag: None,
             id: Some(2),
             num_players: 4,
-            majsoul_meta: None,
+            game_meta: None,
         }),
     )
     .await

--- a/tests/example_bot.rs
+++ b/tests/example_bot.rs
@@ -91,7 +91,7 @@ fn start_game(seat: u8) -> MjaiEvent {
         aka_flag: Some(true),
         id: Some(seat),
         num_players: 4,
-        majsoul_meta: None,
+        game_meta: None,
     }
 }
 


### PR DESCRIPTION
Closes #270.

## What

Adds a platform-tagged `MatchInfo` to every persisted `GameRecord` so history knows **which room / rank lobby** a game was played in and **which game** it was (replay id):

| Platform | Captured |
|---|---|
| Majsoul | raw `game_uuid` (replay id), `meta.mode_id` (ranked room), `meta.room_id` (friendly/AI room), `meta.contest_uid` (tournament) — zeros stored as `None` |
| Tenhou | `TAIKYOKU log` paifu id, `GO type` rule/room bitfield, `GO lobby` number |
| Riichi City | skeleton (`cmd_enter_room` classify id) until the payload fields are mapped |

## How

- `schema/history.rs`: new `MatchInfo` enum, internally tagged on `platform`, every field `Option` + `serde(default)` — **old `index.jsonl` lines keep parsing** (`match_info: None`). Raw platform values only; label mapping is a frontend concern so an unknown id renders as its number, never a wrong name.
- `schema/mjai`: the Majsoul-only in-process `StartGame` meta is generalised to `GameMeta { game_id, match_mode, match_info }`. Still `#[serde(skip)]`: mjai logs and the cloud inference payload are byte-identical to before (locked by the existing `private_game_metadata_never_changes_mjai_json` test).
- Majsoul bridge: keeps the raw `game_uuid` alongside the existing FNV reconnect hash and fills `MatchInfo::Majsoul`.
- Tenhou bridge: now parses `GO` / `UN` / `TAIKYOKU log`. `UN` roster names are percent-decoded and remapped from wire-relative to absolute seats (sanma ghost slot skipped), replacing the `0/1/2/3` placeholder names history used to store; a partial reconnect `UN` cannot clobber the roster. Stash fields are consumed with `take()` so nothing leaks across games.
- History aggregator copies the meta into the record; reconnect dedup unchanged.
- Frontend: `Room` column in the game list; room + game id (with **open replay** for Tenhou — region-independent URL) in the detail dialog; `lib/matchInfo.ts` maps Majsoul mode ids 1–28 → Bronze/Silver/Gold/Jade/Throne/Melee and Tenhou `GO type` bits 0x20/0x80 → 般/上/特/鳳; new `history.room.*` strings in all four locales (Majsoul room names use the official per-locale translations). Majsoul shows the copyable uuid only — replay hosts are region-specific and the region isn't recorded.

## Tests

- Schema: tagged round-trip, `None`-field omission, legacy-line (no `match_info` key) parse.
- Aggregator: meta → record copy.
- Majsoul: uuid/mode_id capture, zero→`None` filtering (real 3p AI-room payload).
- Tenhou: GO/UN/TAIKYOKU→`start_game` metadata, partial-UN rejection, sanma ghost-slot name mapping.
- `cargo fmt --check` / clippy clean; 929 lib + all integration suites pass; frontend `tsc -b` and eslint clean.