### PR TITLE
fix(riichi-city): match the client's own req_game_action shapes

### DIFF
--- a/src/autoplay/riichi_city/mod.rs
+++ b/src/autoplay/riichi_city/mod.rs
@@ -28,17 +28,17 @@ impl PlatformAutoplay for RiichiCityAutoplay {
             return PlanResult::default();
         }
         // A win names its tile: the drawn tile for a tsumo, the claimed
-        // discard for a ron. Call requests also carry the consumed tiles'
-        // hand positions, so pass our tehai through (see
-        // `build::encode_action_with`).
-        let hand = ctx
-            .snapshot
-            .players
-            .get(ctx.our_seat as usize)
-            .map(|p| p.tehai.clone());
+        // discard for a ron. Discards and calls carry rack positions, so
+        // pass our tehai and the held draw through (see
+        // `build::encode_action_with`). The snapshot's `drawn_tile` — not
+        // `last_self_tsumo`, which stays stale through a post-call
+        // discard — says whether a draw is actually in the rack now.
+        let player = ctx.snapshot.players.get(ctx.our_seat as usize);
+        let hand = player.map(|p| p.tehai.clone());
+        let drawn = player.and_then(|p| p.drawn_tile.clone());
         let Some(frame) = build::encode_action_with(
             ctx.action,
-            ctx.last_self_tsumo,
+            drawn.as_deref(),
             ctx.last_kawa_tile,
             hand.as_deref(),
         ) else {

--- a/src/bridge/riichi_city/build.rs
+++ b/src/bridge/riichi_city/build.rs
@@ -2,10 +2,18 @@
 //!
 //! Gameplay actions ride `"req_game_action"` with the same numeric action
 //! codes the server broadcasts back. Every shape below is verified against
-//! the client's own sender (the game logic ships as Lua:
-//! `lua_models_game` `ReqOutCard`/`ReqGameOpt`, and the offer-to-button
-//! construction in `lua_procestates_game_components`), cross-checked with
-//! recorded uplink frames from live play.
+//! the client's own senders (the game logic ships as plain-text Lua:
+//! `ReqOutCard`/`ReqGameOpt` in `lua_models_game` build the frames, the
+//! offer construction in `lua_procestates_game_components` fills in
+//! `card`/`group_cards`/positions, `EMjActionType` in
+//! `lua_procestates_game` names the codes), cross-checked with recorded
+//! uplink frames from live play.
+//!
+//! Wire positions (`move_cards_pos`) are 1-based slots in the client's
+//! tile *rack*: the sorted concealed hand with a freshly drawn tile
+//! appended LAST. The engine's tehai merges the drawn tile in sort order
+//! instead, so [`Rack`] reconstructs the client's view before any
+//! position is computed.
 
 use crate::schema::MjaiEvent;
 use serde_json::{json, Value};
@@ -51,34 +59,95 @@ fn chi_action_code(claimed: u32, consumed: &[u32; 2]) -> Option<i64> {
     }
 }
 
-/// Positions of `tiles` within `hand` (the tracker's tehai, which mirrors
-/// the server's hand order — that is what the wire positions index).
-/// Each hand tile is consumed at most once. `None` when a tile is absent
-/// or no hand was given: the caller then omits `move_cards_pos`.
-fn hand_positions(hand: Option<&[String]>, tiles: &[String]) -> Option<Vec<u32>> {
-    let hand = hand?;
-    let mut used = vec![false; hand.len()];
-    let mut out = Vec::with_capacity(tiles.len());
-    'next: for t in tiles {
-        for (i, h) in hand.iter().enumerate() {
-            if !used[i] && h == t {
-                used[i] = true;
-                out.push(i as u32);
-                continue 'next;
-            }
-        }
-        return None;
-    }
-    Some(out)
+/// The client's rack view of our hand: concealed tiles in engine (sorted)
+/// order with the currently held draw re-appended last, the way the
+/// client displays and indexes them. All wire positions are 1-based
+/// slots in this rack.
+struct Rack {
+    tiles: Vec<String>,
+    /// The last slot is a freshly drawn tile (wall or rinshan).
+    drawn_last: bool,
 }
 
