### PR TITLE
fix(riichi-city): encode the bot's kyuushu declaration

### DIFF
--- a/src/autoplay/manager.rs
+++ b/src/autoplay/manager.rs
@@ -1013,7 +1013,9 @@ fn retry_hold_ms(base: u32, attempt: u32) -> u32 {
 /// a timed-out claim from ever landing in the next window.
 fn future_window_grace(action: &MjaiEvent) -> Duration {
     match action {
-        MjaiEvent::Dahai { .. } | MjaiEvent::Reach { .. } => Duration::from_secs(15),
+        MjaiEvent::Dahai { .. }
+        | MjaiEvent::Reach { .. }
+        | MjaiEvent::Ryukyoku { deltas: None } => Duration::from_secs(15),
         _ => Duration::from_secs(3),
     }
 }
@@ -1387,6 +1389,12 @@ mod tests {
         assert_eq!(
             future_window_grace(&MjaiEvent::None),
             Duration::from_secs(3)
+        );
+        // Kyuushu rides our own first-turn draw, so it gets the own-turn
+        // grace — not the claim-tight one.
+        assert_eq!(
+            future_window_grace(&MjaiEvent::Ryukyoku { deltas: None }),
+            Duration::from_secs(15)
         );
     }
 

--- a/src/autoplay/riichi_city/mod.rs
+++ b/src/autoplay/riichi_city/mod.rs
@@ -70,7 +70,9 @@ fn is_our_decision(ev: &MjaiEvent, our_seat: u8) -> bool {
         | MjaiEvent::Hora { actor, .. }
         | MjaiEvent::Kita { actor, .. } => Some(*actor),
         // `None` is the bot declining *our* call window — ours to send.
-        MjaiEvent::None => None,
+        // `Ryukyoku` (kyuushu, `deltas: None`) is the bot declaring on
+        // *our* first-turn draw — no actor field, inherently ours.
+        MjaiEvent::None | MjaiEvent::Ryukyoku { deltas: None } => None,
         _ => return false,
     };
     actor.is_none_or(|a| a == our_seat)
@@ -87,6 +89,7 @@ fn decision_kind(ev: &MjaiEvent) -> DecisionKind {
         MjaiEvent::Kakan { .. } => DecisionKind::Kakan,
         MjaiEvent::Hora { .. } => DecisionKind::Hora,
         MjaiEvent::Kita { .. } => DecisionKind::Kita,
+        MjaiEvent::Ryukyoku { .. } => DecisionKind::Ryukyoku,
         _ => DecisionKind::Pass,
     }
 }
@@ -246,5 +249,34 @@ mod tests {
             panic!("expected sleep");
         };
         assert!(duration_ms > 0);
+    }
+
+    /// A kyuushu declaration is ours to send (no actor field — it can
+    /// only come from the bot's own decision) and plans like any button
+    /// decision: think, then frame. Regression for the live timeout where
+    /// the declaration fell through `is_our_decision` and the server's
+    /// countdown had to auto-discard for us.
+    #[test]
+    fn kyuushu_declaration_plans_a_frame() {
+        let ev = MjaiEvent::Ryukyoku { deltas: None };
+        let f = CtxFixture::new();
+        let plan = RiichiCityAutoplay::new().plan(&f.ctx(&ev));
+        assert_eq!(plan.steps.len(), 2, "sleep then frame");
+        let Step::SendFrame(frame) = &plan.steps[1] else {
+            panic!("expected a frame step");
+        };
+        let pkts = WPacket::parse_frame(frame);
+        assert_eq!(pkts[0].body["data"]["action"], 12);
+    }
+
+    /// An observed exhaustive draw (deltas present) is not a decision —
+    /// it must not plan, let alone send.
+    #[test]
+    fn observed_draw_does_not_plan() {
+        let ev = MjaiEvent::Ryukyoku {
+            deltas: Some(vec![1500, -500, -500, -500]),
+        };
+        let f = CtxFixture::new();
+        assert!(RiichiCityAutoplay::new().plan(&f.ctx(&ev)).steps.is_empty());
     }
 }

--- a/src/bridge/riichi_city/build.rs
+++ b/src/bridge/riichi_city/build.rs
@@ -30,12 +30,14 @@ const BIN_CMD_REQUEST: u16 = 6;
 /// against the client's `EMjActionType` enum and uplink recordings: 1
 /// pass, 2/3/4 chi variants (claimed tile low/middle/high in the run),
 /// 5 pon, 6 daiminkan, 7 ron, 8 ankan, 9 kakan, 10 tsumo, 11 dahai,
