### PR TITLE
feat(riichi-city): complete the game_play mode labels from the client's own enum

### DIFF
--- a/frontend/src/i18n/resources/en.json
+++ b/frontend/src/i18n/resources/en.json
@@ -118,7 +118,18 @@
       "rc_tournament": "Tournament",
       "rc_friendly": "Friendly Match",
       "rc_one_round": "1-Round Challenge",
-      "rc_casual": "Casual Game"
+      "rc_two_player": "2-Player",
+      "rc_ak_2p": "2-Player (AK Collab)",
+      "rc_command": "Command Challenge",
+      "rc_chinitsu": "Chinitsu Challenge",
+      "rc_taiwan": "16 Tiles",
+      "rc_ai_challenge": "AI Conquest Challenge",
+      "rc_chill": "Chill Mahjong",
+      "rc_seventeen": "17 Steps",
+      "rc_practice": "Practice Match",
+      "rc_fury_waves": "Fury Waves",
+      "rc_taiwan_ranked": "16 Tiles Ranked",
+      "rc_hidden_war": "12 Tiles"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/ja.json
+++ b/frontend/src/i18n/resources/ja.json
@@ -118,7 +118,18 @@
       "rc_tournament": "大会戦",
       "rc_friendly": "友人戦",
       "rc_one_round": "一局戦",
-      "rc_casual": "娯楽戦"
+      "rc_two_player": "二麻",
+      "rc_ak_2p": "二麻（AKコラボ）",
+      "rc_command": "指令戦",
+      "rc_chinitsu": "清一色の試練",
+      "rc_taiwan": "16張",
+      "rc_ai_challenge": "AI突破チャレンジ戦",
+      "rc_chill": "悠々麻雀",
+      "rc_seventeen": "決闘十七歩",
+      "rc_practice": "練習場",
+      "rc_fury_waves": "怒涛の戦",
+      "rc_taiwan_ranked": "16張段位戦",
+      "rc_hidden_war": "隠し牌戦"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/zh-CN.json
+++ b/frontend/src/i18n/resources/zh-CN.json
@@ -118,7 +118,18 @@
       "rc_tournament": "大会战",
       "rc_friendly": "友人战",
       "rc_one_round": "一局战",
-      "rc_casual": "休闲场"
+      "rc_two_player": "二麻",
+      "rc_ak_2p": "二麻（AK联动）",
+      "rc_command": "指令战",
+      "rc_chinitsu": "清一色试炼",
+      "rc_taiwan": "16张",
+      "rc_ai_challenge": "AI突围挑战赛",
+      "rc_chill": "悠悠麻将",
+      "rc_seventeen": "决斗十七步",
+      "rc_practice": "练习场",
+      "rc_fury_waves": "怒涛战",
+      "rc_taiwan_ranked": "16张段位战",
+      "rc_hidden_war": "隐牌战"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -118,7 +118,18 @@
       "rc_tournament": "大會戰",
       "rc_friendly": "友人戰",
       "rc_one_round": "一局戰",
-      "rc_casual": "休閒場"
+      "rc_two_player": "2麻",
+      "rc_ak_2p": "2麻（AK聯動）",
+      "rc_command": "指令戰",
+      "rc_chinitsu": "清一色試煉",
+      "rc_taiwan": "16張",
+      "rc_ai_challenge": "AI突圍挑戰賽",
+      "rc_chill": "悠悠麻將",
+      "rc_seventeen": "決鬥十七步",
+      "rc_practice": "練習場",
+      "rc_fury_waves": "怒濤戰",
+      "rc_taiwan_ranked": "16張段位戰",
+      "rc_hidden_war": "隱牌戰"
     }
   },
   "logs": {

--- a/frontend/src/i18n/resources/zh-TW.json
+++ b/frontend/src/i18n/resources/zh-TW.json
@@ -128,7 +128,7 @@
       "rc_seventeen": "決鬥十七步",
       "rc_practice": "練習場",
       "rc_fury_waves": "怒濤戰",
-      "rc_taiwan_ranked": "16張段位戰",
+      "rc_taiwan_ranked": "台麻16張段位戰",
       "rc_hidden_war": "隱牌戰"
     }
   },