-/// Attach `move_cards_pos` when the positions are computable; the client
-/// omits the field, so we do too rather than send a null.
-fn with_pos(mut d: Value, hand: Option<&[String]>, tiles: &[String]) -> Value {
-    if let Some(p) = hand_positions(hand, tiles) {
-        d["move_cards_pos"] = json!(p);
+impl Rack {
+    /// `hand` is the engine tehai (drawn tile merged in sort order);
+    /// `drawn` is the tile currently held from the wall, if any.
+    fn build(hand: Option<&[String]>, drawn: Option<&str>) -> Option<Rack> {
+        let hand = hand?;
+        if hand.is_empty() {
+            return None;
+        }
+        let mut tiles = hand.to_vec();
+        let drawn_last = drawn
+            .and_then(|d| tiles.iter().position(|t| t == d))
+            .map(|i| {
+                let t = tiles.remove(i);
+                tiles.push(t);
+            })
+            .is_some();
+        Some(Rack { tiles, drawn_last })
     }
-    d
+
+    fn len(&self) -> usize {
+        self.tiles.len()
+    }
+
+    /// 1-based positions of `tiles`, collected by scanning the rack in
+    /// order with each slot used at most once — exactly how the client's
+    /// offer builders (`GetCardIdx`/`GetPengIdx`/`GetChiIdx`) walk the
+    /// rack. Also returns the matched rack tiles in that same scan order,
+    /// which is the order the client lists `group_cards` in. `None` when
+    /// any tile is missing from the rack.
+    fn positions<'a>(&'a self, tiles: &[String]) -> Option<(Vec<u32>, Vec<&'a str>)> {
+        let mut want: Vec<&String> = tiles.iter().collect();
+        let mut pos = Vec::with_capacity(tiles.len());
+        let mut matched = Vec::with_capacity(tiles.len());
+        for (i, t) in self.tiles.iter().enumerate() {
+            if let Some(w) = want.iter().position(|w| *w == t) {
+                want.remove(w);
+                pos.push(i as u32 + 1);
+                matched.push(t.as_str());
+                if want.is_empty() {
+                    break;
+                }
+            }
+        }
+        if want.is_empty() {
+            Some((pos, matched))
+        } else {
+            None
+        }
+    }
+
+    /// 1-based rack slot of the first tile of `pai`'s kind (red and plain
+    /// fives match each other) — the client's masked `RealFlag` scan used
+    /// by the kakan and kita offers.
+    fn first_of_kind(&self, pai: &str) -> Option<u32> {
+        let kind = mjai_to_card(pai)? & 0xff;
+        self.tiles
+            .iter()
+            .position(|t| mjai_to_card(t).is_some_and(|c| c & 0xff == kind))
+            .map(|i| i as u32 + 1)
+    }
+}
+
+/// A claim request: `{action, card}` plus the consumed tiles and their
+/// rack slots, mirroring the client's offer construction (`group_cards`
+/// and `move_cards_pos` both listed in rack-scan order — for a pon this
+/// is also how the red-five choice reaches the server). Without a rack
+/// the consumed tiles go out in the bot's order and the positions are
+/// omitted; the client always sends both, but the server derives the
+/// meld from `group_cards`.
+fn call_data(action: i64, card: u32, rack: Option<&Rack>, consumed: &[String]) -> Option<Value> {
+    let mut d = json!({ "action": action, "card": card });
+    match rack.and_then(|r| r.positions(consumed)) {
+        Some((pos, matched)) => {
+            d["group_cards"] = json!(cards(matched)?);
+            d["move_cards_pos"] = json!(pos);
+        }
+        None => d["group_cards"] = json!(cards(consumed)?),
+    }
+    Some(d)
 }
 
 /// mjai tile string → Riichi City card code (inverse of `consts::card_to_mjai`).
@@ -139,90 +208,96 @@ pub fn encode_action(ev: &MjaiEvent) -> Option<Vec<u8>> {
     encode_action_with(ev, None, None, None)
 }
 
-/// [`encode_action`] plus the table state some actions need: the tile we
-/// just drew (a tsumo's `card` is the winning tile), the most recent
-/// discard (a ron's `card` is the claimed tile), and our tehai (call
-/// requests carry `move_cards_pos` — the consumed tiles' positions in the
-/// server-ordered hand). The autoplay planner supplies all three from its
-/// `ActionContext`.
+/// [`encode_action`] plus the table state some actions need: the tile
+/// currently held from the wall (a tsumo's `card` is the winning tile,
+/// and the rack racks it last), the most recent discard (a ron's `card`
+/// is the claimed tile), and our tehai (discards and calls carry rack
+/// positions, calls also `group_cards`). The autoplay planner supplies
+/// all three from its `ActionContext` snapshot.
 pub fn encode_action_with(
     ev: &MjaiEvent,
-    tsumo_pai: Option<&str>,
+    drawn: Option<&str>,
     last_discard: Option<&str>,
     hand: Option<&[String]>,
 ) -> Option<Vec<u8>> {
+    let rack = Rack::build(hand, drawn);
+    let rack = rack.as_ref();
     let data: Value = match ev {
-        MjaiEvent::Dahai { pai, tsumogiri, .. } => dahai_data(pai, *tsumogiri, false, hand)?,
-        MjaiEvent::Reach { pai: Some(pai), .. } => dahai_data(pai, false, true, hand)?,
-        // Discard-claims (chi/pon) are bare `{action, card}` on the wire:
-        // the client's own claim buttons send nothing else — the server
-        // derives the meld from the variant code plus our hand.
+        MjaiEvent::Dahai { pai, tsumogiri, .. } => dahai_data(pai, *tsumogiri, false, rack)?,
+        MjaiEvent::Reach { pai: Some(pai), .. } => dahai_data(pai, false, true, rack)?,
+        // Chi and pon: the claim buttons send the variant code, the
+        // claimed tile, and the consumed pair with its rack slots
+        // (`GetChiIdx`/`GetPengIdx` — which offer a second button when a
+        // red five makes the pair ambiguous, so `group_cards` is the
+        // choice, not decoration).
         MjaiEvent::Chi { pai, consumed, .. } => {
             let card = mjai_to_card(pai)?;
             let group = cards(consumed)?;
-            json!({
-                "action": chi_action_code(card, &[group[0], group[1]])?,
-                "card": card,
-            })
+            call_data(
+                chi_action_code(card, &[group[0], group[1]])?,
+                card,
+                rack,
+                consumed,
+            )?
         }
-        MjaiEvent::Pon { pai, .. } => json!({
-            "action": action::PON,
-            "card": mjai_to_card(pai)?,
-        }),
-        // Daiminkan is the one claim that does carry the consumed tiles:
-        // `card` names the claimed discard, `group_cards` the three
-        // matching tiles from our hand, `move_cards_pos` their positions.
-        MjaiEvent::Daiminkan { pai, consumed, .. } => with_pos(
-            json!({
-                "action": action::DAIMINKAN,
-                "card": mjai_to_card(pai)?,
-                "group_cards": cards(consumed)?,
-            }),
-            hand,
-            consumed,
-        ),
-        // Ankan (from the client's offer builder): `card` is one of the
-        // four, `group_cards` carries three ("the server only needs
-        // three" — its own comment), and `move_cards_pos` the positions
-        // of all four.
-        MjaiEvent::Ankan { consumed, .. } => {
-            let group = cards(consumed)?;
-            with_pos(
+        MjaiEvent::Pon { pai, consumed, .. } => {
+            call_data(action::PON, mjai_to_card(pai)?, rack, consumed)?
+        }
+        // Daiminkan: `card` names the claimed discard, `group_cards` the
+        // three matching tiles from our hand, `move_cards_pos` their
+        // rack slots.
+        MjaiEvent::Daiminkan { pai, consumed, .. } => {
+            call_data(action::DAIMINKAN, mjai_to_card(pai)?, rack, consumed)?
+        }
+        // Ankan (offer builder): the four copies are looked up in rack
+        // order; `card` is the first, `group_cards` the remaining three
+        // ("服务器只需要三张" — the client's own comment), and
+        // `move_cards_pos` all four slots.
+        MjaiEvent::Ankan { consumed, .. } => match rack.and_then(|r| r.positions(consumed)) {
+            Some((pos, matched)) => {
+                let group = cards(matched)?;
                 json!({
                     "action": action::ANKAN,
                     "card": group.first().copied()?,
                     "group_cards": &group[1..],
-                }),
-                hand,
-                consumed,
-            )
+                    "move_cards_pos": pos,
+                })
+            }
+            None => {
+                let group = cards(consumed)?;
+                json!({
+                    "action": action::ANKAN,
+                    "card": group.first().copied()?,
+                    "group_cards": &group[1..],
+                })
+            }
+        },
+        // Kakan (`ActionBuGang`): the promoted tile plus the rack slot of
+        // the first tile of its kind (the client scans by masked flag);
+        // `ReqGameOpt` drops `group_cards` for this action.
+        MjaiEvent::Kakan { pai, .. } => {
+            let mut d = json!({ "action": action::KAKAN, "card": mjai_to_card(pai)? });
+            if let Some(p) = rack.and_then(|r| r.first_of_kind(pai)) {
+                d["move_cards_pos"] = json!([p]);
+            }
+            d
         }
-        // Kakan (client's `ActionBuGang` branch): the promoted tile and
-        // its hand position, and no `group_cards`.
-        MjaiEvent::Kakan { pai, .. } => with_pos(
-            json!({
-                "action": action::KAKAN,
-                "card": mjai_to_card(pai)?,
-            }),
-            hand,
-            std::slice::from_ref(pai),
-        ),
-        // Kita (client's `ActionPullNorth`): the north tile, bare.
-        MjaiEvent::Kita { pai, .. } => json!({
-            "action": action::KITA,
-            "card": mjai_to_card(pai.as_deref().unwrap_or("N"))?,
-        }),
+        // Kita (`ActionPullNorth`): the north tile plus its rack slot.
+        MjaiEvent::Kita { pai, .. } => {
+            let pai = pai.as_deref().unwrap_or("N");
+            let mut d = json!({ "action": action::KITA, "card": mjai_to_card(pai)? });
+            if let Some(p) = rack.and_then(|r| r.first_of_kind(pai)) {
+                d["move_cards_pos"] = json!([p]);
+            }
+            d
+        }
         // Tsumo names its winning tile (`{"action":10,"card":6}` for a 6p
         // self-draw win — recorded). A ron mirrors it with the claimed
         // discard, per the client's claim-button construction.
         MjaiEvent::Hora { target, actor, .. } => {
             let mut d =
                 json!({ "action": if target == actor { action::TSUMO } else { action::RON } });
-            if let Some(pai) = if target == actor {
-                tsumo_pai
-            } else {
-                last_discard
-            } {
+            if let Some(pai) = if target == actor { drawn } else { last_discard } {
                 d["card"] = json!(mjai_to_card(pai)?);
             }
             d
@@ -237,33 +312,43 @@ pub fn encode_action_with(
 /// A discard request. Riichi is the same request with `is_li_zhi: true`
 /// (verified: the recorded riichi discard carries exactly these fields).
 ///
-/// `move_cards_pos` is client display metadata, never validated: the
-/// client computes `[index, toIndex]` as animation hints (which rack slot
-/// the tile slides from) and the server merely relays them in the
-/// broadcast so other clients can animate. `index` is the tile's 1-based
-/// position in the hand — the drawn tile sits last (`CheckOutCardIndex`).
-/// `toIndex` depends on the player's chosen tile-sort order
-/// (`GetMoveIndexByOutCard`); the client's own fallback branches return
-/// `hand.len() - 1`, which is what we send. Without a hand we fall back
-/// to the recorded placeholder shapes.
-fn dahai_data(pai: &str, tsumogiri: bool, riichi: bool, hand: Option<&[String]>) -> Option<Value> {
-    let pos: Value = match hand {
-        Some(hand) if !hand.is_empty() => {
-            let to = (hand.len() - 1).max(1) as u32;
+/// `move_cards_pos` is `[index, toIndex]`, display metadata the server
+/// relays so other clients can animate. `index` is the tile's 1-based
+/// rack slot; the client sends the LAST slot for the held draw and clamps
+/// a would-be last-slot tedashi to the slot before it
+/// (`CheckOutCardIndex`), so `index == rack len` on a drawn turn always
+/// means tsumogiri — our own inbound decoder relies on that, which makes
+/// this formula load-bearing, not just cosmetic. `toIndex` is where the
+/// drawn tile slides after a tedashi; it depends on the player's
+/// tile-sort setting (`GetMoveIndexByOutCard`'s `sortMap`), so we send
+/// the client's own fallback `#privateList - 1` — also its real value
+/// for every tsumogiri. Without a rack: the recorded placeholder shapes.
+fn dahai_data(pai: &str, tsumogiri: bool, riichi: bool, rack: Option<&Rack>) -> Option<Value> {
+    let pos: Value = match rack {
+        Some(rack) => {
+            let len = rack.len() as u32;
+            let to = (len - 1).max(1);
+            // Rack slots that are not the held draw — a tedashi can only
+            // come from these.
+            let hand_slots = rack.len() - rack.drawn_last as usize;
             let from = if tsumogiri {
-                hand.len() as u32
+                len
             } else {
-                // First matching tile, 1-based — mirrors the client's
-                // card-object lookup well enough for an animation hint.
-                hand.iter()
-                    .position(|h| h == pai)
-                    .map(|i| i as u32 + 1)
-                    .unwrap_or(to)
+                match rack.tiles[..hand_slots].iter().position(|t| t == pai) {
+                    Some(i) => i as u32 + 1,
+                    // Only the held draw matches: a riichi that discards
+                    // the drawn tile lands here (mjai `reach` carries no
+                    // tsumogiri flag) — the client names the drawn slot.
+                    None if rack.drawn_last && rack.tiles[hand_slots] == pai => len,
+                    // Tile not in the rack (state mismatch): the client's
+                    // clamp value keeps the shape plausible.
+                    None => to,
+                }
             };
             json!([from, to])
         }
-        // No hand: the recorded placeholder shapes.
-        _ => json!([if tsumogiri { 14 } else { 13 }, 13]),
+        // No rack: the recorded placeholder shapes.
+        None => json!([if tsumogiri { 14 } else { 13 }, 13]),
     };
     Some(json!({
         "action": action::DAHAI,
@@ -423,11 +508,10 @@ mod tests {
         assert_eq!(code(&pick("6m", "7m")), 2, "5-6-7: claimed is low");
     }
 
-    /// Kan requests carry the consumed tiles' positions in the server-
-    /// ordered hand; unresolvable positions omit the field instead of
-    /// sending nonsense. Chi and pon carry nothing but the variant code
-    /// and the claimed tile — the client's own claim buttons send exactly
-    /// that, and the server derives the meld from our hand.
+    /// Claims carry the consumed tiles (`group_cards`) and their 1-based
+    /// rack slots (`move_cards_pos`), both in rack-scan order — the shape
+    /// every `ReqGameOpt` button sends. Unresolvable slots omit only the
+    /// position field; `group_cards` still expresses the meld.
     #[test]
     fn calls_carry_hand_positions_when_known() {
         let hand: Vec<String> = [
@@ -445,10 +529,9 @@ mod tests {
         let pkt = &WPacket::parse_frame(
             &encode_action_with(&daiminkan, None, None, Some(&hand)).unwrap(),
         )[0];
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([6, 7, 8]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([7, 8, 9]));
         assert_eq!(pkt.body["data"]["group_cards"], json!([0x31, 0x31, 0x31]));
 
-        // Chi and pon stay bare even with a hand available.
         let pon = MjaiEvent::Pon {
             actor: 0,
             target: 1,
@@ -457,27 +540,40 @@ mod tests {
         };
         let pkt =
             &WPacket::parse_frame(&encode_action_with(&pon, None, None, Some(&hand)).unwrap())[0];
-        assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
         assert_eq!(pkt.body["data"]["action"], 5);
         assert_eq!(pkt.body["data"]["card"], 0x31);
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x31, 0x31]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([7, 8]));
 
+        // The red-five choice travels in `group_cards`: the client offers
+        // one button per candidate pair, so the pair the bot chose must
+        // go out.
         let chi = MjaiEvent::Chi {
             actor: 0,
             target: 1,
             pai: "3p".into(),
             consumed: ["4p".into(), "5pr".into()],
         };
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&chi, None, None, Some(&hand)).unwrap())[0];
+        assert_eq!(pkt.body["data"]["action"], 2, "claimed 3p is the low end");
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x04, 0x105]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([3, 4]));
+
+        // Tiles not in the tracked hand: positions are omitted, the meld
+        // itself still goes out.
         let unknown: Vec<String> = vec!["9s".to_string(); 13];
         let pkt =
             &WPacket::parse_frame(&encode_action_with(&chi, None, None, Some(&unknown)).unwrap())
                 [0];
         assert!(pkt.body["data"].get("move_cards_pos").is_none());
-        assert!(pkt.body["data"].get("group_cards").is_none());
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x04, 0x105]));
     }
 
-    /// Ankan carries three `group_cards` (the client's own comment: "the
-    /// server only needs three") with the positions of all four, and the
-    /// promoted-tile kakan carries only the tile and its position.
+    /// Ankan carries three `group_cards` (the client's own comment:
+    /// "服务器只需要三张") with the rack slots of all four — the freshly
+    /// drawn fourth copy racks LAST, not at its sorted position — and the
+    /// promoted-tile kakan carries only the tile and its slot.
     #[test]
     fn kan_shapes_match_the_client_sender() {
         let hand: Vec<String> = [
@@ -490,14 +586,24 @@ mod tests {
             actor: 0,
             consumed: ["5mr".into(), "5m".into(), "5m".into(), "5m".into()],
         };
+        // No draw tracked: the four copies sit at rack slots 3-6, and
+        // `card`/`group_cards` list them in rack-scan order.
         let pkt =
             &WPacket::parse_frame(&encode_action_with(&ankan, None, None, Some(&hand)).unwrap())[0];
         assert_eq!(pkt.body["data"]["action"], 8);
+        assert_eq!(pkt.body["data"]["card"], 0x25);
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x125, 0x25, 0x25]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([3, 4, 5, 6]));
+
+        // With the fourth copy freshly drawn, its slot is the rack's last
+        // (the engine merges it into sort order; the client racks it
+        // apart on the right).
+        let pkt = &WPacket::parse_frame(
+            &encode_action_with(&ankan, Some("5m"), None, Some(&hand)).unwrap(),
+        )[0];
         assert_eq!(pkt.body["data"]["card"], 0x125);
         assert_eq!(pkt.body["data"]["group_cards"], json!([0x25, 0x25, 0x25]));
-        // Positions follow the consumed list's order (the red five is
-        // listed first and sits at hand index 3).
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([3, 2, 4, 5]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([3, 4, 5, 13]));
 
         let kakan = MjaiEvent::Kakan {
             actor: 0,
@@ -511,20 +617,30 @@ mod tests {
         assert_eq!(pkt.body["data"]["action"], 9);
         assert_eq!(pkt.body["data"]["card"], 0x05);
         assert!(pkt.body["data"].get("group_cards").is_none());
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([0]));
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([1]));
     }
 
-    /// Kita is the bare north tile, per the client's `ActionPullNorth`
-    /// offer construction.
+    /// Kita sends the north tile plus its rack slot (the client's
+    /// `ActionPullNorth` offer carries `idxs = {idx}`); with no tracked
+    /// hand the slot is omitted.
     #[test]
-    fn kita_is_bare() {
+    fn kita_names_its_rack_slot() {
         let kita = MjaiEvent::Kita {
             actor: 0,
             pai: Some("N".into()),
         };
+        let hand: Vec<String> = ["1m", "2m", "3m", "N", "P"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&kita, None, None, Some(&hand)).unwrap())[0];
+        assert_eq!(pkt.body["data"]["action"], 13);
+        assert_eq!(pkt.body["data"]["card"], 0x61);
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([4]));
+
         let pkt = &WPacket::parse_frame(&encode_action(&kita).unwrap())[0];
         assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
-        assert_eq!(pkt.body["data"]["action"], 13);
         assert_eq!(pkt.body["data"]["card"], 0x61);
     }
 
@@ -599,39 +715,64 @@ mod tests {
         assert_eq!(pkt.body["data"]["is_li_zhi"], false);
     }
 
-    /// With the hand available, `move_cards_pos` follows the client's
-    /// formula: the tile's 1-based hand position (the drawn tile sits
-    /// last), and the client's own `hand.len() - 1` fallback for the
-    /// animation target slot.
+    /// With the hand tracked, `move_cards_pos` follows the client's
+    /// formula: the tile's 1-based rack slot with the held draw racked
+    /// last, and the client's `#privateList - 1` fallback as `toIndex`.
+    /// `index == rack len` must mean tsumogiri and nothing else — our own
+    /// inbound decoder infers the flag from it.
     #[test]
     fn discard_positions_follow_the_client_formula() {
+        // Engine tehai after drawing the 3m: merged into sort order.
         let hand: Vec<String> = [
-            "1m", "2m", "3m", "4p", "5p", "6s", "7s", "8s", "9s", "E", "S", "W", "N", "F",
+            "1m", "2m", "3m", "4p", "5p", "6s", "7s", "8s", "9s", "E", "S", "W", "N", "C",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
-        // Tedashi of the 4p (0-based index 3 → 1-based 4).
-        let tedashi = MjaiEvent::Dahai {
+        let dahai = |pai: &str, tsumogiri: bool| MjaiEvent::Dahai {
             actor: 0,
-            pai: "4p".into(),
-            tsumogiri: false,
+            pai: pai.into(),
+            tsumogiri,
         };
-        let pkt =
-            &WPacket::parse_frame(&encode_action_with(&tedashi, None, None, Some(&hand)).unwrap())
-                [0];
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([4, 13]));
+        let pos = |ev: &MjaiEvent, hand: &[String]| {
+            WPacket::parse_frame(&encode_action_with(ev, Some("3m"), None, Some(hand)).unwrap())[0]
+                .body["data"]["move_cards_pos"]
+                .clone()
+        };
+        // Tedashi of the 4p: rack slot 3 (the drawn 3m no longer sits
+        // between 2m and 4p — it racks last).
+        assert_eq!(pos(&dahai("4p", false), &hand), json!([3, 13]));
+        // Tsumogiri names the last slot.
+        assert_eq!(pos(&dahai("3m", true), &hand), json!([14, 13]));
+        // Tedashi of the hand's highest tile: slot 13, NOT 14 — the
+        // engine sorts the drawn 3m into the middle, but the rack keeps
+        // it last, so the lone C stays below the tsumogiri sentinel.
+        assert_eq!(pos(&dahai("C", false), &hand), json!([13, 13]));
 
-        // Tsumogiri always names the last slot.
-        let tsumogiri = MjaiEvent::Dahai {
+        // Post-meld turn: ten concealed tiles plus the draw rack 11
+        // slots, so tsumogiri names 11 (the inbound decoder keys on
+        // rack size per seat, not on a constant 14).
+        let melded: Vec<String> = [
+            "1m", "2m", "3m", "4p", "5p", "6s", "7s", "8s", "9s", "E", "S",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(pos(&dahai("3m", true), &melded), json!([11, 10]));
+
+        // A riichi that discards the drawn tile (its only copy) names the
+        // drawn slot — mjai `reach` has no tsumogiri flag to say so.
+        let riichi = MjaiEvent::Reach {
             actor: 0,
-            pai: "F".into(),
-            tsumogiri: true,
+            pai: Some("3m".into()),
         };
-        let pkt = &WPacket::parse_frame(
-            &encode_action_with(&tsumogiri, None, None, Some(&hand)).unwrap(),
-        )[0];
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([14, 13]));
+        let no_other_3m: Vec<String> = [
+            "1m", "2m", "3m", "4p", "5p", "6s", "7s", "8s", "9s", "E", "S", "W", "N", "C",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(pos(&riichi, &no_other_3m), json!([14, 13]));
     }
 
     /// The round-advance press must be a bare req_user_prepare on binary

--- a/src/bridge/riichi_city/build.rs
+++ b/src/bridge/riichi_city/build.rs
@@ -1,11 +1,11 @@
 //! Riichi City outbound (client → server) frame builder.
 //!
 //! Gameplay actions ride `"req_game_action"` with the same numeric action
-//! codes the server broadcasts back. Verified from a recorded session:
-//! discard (`action:11`, riichi = same request with `is_li_zhi:true`),
-//! pass (`action:1`), tsumo (`action:10`). Unverified (no sample): chi/
-//! pon/kan/kita shapes, ron, and the tedashi value of `move_cards_pos` —
-//! see the TODO(capture) notes inline.
+//! codes the server broadcasts back. Every shape below is verified against
+//! the client's own sender (the game logic ships as Lua:
+//! `lua_models_game` `ReqOutCard`/`ReqGameOpt`, and the offer-to-button
+//! construction in `lua_procestates_game_components`), cross-checked with
+//! recorded uplink frames from live play.
 
 use crate::schema::MjaiEvent;
 use serde_json::{json, Value};
@@ -19,8 +19,10 @@ const CMD_GAME_ACTION: &str = "req_game_action";
 const BIN_CMD_REQUEST: u16 = 6;
 
 /// Action codes shared with the inbound `cmd_game_action_brc`. Verified
-/// uplink: 1 pass, 2/3/4 chi variants, 5 pon, 6 daiminkan, 7 ron, 8
-/// ankan, 10 tsumo, 11 dahai.
+/// against the client's `EMjActionType` enum and uplink recordings: 1
+/// pass, 2/3/4 chi variants (claimed tile low/middle/high in the run),
+/// 5 pon, 6 daiminkan, 7 ron, 8 ankan, 9 kakan, 10 tsumo, 11 dahai,
+/// 13 kita.
 mod action {
     pub const PASS: i64 = 1;
     pub const RON: i64 = 7;
@@ -150,30 +152,26 @@ pub fn encode_action_with(
     hand: Option<&[String]>,
 ) -> Option<Vec<u8>> {
     let data: Value = match ev {
-        MjaiEvent::Dahai { pai, tsumogiri, .. } => dahai_data(pai, *tsumogiri, false)?,
-        MjaiEvent::Reach { pai: Some(pai), .. } => dahai_data(pai, false, true)?,
+        MjaiEvent::Dahai { pai, tsumogiri, .. } => dahai_data(pai, *tsumogiri, false, hand)?,
+        MjaiEvent::Reach { pai: Some(pai), .. } => dahai_data(pai, false, true, hand)?,
+        // Discard-claims (chi/pon) are bare `{action, card}` on the wire:
+        // the client's own claim buttons send nothing else — the server
+        // derives the meld from the variant code plus our hand.
         MjaiEvent::Chi { pai, consumed, .. } => {
             let card = mjai_to_card(pai)?;
             let group = cards(consumed)?;
-            with_pos(
-                json!({
-                    "action": chi_action_code(card, &[group[0], group[1]])?,
-                    "card": card,
-                    "group_cards": group,
-                }),
-                hand,
-                consumed,
-            )
-        }
-        MjaiEvent::Pon { pai, consumed, .. } => with_pos(
             json!({
-                "action": action::PON,
-                "card": mjai_to_card(pai)?,
-                "group_cards": cards(consumed)?,
-            }),
-            hand,
-            consumed,
-        ),
+                "action": chi_action_code(card, &[group[0], group[1]])?,
+                "card": card,
+            })
+        }
+        MjaiEvent::Pon { pai, .. } => json!({
+            "action": action::PON,
+            "card": mjai_to_card(pai)?,
+        }),
+        // Daiminkan is the one claim that does carry the consumed tiles:
+        // `card` names the claimed discard, `group_cards` the three
+        // matching tiles from our hand, `move_cards_pos` their positions.
         MjaiEvent::Daiminkan { pai, consumed, .. } => with_pos(
             json!({
                 "action": action::DAIMINKAN,
@@ -183,15 +181,24 @@ pub fn encode_action_with(
             hand,
             consumed,
         ),
-        MjaiEvent::Ankan { consumed, .. } => with_pos(
-            json!({
-                "action": action::ANKAN,
-                "card": cards(consumed)?.first().copied()?,
-                "group_cards": cards(consumed)?,
-            }),
-            hand,
-            consumed,
-        ),
+        // Ankan (from the client's offer builder): `card` is one of the
+        // four, `group_cards` carries three ("the server only needs
+        // three" — its own comment), and `move_cards_pos` the positions
+        // of all four.
+        MjaiEvent::Ankan { consumed, .. } => {
+            let group = cards(consumed)?;
+            with_pos(
+                json!({
+                    "action": action::ANKAN,
+                    "card": group.first().copied()?,
+                    "group_cards": &group[1..],
+                }),
+                hand,
+                consumed,
+            )
+        }
+        // Kakan (client's `ActionBuGang` branch): the promoted tile and
+        // its hand position, and no `group_cards`.
         MjaiEvent::Kakan { pai, .. } => with_pos(
             json!({
                 "action": action::KAKAN,
@@ -200,13 +207,14 @@ pub fn encode_action_with(
             hand,
             std::slice::from_ref(pai),
         ),
+        // Kita (client's `ActionPullNorth`): the north tile, bare.
         MjaiEvent::Kita { pai, .. } => json!({
             "action": action::KITA,
             "card": mjai_to_card(pai.as_deref().unwrap_or("N"))?,
         }),
-        // Verified: a tsumo names its winning tile (`{"action":10,"card":6}`
-        // for a 6p self-draw win). A ron presumably mirrors that with the
-        // claimed tile; no sample yet. TODO(capture): confirm the ron shape.
+        // Tsumo names its winning tile (`{"action":10,"card":6}` for a 6p
+        // self-draw win — recorded). A ron mirrors it with the claimed
+        // discard, per the client's claim-button construction.
         MjaiEvent::Hora { target, actor, .. } => {
             let mut d =
                 json!({ "action": if target == actor { action::TSUMO } else { action::RON } });
@@ -229,16 +237,34 @@ pub fn encode_action_with(
 /// A discard request. Riichi is the same request with `is_li_zhi: true`
 /// (verified: the recorded riichi discard carries exactly these fields).
 ///
-/// `move_cards_pos` is client display metadata the server relays in the
-/// broadcast. The tsumogiri shape `[14,13]` is verified. The tedashi shape
-/// is NOT: the two values reference the client's internal tile-rack
-/// positions (they did not match dealt order, code-sorted order, or
-/// 0/1-based indices of either in the recording), so `[13,13]` — one of
-/// the observed shapes — is sent as a placeholder.
-/// TODO(capture/live): watch the first tedashis of a live autoplay game;
-/// if the server validates or relays visibly wrong positions, record a
-/// manual tedashi and derive the real formula.
-fn dahai_data(pai: &str, tsumogiri: bool, riichi: bool) -> Option<Value> {
+/// `move_cards_pos` is client display metadata, never validated: the
+/// client computes `[index, toIndex]` as animation hints (which rack slot
+/// the tile slides from) and the server merely relays them in the
+/// broadcast so other clients can animate. `index` is the tile's 1-based
+/// position in the hand — the drawn tile sits last (`CheckOutCardIndex`).
+/// `toIndex` depends on the player's chosen tile-sort order
+/// (`GetMoveIndexByOutCard`); the client's own fallback branches return
+/// `hand.len() - 1`, which is what we send. Without a hand we fall back
+/// to the recorded placeholder shapes.
+fn dahai_data(pai: &str, tsumogiri: bool, riichi: bool, hand: Option<&[String]>) -> Option<Value> {
+    let pos: Value = match hand {
+        Some(hand) if !hand.is_empty() => {
+            let to = (hand.len() - 1).max(1) as u32;
+            let from = if tsumogiri {
+                hand.len() as u32
+            } else {
+                // First matching tile, 1-based — mirrors the client's
+                // card-object lookup well enough for an animation hint.
+                hand.iter()
+                    .position(|h| h == pai)
+                    .map(|i| i as u32 + 1)
+                    .unwrap_or(to)
+            };
+            json!([from, to])
+        }
+        // No hand: the recorded placeholder shapes.
+        _ => json!([if tsumogiri { 14 } else { 13 }, 13]),
+    };
     Some(json!({
         "action": action::DAHAI,
         "card": mjai_to_card(pai)?,
@@ -247,7 +273,7 @@ fn dahai_data(pai: &str, tsumogiri: bool, riichi: bool) -> Option<Value> {
         // its first uninterrupted turn (junme <= 1 with no calls).
         "is_xuan_gao_ting": false,
         "li_zhi_operate": 0,
-        "move_cards_pos": if tsumogiri { [14, 13] } else { [13, 13] },
+        "move_cards_pos": pos,
     }))
 }
 
@@ -397,17 +423,32 @@ mod tests {
         assert_eq!(code(&pick("6m", "7m")), 2, "5-6-7: claimed is low");
     }
 
-    /// Call requests carry the consumed tiles' positions in the server-
+    /// Kan requests carry the consumed tiles' positions in the server-
     /// ordered hand; unresolvable positions omit the field instead of
-    /// sending nonsense.
+    /// sending nonsense. Chi and pon carry nothing but the variant code
+    /// and the claimed tile — the client's own claim buttons send exactly
+    /// that, and the server derives the meld from our hand.
     #[test]
     fn calls_carry_hand_positions_when_known() {
         let hand: Vec<String> = [
-            "1m", "2m", "4p", "5pr", "6s", "7s", "E", "E", "S", "W", "N", "P", "F",
+            "1m", "2m", "4p", "5pr", "6s", "7s", "E", "E", "E", "W", "N", "P", "F",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
+        let daiminkan = MjaiEvent::Daiminkan {
+            actor: 0,
+            target: 1,
+            pai: "E".into(),
+            consumed: ["E".into(), "E".into(), "E".into()],
+        };
+        let pkt = &WPacket::parse_frame(
+            &encode_action_with(&daiminkan, None, None, Some(&hand)).unwrap(),
+        )[0];
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([6, 7, 8]));
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x31, 0x31, 0x31]));
+
+        // Chi and pon stay bare even with a hand available.
         let pon = MjaiEvent::Pon {
             actor: 0,
             target: 1,
@@ -416,9 +457,10 @@ mod tests {
         };
         let pkt =
             &WPacket::parse_frame(&encode_action_with(&pon, None, None, Some(&hand)).unwrap())[0];
-        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([6, 7]));
+        assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
+        assert_eq!(pkt.body["data"]["action"], 5);
+        assert_eq!(pkt.body["data"]["card"], 0x31);
 
-        // Tile not in hand → no field at all.
         let chi = MjaiEvent::Chi {
             actor: 0,
             target: 1,
@@ -430,6 +472,77 @@ mod tests {
             &WPacket::parse_frame(&encode_action_with(&chi, None, None, Some(&unknown)).unwrap())
                 [0];
         assert!(pkt.body["data"].get("move_cards_pos").is_none());
+        assert!(pkt.body["data"].get("group_cards").is_none());
+    }
+
+    /// Ankan carries three `group_cards` (the client's own comment: "the
+    /// server only needs three") with the positions of all four, and the
+    /// promoted-tile kakan carries only the tile and its position.
+    #[test]
+    fn kan_shapes_match_the_client_sender() {
+        let hand: Vec<String> = [
+            "1m", "2m", "5m", "5mr", "5m", "5m", "6s", "7s", "E", "S", "W", "N", "P",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let ankan = MjaiEvent::Ankan {
+            actor: 0,
+            consumed: ["5mr".into(), "5m".into(), "5m".into(), "5m".into()],
+        };
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&ankan, None, None, Some(&hand)).unwrap())[0];
+        assert_eq!(pkt.body["data"]["action"], 8);
+        assert_eq!(pkt.body["data"]["card"], 0x125);
+        assert_eq!(pkt.body["data"]["group_cards"], json!([0x25, 0x25, 0x25]));
+        // Positions follow the consumed list's order (the red five is
+        // listed first and sits at hand index 3).
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([3, 2, 4, 5]));
+
+        let kakan = MjaiEvent::Kakan {
+            actor: 0,
+            pai: "5p".into(),
+            consumed: ["5p".into(), "5p".into(), "5p".into()],
+        };
+        let hand2: Vec<String> = vec!["5p".to_string(); 14];
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&kakan, None, None, Some(&hand2)).unwrap())
+                [0];
+        assert_eq!(pkt.body["data"]["action"], 9);
+        assert_eq!(pkt.body["data"]["card"], 0x05);
+        assert!(pkt.body["data"].get("group_cards").is_none());
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([0]));
+    }
+
+    /// Kita is the bare north tile, per the client's `ActionPullNorth`
+    /// offer construction.
+    #[test]
+    fn kita_is_bare() {
+        let kita = MjaiEvent::Kita {
+            actor: 0,
+            pai: Some("N".into()),
+        };
+        let pkt = &WPacket::parse_frame(&encode_action(&kita).unwrap())[0];
+        assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
+        assert_eq!(pkt.body["data"]["action"], 13);
+        assert_eq!(pkt.body["data"]["card"], 0x61);
+    }
+
+    /// A ron names the claimed discard, mirroring the tsumo's winning
+    /// tile — the client's claim buttons send `{action, card}`.
+    #[test]
+    fn ron_names_the_claimed_discard() {
+        let ron = MjaiEvent::Hora {
+            actor: 0,
+            target: 2,
+            deltas: None,
+            ura_markers: None,
+        };
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&ron, None, Some("7s"), None).unwrap())[0];
+        assert_eq!(pkt.body["data"]["action"], 7);
+        assert_eq!(pkt.body["data"]["card"], 0x17);
+        assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
     }
 
     /// Verbatim from the recording: a 6p self-draw win went out as
@@ -484,6 +597,41 @@ mod tests {
         assert_eq!(pkt.body["data"]["move_cards_pos"][0], 14);
         assert_eq!(pkt.body["data"]["move_cards_pos"][1], 13);
         assert_eq!(pkt.body["data"]["is_li_zhi"], false);
+    }
+
+    /// With the hand available, `move_cards_pos` follows the client's
+    /// formula: the tile's 1-based hand position (the drawn tile sits
+    /// last), and the client's own `hand.len() - 1` fallback for the
+    /// animation target slot.
+    #[test]
+    fn discard_positions_follow_the_client_formula() {
+        let hand: Vec<String> = [
+            "1m", "2m", "3m", "4p", "5p", "6s", "7s", "8s", "9s", "E", "S", "W", "N", "F",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        // Tedashi of the 4p (0-based index 3 → 1-based 4).
+        let tedashi = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "4p".into(),
+            tsumogiri: false,
+        };
+        let pkt =
+            &WPacket::parse_frame(&encode_action_with(&tedashi, None, None, Some(&hand)).unwrap())
+                [0];
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([4, 13]));
+
+        // Tsumogiri always names the last slot.
+        let tsumogiri = MjaiEvent::Dahai {
+            actor: 0,
+            pai: "F".into(),
+            tsumogiri: true,
+        };
+        let pkt = &WPacket::parse_frame(
+            &encode_action_with(&tsumogiri, None, None, Some(&hand)).unwrap(),
+        )[0];
+        assert_eq!(pkt.body["data"]["move_cards_pos"], json!([14, 13]));
     }
 
     /// The round-advance press must be a bare req_user_prepare on binary

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -341,18 +341,25 @@ impl RiichiCityBridge {
 
         self.status.pending_dora.clear();
         self.status.pending_reach = None;
+        self.status.meld_counts = [0; 4];
 
         // Opening draw: our own drawn 14th tile if we are the dealer, otherwise
         // the dealer's hidden first draw.
         match tsumo_code {
-            Some(code) => events.push(MjaiEvent::Tsumo {
-                actor: self.status.seat,
-                pai: card_to_mjai(code as u32),
-            }),
-            None => events.push(MjaiEvent::Tsumo {
-                actor: oya,
-                pai: "?".to_string(),
-            }),
+            Some(code) => {
+                self.status.drawn_by = Some(self.status.seat);
+                events.push(MjaiEvent::Tsumo {
+                    actor: self.status.seat,
+                    pai: card_to_mjai(code as u32),
+                });
+            }
+            None => {
+                self.status.drawn_by = Some(oya);
+                events.push(MjaiEvent::Tsumo {
+                    actor: oya,
+                    pai: "?".to_string(),
+                });
+            }
         }
         events
     }
@@ -368,6 +375,7 @@ impl RiichiCityBridge {
             warn!(target: LOG, "cmd_in_card_brc from unknown user_id");
             return events;
         };
+        self.status.drawn_by = Some(actor);
         events.push(MjaiEvent::Tsumo {
             actor,
             pai: field_card(data, "card"),
@@ -375,12 +383,17 @@ impl RiichiCityBridge {
         events
     }
 
-    /// `cmd_send_current_action` — our own draw (revealed tile).
+    /// `cmd_send_current_action` — our own draw (revealed tile). Also
+    /// fires with `in_card: 0` as the discard prompt after our own
+    /// chi/pon (the client's handler documents both), which is no draw
+    /// at all — the `"?"` guard skips it, and `drawn_by` must stay unset
+    /// so the following discard is never read as tsumogiri.
     fn on_send_current_action(&mut self, data: Option<&JsonValue>) -> Vec<MjaiEvent> {
         let mut events = self.flush_pending_reach();
         let Some(data) = data else { return events };
         let pai = field_card(data, "in_card");
         if pai != "?" {
+            self.status.drawn_by = Some(self.status.seat);
             events.push(MjaiEvent::Tsumo {
                 actor: self.status.seat,
                 pai,
@@ -414,6 +427,13 @@ impl RiichiCityBridge {
                 warn!(target: LOG, "game action from unknown user_id");
                 continue;
             };
+            // Chi/pon/daiminkan/ankan shrink the caller's rack by one
+            // 3-tile set (a kakan upgrades a counted pon; kita nets zero).
+            if matches!(act, 2..=6 | 8) {
+                if let Some(m) = self.status.meld_counts.get_mut(actor as usize) {
+                    *m = m.saturating_add(1);
+                }
+            }
             match act {
                 2..=4 => {
                     // Chi always calls from kamicha (previous seat).
@@ -472,11 +492,27 @@ impl RiichiCityBridge {
                 }
                 11 => {
                     let pai = field_card(action, "card");
-                    let tsumogiri = match action.get("move_cards_pos").and_then(JsonValue::as_array)
-                    {
-                        Some(a) if !a.is_empty() => a.first().and_then(json_i64) == Some(14),
-                        _ => true,
-                    };
+                    // Tsumogiri inference: `move_cards_pos[0]` is the tile's
+                    // 1-based rack slot and the held draw racks LAST, so a
+                    // tsumogiri names exactly `13 - 3*melds + 1` — the rack
+                    // size while holding a draw. The client clamps a
+                    // would-be last-slot tedashi below that
+                    // (`CheckOutCardIndex`), making the sentinel
+                    // unambiguous — but only on a turn that actually drew:
+                    // a post-chi/pon discard reuses the same slot range
+                    // with no draw involved.
+                    let drawn_slot = self
+                        .status
+                        .meld_counts
+                        .get(actor as usize)
+                        .map(|&m| 13 - 3 * m as i64 + 1);
+                    let tsumogiri = self.status.drawn_by == Some(actor)
+                        && match action.get("move_cards_pos").and_then(JsonValue::as_array) {
+                            Some(a) if !a.is_empty() => a.first().and_then(json_i64) == drawn_slot,
+                            // No positions: the draw is all we know.
+                            _ => true,
+                        };
+                    self.status.drawn_by = None;
                     let is_li_zhi = field_bool(action, "is_li_zhi");
                     if is_li_zhi {
                         events.push(MjaiEvent::Reach { actor, pai: None });
@@ -1180,6 +1216,127 @@ mod tests {
             }
             other => panic!("expected Tsumo, got {other:?}"),
         }
+    }
+
+    /// Tsumogiri is inferred from the rack-slot sentinel plus a live
+    /// draw: `move_cards_pos[0]` equal to the seat's rack size
+    /// (`13 - 3*melds + 1`) on a turn that drew — the client racks the
+    /// held draw last and clamps tedashi below it.
+    #[test]
+    fn tsumogiri_needs_a_draw_and_the_drawn_slot() {
+        let mut b = started_4p();
+        // Seat 1 draws, then discards the drawn slot → tsumogiri.
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_in_card_brc", "data": {"user_id": 1002, "card": 0}}),
+        );
+        let e = feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 11, "user_id": 1002, "card": 0x25, "move_cards_pos": [14], "is_li_zhi": false}
+            ]}}),
+        );
+        assert!(matches!(
+            &e[0],
+            MjaiEvent::Dahai {
+                actor: 1,
+                tsumogiri: true,
+                ..
+            }
+        ));
+
+        // Seat 2 draws but discards a lower slot → tedashi.
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_in_card_brc", "data": {"user_id": 1003, "card": 0}}),
+        );
+        let e = feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 11, "user_id": 1003, "card": 0x25, "move_cards_pos": [13], "is_li_zhi": false}
+            ]}}),
+        );
+        assert!(matches!(
+            &e[0],
+            MjaiEvent::Dahai {
+                actor: 2,
+                tsumogiri: false,
+                ..
+            }
+        ));
+    }
+
+    /// After a call the rack shrinks: the tsumogiri sentinel follows the
+    /// seat's meld count, and a post-call discard (no draw) is never
+    /// tsumogiri even when it names the rack's last slot.
+    #[test]
+    fn tsumogiri_slot_follows_the_melded_rack() {
+        let mut b = started_4p();
+        // Seat 1 draws and discards; we pon it and must now discard from
+        // an 11-slot rack without drawing.
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_in_card_brc", "data": {"user_id": 1002, "card": 0}}),
+        );
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 11, "user_id": 1002, "card": 0x25, "move_cards_pos": [14], "is_li_zhi": false}
+            ]}}),
+        );
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 5, "user_id": 1001, "card": 0x25, "group_cards": [0x25, 0x25]}
+            ]}}),
+        );
+        let e = feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 11, "user_id": 1001, "card": 0x31, "move_cards_pos": [11], "is_li_zhi": false}
+            ]}}),
+        );
+        assert!(
+            matches!(
+                &e[0],
+                MjaiEvent::Dahai {
+                    actor: 0,
+                    tsumogiri: false,
+                    ..
+                }
+            ),
+            "post-call discard is tedashi even at the last slot"
+        );
+
+        // Next turn we draw; slot 11 now IS the drawn slot.
+        feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_send_current_action", "data": {"in_card": 0x05}}),
+        );
+        let e = feed(
+            &mut b,
+            18,
+            json!({"cmd": "cmd_game_action_brc", "data": {"action_info": [
+                {"action": 11, "user_id": 1001, "card": 0x05, "move_cards_pos": [11], "is_li_zhi": false}
+            ]}}),
+        );
+        assert!(matches!(
+            &e[0],
+            MjaiEvent::Dahai {
+                actor: 0,
+                tsumogiri: true,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/bridge/riichi_city/state.rs
+++ b/src/bridge/riichi_city/state.rs
@@ -45,6 +45,17 @@ pub struct GameStatus {
     pub nicknames: std::collections::HashMap<i64, String>,
     /// Actor of the most recent discard — the ron/pon/kan target.
     pub last_dahai_actor: Option<u8>,
+    /// Seat currently holding a fresh draw (wall or rinshan), set by the
+    /// draw broadcasts and cleared by that seat's discard. Gates the
+    /// tsumogiri inference: a discard can only be tsumogiri on a turn
+    /// that drew — a post-chi/pon discard never is.
+    pub drawn_by: Option<u8>,
+    /// Called melds per actor this kyoku (chi/pon/daiminkan/ankan; a
+    /// kakan upgrades an existing pon and keeps the count). Sizes each
+    /// seat's tile rack: holding a draw, it racks `13 - 3*melds + 1`
+    /// tiles, and that last slot is the `move_cards_pos` index the
+    /// client sends for a tsumogiri.
+    pub meld_counts: [u8; 4],
     /// Deferred `reach_accepted`, emitted just before the next action so a
     /// chi/pon/kan on the riichi discard is ordered correctly.
     pub pending_reach: Option<MjaiEvent>,
@@ -69,6 +80,8 @@ impl Default for GameStatus {
             game_play: None,
             nicknames: std::collections::HashMap::new(),
             last_dahai_actor: None,
+            drawn_by: None,
+            meld_counts: [0; 4],
             pending_reach: None,
             pending_dora: Vec::new(),
             game_start: false,


### PR DESCRIPTION
Resolves the `TODO(capture)` notes in the Riichi City frame builder — not with more captures, but with the client's own source: the game's logic ships as plain-text Lua in the install (`Mahjong-JP_Data/StreamingAssets/Base/`), so the exact uplink templates are readable directly.

Sources: the discard/call senders (`ReqOutCard` / `ReqGameOpt` in `lua_models_game`), the offer-to-button construction (`lua_procestates_game_components`), and the action enum (`EMjActionType` in `lua_procestates_game`).

## Findings

- **Discard `move_cards_pos` is display-only animation metadata**, never validated: the client computes `[index, toIndex]` as rack-position hints (which slot the tile slides from) and the server merely relays them for other clients' animations. `index` is the tile's 1-based hand position with the drawn tile last (`CheckOutCardIndex`); `toIndex` depends on the player's tile-sort order (`GetMoveIndexByOutCard`) and the client's own fallback branches return `hand.len() - 1`. We now send the faithful values instead of the `[13,13]` placeholder.
- **Chi and pon are bare `{action, card}`** — the client's claim buttons send nothing else; the server derives the meld from the variant code plus the hand. We had been sending tolerated-but-extra `group_cards` and positions.
- **Ankan carries three `group_cards`** (the client's own comment: "the server only needs three"); we sent four.
- **Ron, kakan, and kita confirmed exactly as built**; daiminkan already matched (`card` = claimed discard, three `group_cards`, three positions).

Chi-variant codes 2/3/4 (claimed tile low/middle/high) and the bare-`{action:1}` pass were already verified from recorded uplinks and are unchanged.

Five new tests pin each verified shape and the discard-position formula.

`cargo test` green on top of latest v3.