-/// 13 kita.
+/// 12 kyuushu (nine terminals, `ActionEndGame` — offered as
+/// `is_nine_cards`), 13 kita.
 mod action {
     pub const PASS: i64 = 1;
     pub const RON: i64 = 7;
     pub const TSUMO: i64 = 10;
     pub const DAHAI: i64 = 11;
+    pub const NINE_CARDS: i64 = 12;
     pub const KITA: i64 = 13;
     pub const PON: i64 = 5;
     pub const DAIMINKAN: i64 = 6;
@@ -304,6 +306,14 @@ pub fn encode_action_with(
         }
         // Verified: declining a call window is a bare `{"action":1}`.
         MjaiEvent::None => json!({ "action": action::PASS }),
+        // Kyuushu (nine terminals): the offer builder adds a bare
+        // `{action = ActionEndGame}` for `is_nine_cards` and the button
+        // click sends it unchanged through `ReqGameOpt` — nil fields
+        // omitted, no confirm dialog. Only the bot's declaration form
+        // (`deltas: None`, how `BotAction::Kyushu` maps) is encodable: a
+        // Ryukyoku carrying deltas is an exhaustive draw observed on the
+        // wire, never a decision we can send.
+        MjaiEvent::Ryukyoku { deltas: None } => json!({ "action": action::NINE_CARDS }),
         _ => return None,
     };
     Some(action_frame(&data))
@@ -659,6 +669,36 @@ mod tests {
         assert_eq!(pkt.body["data"]["action"], 7);
         assert_eq!(pkt.body["data"]["card"], 0x17);
         assert_eq!(pkt.body["data"].as_object().unwrap().len(), 2);
+    }
+
+    /// Kyuushu (nine terminals) is a bare `{"action":12}` — the offer
+    /// builder's `{action = ActionEndGame}` for `is_nine_cards`, sent
+    /// unchanged by the button click. Regression for a live timeout
+    /// (2026-08-23): the bot declared on a 9-terminal first draw and the
+    /// unencodable action left the window open until the server
+    /// auto-discarded ~27s later.
+    #[test]
+    fn kyuushu_is_a_bare_twelve() {
+        let pkt =
+            &WPacket::parse_frame(&encode_action(&MjaiEvent::Ryukyoku { deltas: None }).unwrap())
+                [0];
+        assert_eq!(pkt.body["cmd"], CMD_GAME_ACTION);
+        assert_eq!(pkt.body["data"]["action"], 12);
+        assert_eq!(
+            pkt.body["data"].as_object().unwrap().len(),
+            1,
+            "no card, no positions — the client sends the code alone"
+        );
+    }
+
+    /// A Ryukyoku carrying deltas is an exhaustive draw observed on the
+    /// wire, not a decision — it must never encode.
+    #[test]
+    fn an_observed_draw_is_not_an_action() {
+        assert!(encode_action(&MjaiEvent::Ryukyoku {
+            deltas: Some(vec![1000, -1000, 1000, -1000]),
+        })
+        .is_none());
     }
 
     /// Verbatim from the recording: a 6p self-draw win went out as


### PR DESCRIPTION
Fills a gap the live logs caught: on a first-turn draw completing nine distinct terminal/honor tiles, the offer carries `is_nine_cards` and the bot answers with mjai `ryukyoku` — but the Riichi City planner had no arm for it. The unencodable action was silently dropped, the decision window sat open through the server's countdown (~27s, the turn timer visibly reaching the 5-second marks), and the server auto-tsumogiri'd for us.

The wire shape is verified from the client's own path, per the #273 standard: the offer builder adds a bare `{action = ActionEndGame}` for `is_nine_cards` (`OnRecvCurrentActionTips`), and the button click sends it unchanged through `ReqGameOpt` — nil fields omitted, no confirmation dialog. So: action 12, alone.

- **Frame builder**: `Ryukyoku { deltas: None }` encodes as `{"action":12}`. The `deltas` guard is load-bearing: `Ryukyoku` is shared with observed exhaustive draws (which carry score deltas), and those are events to record, never decisions to send.
- **Planner**: the declaration counts as our decision (no actor field — only the bot's own response reaches the planner) and plans sleep-then-frame under `DecisionKind::Ryukyoku`. Majsoul and Tenhou already handle kyuushu; Riichi City was the one planner missing it.
- **Manager**: kyuushu rides our own first-turn draw, so it gets the 15s own-turn window grace rather than the claim-tight 3s.

Four new tests pin the frame shape, the deltas guard, the plan, and the grace classification. `cargo test` green on top of latest v3 (936 passing).