--- a/frontend/src/lib/matchInfo.test.ts
+++ b/frontend/src/lib/matchInfo.test.ts
@@ -82,9 +82,19 @@ describe('roomLabelKey', () => {
     expect(
       roomLabelKey({ platform: 'riichi_city', game_play: 1004 }),
     ).toEqual({ key: 'history.room.rc_one_round' })
+    // The mode-specific labels extracted from the client's own enum.
     expect(
       roomLabelKey({ platform: 'riichi_city', game_play: 1010 }),
-    ).toEqual({ key: 'history.room.rc_casual' })
+    ).toEqual({ key: 'history.room.rc_taiwan' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1015 }),
+    ).toEqual({ key: 'history.room.rc_practice' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1021 }),
+    ).toEqual({ key: 'history.room.rc_taiwan_ranked' })
+    expect(
+      roomLabelKey({ platform: 'riichi_city', game_play: 1022 }),
+    ).toEqual({ key: 'history.room.rc_hidden_war' })
     // Unknown mode ids degrade to the raw number.
     expect(roomLabelKey({ platform: 'riichi_city', game_play: 1099 })).toEqual({
       key: 'history.room.raw',
@@ -159,7 +169,18 @@ describe('locale coverage', () => {
     'rc_tournament',
     'rc_friendly',
     'rc_one_round',
-    'rc_casual',
+    'rc_two_player',
+    'rc_ak_2p',
+    'rc_command',
+    'rc_chinitsu',
+    'rc_taiwan',
+    'rc_ai_challenge',
+    'rc_chill',
+    'rc_seventeen',
+    'rc_practice',
+    'rc_fury_waves',
+    'rc_taiwan_ranked',
+    'rc_hidden_war',
     'raw',
   ]
 

--- a/frontend/src/lib/matchInfo.ts
+++ b/frontend/src/lib/matchInfo.ts
@@ -44,9 +44,10 @@ const MAJSOUL_ROOM_TIERS: Record<number, string> = {
 
 /**
  * Riichi City `options.stage_type` → ranked room tier, lowest to highest.
- * Tier names follow the client's own strings (`MATCHING_VIEW_STATE_TYPE_*`:
- * 新星/霞月/炎陽/銀河, EN Star/Moon/Sun/Galaxy); its replay list labels a
- * ranked game exactly this way.
+ * The client's tier enum is exhaustive at four (NewStar/BrightMoon/HotSun/
+ * MilkyWay). Tier names follow the client's own strings
+ * (`MATCHING_VIEW_STATE_TYPE_*`: 新星/霞月/炎陽/銀河, EN Star/Moon/Sun/
+ * Galaxy); its replay list labels a ranked game exactly this way.
  */
 const RIICHI_CITY_ROOM_TIERS: Record<number, string> = {
   1: 'star',
@@ -57,27 +58,38 @@ const RIICHI_CITY_ROOM_TIERS: Record<number, string> = {
 
 /**
  * Riichi City `options.game_play` → mode label key, from the client's
- * `GamePlayType` enum. 1001 (ranked) is handled separately via the stage
- * tier above; 1021 is the tier-less Taiwan-rules ranked ladder. The
- * 1007–1016/1022 block are the casual-hall variants (directive war,
- * chinitsu trial, Taiwan rules, 17-steps, bleed, hidden war, …), labeled
- * with the client's own "Casual Game" umbrella term.
+ * `GamePlayType` enum (its game logic ships as Lua in
+ * `Mahjong-JP_Data/StreamingAssets/Base/lua_common`). Labels are the
+ * client's own localized strings — the ones its replay list uses to title
+ * each mode.
+ *
+ * 1001 (Rank) is handled separately via the stage tier above. 1005 is the
+ * one-round lobby's queue instance of 1004, and 1008 the casual-hall
+ * instance of 1007 — each pair shares one client string. 1006 (TwoPlay,
+ * folded into friend rooms) and 1011 (AK2P, a retired collab) have no
+ * replay-list branch in the client; their labels combine the official
+ * 2-player string (PLAY_NAME_2) with the enum's own comment. `All` (0) is
+ * a filter sentinel and `CombineMahjong` (1) is a merge minigame — neither
+ * reaches a mahjong table.
  */
 const RIICHI_CITY_MODES: Record<number, string> = {
   1002: 'rc_tournament',
   1003: 'rc_friendly',
   1004: 'rc_one_round',
   1005: 'rc_one_round',
-  1007: 'rc_casual',
-  1008: 'rc_casual',
-  1009: 'rc_casual',
-  1010: 'rc_casual',
-  1013: 'rc_casual',
-  1014: 'rc_casual',
-  1015: 'rc_casual',
-  1016: 'rc_casual',
-  1021: 'rc_ranked',
-  1022: 'rc_casual',
+  1006: 'rc_two_player',
+  1007: 'rc_command',
+  1008: 'rc_command',
+  1009: 'rc_chinitsu',
+  1010: 'rc_taiwan',
+  1011: 'rc_ak_2p',
+  1012: 'rc_ai_challenge',
+  1013: 'rc_chill',
+  1014: 'rc_seventeen',
+  1015: 'rc_practice',
+  1016: 'rc_fury_waves',
+  1021: 'rc_taiwan_ranked',
+  1022: 'rc_hidden_war',
 }
 
 /**

--- a/src/schema/history.rs
+++ b/src/schema/history.rs
@@ -87,9 +87,11 @@ pub enum MatchInfo {
     /// Riichi City. `stage_type` / `game_play` / `classify_id` come from
     /// `cmd_enter_room.options` and identify the matchmaking room;
     /// `stage_type` 1..=4 = Star / Moon / Sun / Galaxy (新星/霞月/炎陽/銀河,
-    /// the ranked room tiers) and `game_play` is the client's `GamePlayType`
-    /// (1001 ranked, 1002 tournament, 1003 friendly, 1004/1005 one-round,
-    /// 1021 Taiwan-rules ranked, 1007..=1016/1022 casual-hall variants).
+    /// the ranked room tiers — the client's tier enum is exhaustive at
+    /// four) and `game_play` is the client's `GamePlayType` enum (its
+    /// game logic ships as Lua; the full id→mode mapping with the
+    /// client's own localized names lives in the frontend's
+    /// `matchInfo.ts`).
     /// `room_id` is the table-instance token from the `cmd_enter_room`
     /// wrapper. All raw wire values.
     RiichiCity {


### PR DESCRIPTION
Fills in the Riichi City skeleton left by #271.

## What was left open

#271 mapped `game_play` partially: the 1007–1016/1022 casual-hall block collapsed into one "Casual Game" umbrella, 1006/1011/1012 were unmapped, and 1021 got the generic "Ranked Match" — all pending confirmed enumerations.

## Ground truth

The client's game logic ships as **Lua** (`Mahjong-JP_Data/StreamingAssets/Base/lua_common` in the Steam install), so the complete `GamePlayType` enum is readable straight off disk, and its localization table (`lua_config`) carries the official EN/JA/ko/zh strings — the same ones the client's own replay list uses to title each mode:

```
Rank 1001, Match 1002, Friend 1003, OneRoundFight 1004/1005,
TwoPlay 1006, DirectiveWar 1007, LeisureDirectiveWar 1008,
LeisureQingYiSeTrial 1009, LeisureTaiWan 1010, AK2P 1011,
AIChallenge 1012, YouYou 1013, Seventeen 1014, MahjongStudy 1015,
BleedMahjong 1016, TaiWanRank 1021, HiddenWar 1022
```

The stage tier enum is confirmed **exhaustive at four** (`NewStar/BrightMoon/HotSun/MilkyWay` = 1..=4), so no synthetic tier fallbacks are needed.

Cross-checked against live captures from #268 testing: `game_play 1001` + `stage_type` 3/4 (Sun/Galaxy ranked) and `1015` — which turns out to be the AI **Practice Match** room, previously labeled "Casual Game".

## Changes

- The mode table now maps every enum id to its own label; the two ids the client itself never titles in its replay list (1006 TwoPlay, retired-collab 1011 AK2P) combine the official 2-player string (`PLAY_NAME_2`) with the enum comment. Unknown ids still degrade to the raw number.
- i18n: `rc_casual` umbrella replaced by 12 per-mode keys × 4 locales, all official client strings (e.g. EN "Command Challenge" / "Fury Waves" / "AI Conquest Challenge" / "16 Tiles Ranked" / "12 Tiles").
- The Rust schema doc comment now points at the authoritative mapping.

`npm lint/test/build` and `cargo test` green.