### PR TITLE
fix(riichi-city): resolve our seat on mid-game reconnects

### DIFF
--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -1051,12 +1051,9 @@ mod tests {
         // Roster [1001,1002,1003,1004] rotated left by 2 → actor order
         // [1003,1004,1001,1002]; our uid 1001 lands at seat 2.
         assert_eq!(b.status.seat, 2);
-        assert_eq!(b.status.seat_resolved, true);
+        assert!(b.status.seat_resolved);
         assert_eq!(b.status.shift, 2);
-        assert_eq!(
-            b.status.game_start, false,
-            "mid-hand: start_game is not owed"
-        );
+        assert!(!b.status.game_start, "mid-hand: start_game is not owed");
         assert_eq!(b.status.actor_of(1003), Some(0));
         assert_eq!(b.status.actor_of(1001), Some(2));
 
@@ -1127,7 +1124,7 @@ mod tests {
         let mut b = RiichiCityBridge::new(None, None);
         auth(&mut b);
         reconnect_room(&mut b, Value::Null);
-        assert_eq!(b.status.game_start, true, "start_game still owed");
+        assert!(b.status.game_start, "start_game still owed");
         assert_eq!(b.status.seat, 2);
         let events = feed(
             &mut b,

--- a/src/bridge/riichi_city/mod.rs
+++ b/src/bridge/riichi_city/mod.rs
@@ -217,6 +217,43 @@ impl RiichiCityBridge {
                 }
             }
         }
+        // Mid-game reconnect: the running hand's `cmd_game_start` never
+        // arrives on this connection, so the rotation and our seat must be
+        // resolved here or every event — our own decision windows included
+        // — is attributed to the wrong actor (observed live: our window
+        // tagged `seat 0`, the default, and autoplay went blind). The
+        // payload carries everything the first `cmd_game_start` uses: the
+        // roster plus `initial_dealer_pos`, the first hand's East dealer —
+        // the client does exactly this from this same message
+        // (`GameParam.FirstBanker = initial_dealer_pos + 1`, "根据第一局的
+        // 东家 确定座位").
+        if data.get("is_reconnect").and_then(JsonValue::as_bool) == Some(true)
+            && !status.player_list.is_empty()
+        {
+            let dealer = field_i64(data, "initial_dealer_pos").unwrap_or(0);
+            let mid = dealer.rem_euclid(status.player_list.len() as i64) as usize;
+            status.player_list.rotate_left(mid);
+            let seat = status
+                .player_list
+                .iter()
+                .position(|&id| id == self.uid)
+                .unwrap_or_else(|| {
+                    warn!(target: LOG, "reconnect: our uid not in player_list; defaulting seat 0");
+                    0
+                }) as u8;
+            info!(target: LOG, "reconnect: resolved seat {seat} from initial_dealer_pos {dealer}");
+            status.seat = seat;
+            status.shift = dealer;
+            status.seat_resolved = true;
+            // Mid-hand (`hand_status` present): the game is already running
+            // and the tracker holds its state from the original connection,
+            // so the next kyoku boundary must NOT emit a second
+            // `start_game`. Pre-deal reconnects (`hand_status` null) leave
+            // the flag set — that `start_game` is still owed.
+            if data.get("hand_status").is_some_and(|h| !h.is_null()) {
+                status.game_start = false;
+            }
+        }
         self.status = status;
         if let Some(inject) = &self.inject {
             inject.set_in_game(true);
@@ -235,22 +272,28 @@ impl RiichiCityBridge {
         let n = self.status.num_players as i64;
 
         if self.status.game_start {
-            // Rotate enter-room order so index 0 is the first dealer.
-            if !self.status.player_list.is_empty() {
-                let mid = dealer_pos.rem_euclid(self.status.player_list.len() as i64) as usize;
-                self.status.player_list.rotate_left(mid);
+            // Rotate enter-room order so index 0 is the first dealer —
+            // unless a reconnect already did (seat_resolved); re-rotating
+            // the rotated list would shift every actor.
+            if !self.status.seat_resolved {
+                if !self.status.player_list.is_empty() {
+                    let mid = dealer_pos.rem_euclid(self.status.player_list.len() as i64) as usize;
+                    self.status.player_list.rotate_left(mid);
+                }
+                let seat = self
+                    .status
+                    .player_list
+                    .iter()
+                    .position(|&id| id == self.uid)
+                    .unwrap_or_else(|| {
+                        warn!(target: LOG, "our uid not found in player_list; defaulting seat 0");
+                        0
+                    }) as u8;
+                self.status.seat = seat;
+                self.status.shift = dealer_pos;
+                self.status.seat_resolved = true;
             }
-            let seat = self
-                .status
-                .player_list
-                .iter()
-                .position(|&id| id == self.uid)
-                .unwrap_or_else(|| {
-                    warn!(target: LOG, "our uid not found in player_list; defaulting seat 0");
-                    0
-                }) as u8;
-            self.status.seat = seat;
-            self.status.shift = dealer_pos;
+            let seat = self.status.seat;
             self.rotate_mjai_log();
             // Display names in mjai-actor order (player_list is already
             // dealer-rotated). A missing nickname becomes "" so the frontend
@@ -958,6 +1001,163 @@ mod tests {
             b.status.nicknames.get(&1001).map(String::as_str),
             Some("alice")
         );
+    }
+
+    /// A mid-game reconnect payload (from a live 2026-08-24 capture,
+    /// ids/nicks swapped for fakes): `is_reconnect: true`, the same roster
+    /// as the original table, `initial_dealer_pos` = the first hand's
+    /// East dealer in roster order, and a non-null `hand_status` marking
+    /// the running hand.
+    fn reconnect_room(b: &mut RiichiCityBridge, hand_status: Value) {
+        feed(
+            b,
+            18,
+            json!({
+                "cmd": "cmd_enter_room",
+                "room_id": "reconnecttoken1",
+                "data": {
+                    "is_reconnect": true,
+                    "initial_dealer_pos": 2,
+                    "hand_status": hand_status,
+                    "action_info": { "current_user_id": 1004, "current_action": null },
+                    "options": {
+                        "classify_id": "classifytoken0001",
+                        "player_count": 4,
+                        "stage_type": 1,
+                        "game_play": 1001
+                    },
+                    "players": [
+                        {"user": {"user_id": 1001, "nickname": "alice"}},
+                        {"user": {"user_id": 1002, "nickname": "bob"}},
+                        {"user": {"user_id": 1003, "nickname": "carol"}},
+                        {"user": {"user_id": 1004, "nickname": "dave"}}
+                    ]
+                }
+            }),
+        );
+    }
+
+    /// The live incident: after a mid-game reconnect, our own decision
+    /// window was attributed to the default `seat 0` — the tracker still
+    /// believed our seat was the one from the original connection, so the
+    /// bot was never asked and autoplay went blind for the rest of the
+    /// game. The reconnect enter_room must resolve the rotation and seat
+    /// itself, because the running hand's `cmd_game_start` never arrives.
+    #[test]
+    fn mid_hand_reconnect_resolves_seat_for_our_windows() {
+        let mut b = RiichiCityBridge::new(None, None);
+        auth(&mut b);
+        reconnect_room(&mut b, json!({ "ben_chang_num": 0, "chang_ci": 2 }));
+        // Roster [1001,1002,1003,1004] rotated left by 2 → actor order
+        // [1003,1004,1001,1002]; our uid 1001 lands at seat 2.
+        assert_eq!(b.status.seat, 2);
+        assert_eq!(b.status.seat_resolved, true);
+        assert_eq!(b.status.shift, 2);
+        assert_eq!(
+            b.status.game_start, false,
+            "mid-hand: start_game is not owed"
+        );
+        assert_eq!(b.status.actor_of(1003), Some(0));
+        assert_eq!(b.status.actor_of(1001), Some(2));
+
+        // Our own draw prompt lands on the right actor — pre-fix this was
+        // `actor: 0` and the bot never saw a decision for its seat.
+        let events = feed(
+            &mut b,
+            18,
+            json!({
+                "cmd": "cmd_send_current_action",
+                "data": { "in_card": 0x11, "is_nine_cards": false }
+            }),
+        );
+        assert!(matches!(
+            &events[..],
+            [MjaiEvent::Tsumo { actor: 2, pai }] if pai == "1s"
+        ));
+    }
+
+    /// Mid-hand reconnect: the next kyoku boundary must NOT emit a second
+    /// `start_game` (the tracker holds the game from the original
+    /// connection), but the round math must stay correct through the
+    /// reconnect-resolved `shift`.
+    #[test]
+    fn mid_hand_reconnect_next_kyoku_has_no_start_game_and_correct_oya() {
+        let mut b = RiichiCityBridge::new(None, None);
+        auth(&mut b);
+        reconnect_room(&mut b, json!({ "ben_chang_num": 0, "chang_ci": 2 }));
+        // East-2: dealer_pos 3 (roster coords) with shift 2 → oya 1.
+        let events = feed(
+            &mut b,
+            18,
+            json!({
+                "cmd": "cmd_game_start",
+                "data": {
+                    "quan_feng": 0x31, "bao_pai_card": 0x21, "dealer_pos": 3,
+                    "ben_chang_num": 0, "li_zhi_bang_num": 0,
+                    "user_info_list": [
+                        {"user_id": 1001, "hand_points": 25000},
+                        {"user_id": 1002, "hand_points": 25000},
+                        {"user_id": 1003, "hand_points": 25000},
+                        {"user_id": 1004, "hand_points": 25000}
+                    ],
+                    "hand_cards": [0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x01,0x02,0x03,0x04]
+                }
+            }),
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MjaiEvent::StartGame { .. })),
+            "the tracker already holds this game's start_game"
+        );
+        let kyoku = events.iter().find_map(|e| match e {
+            MjaiEvent::StartKyoku { oya, .. } => Some(*oya),
+            _ => None,
+        });
+        assert_eq!(kyoku, Some(1), "East-2 dealer is actor 1 via shift 2");
+    }
+
+    /// Pre-deal reconnect (`hand_status` null — e.g. during the ready
+    /// countdown): the coming `cmd_game_start` still owes a `start_game`
+    /// (this connection's tracker has nothing), using the seat the
+    /// reconnect already resolved — and must not re-rotate the rotated
+    /// roster.
+    #[test]
+    fn pre_deal_reconnect_still_emits_start_game_without_double_rotation() {
+        let mut b = RiichiCityBridge::new(None, None);
+        auth(&mut b);
+        reconnect_room(&mut b, Value::Null);
+        assert_eq!(b.status.game_start, true, "start_game still owed");
+        assert_eq!(b.status.seat, 2);
+        let events = feed(
+            &mut b,
+            18,
+            json!({
+                "cmd": "cmd_game_start",
+                "data": {
+                    "quan_feng": 0x31, "bao_pai_card": 0x21, "dealer_pos": 2,
+                    "ben_chang_num": 0, "li_zhi_bang_num": 0,
+                    "user_info_list": [
+                        {"user_id": 1001, "hand_points": 25000},
+                        {"user_id": 1002, "hand_points": 25000},
+                        {"user_id": 1003, "hand_points": 25000},
+                        {"user_id": 1004, "hand_points": 25000}
+                    ],
+                    "hand_cards": [0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x01,0x02,0x03,0x04]
+                }
+            }),
+        );
+        match events.iter().find_map(|e| match e {
+            MjaiEvent::StartGame { names, id, .. } => Some((names.clone(), *id)),
+            _ => None,
+        }) {
+            Some((names, id)) => {
+                assert_eq!(id, Some(2));
+                // Rotated actor order, not re-rotated.
+                assert_eq!(names, vec!["carol", "dave", "alice", "bob"]);
+            }
+            None => panic!("pre-deal reconnect still owes a start_game"),
+        }
     }
 
     #[test]

--- a/src/bridge/riichi_city/state.rs
+++ b/src/bridge/riichi_city/state.rs
@@ -64,6 +64,12 @@ pub struct GameStatus {
     /// True between `cmd_enter_room` and the first `cmd_game_start`, when
     /// `start_game` is still owed.
     pub game_start: bool,
+    /// Whether the dealer rotation and our seat have been resolved. Set by
+    /// the first `cmd_game_start`, or immediately on a mid-game reconnect
+    /// (`cmd_enter_room` with `is_reconnect`, which carries the same
+    /// `initial_dealer_pos` but never delivers a `cmd_game_start` for the
+    /// running hand).
+    pub seat_resolved: bool,
 }
 
 impl Default for GameStatus {
@@ -85,6 +91,7 @@ impl Default for GameStatus {
             pending_reach: None,
             pending_dora: Vec::new(),
             game_start: false,
+            seat_resolved: false,
         }
     }
 }

--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -520,7 +520,11 @@ mod tests {
             &[udir.clone(), "--remote-debugging-port=1234".into()],
             profile
         ));
-        assert!(is_controlled_browser("chromium", &[udir.clone()], profile));
+        assert!(is_controlled_browser(
+            "chromium",
+            std::slice::from_ref(&udir),
+            profile
+        ));
 
         // Renderer/GPU child: has --type → not the process we target directly.
         assert!(!is_controlled_browser(
@@ -555,15 +559,23 @@ mod tests {
 
         // A non-browser process is never matched, even with the arg — e.g.
         // the cmd.exe that launched the browser carries the same argument.
-        assert!(!is_controlled_browser("firefox", &[udir.clone()], profile));
-        assert!(!is_controlled_browser("cmd.exe", &[udir.clone()], profile));
+        assert!(!is_controlled_browser(
+            "firefox",
+            std::slice::from_ref(&udir),
+            profile
+        ));
+        assert!(!is_controlled_browser(
+            "cmd.exe",
+            std::slice::from_ref(&udir),
+            profile
+        ));
 
         // Regression: every browser family the backend can auto-detect must
         // match, not just chrome/chromium — a surviving msedge.exe went
         // unreclaimed and capture timed out waiting for the CDP endpoint.
         for name in ["msedge.exe", "brave.exe", "vivaldi.exe", "opera.exe"] {
             assert!(
-                is_controlled_browser(name, &[udir.clone()], profile),
+                is_controlled_browser(name, std::slice::from_ref(&udir), profile),
                 "{name} must be reclaimable"
             );
         }


### PR DESCRIPTION
Closes a hole the live logs caught: on a mid-game reconnect, the fresh per-connection bridge never resolves our seat — the running hand's `cmd_game_start` never arrives on the new connection, so `GameStatus.seat` stays at its default `0`. Our own decision window (`cmd_send_current_action` goes only to the acting player, with `in_card` revealed to the owner) is then emitted as `Tsumo actor 0`, while the tracker still holds the seat from the original connection's `start_game` — the bot is never asked, and autoplay is blind for the rest of the game: every one of our turns runs the clock to zero.

## The fix

The reconnect `cmd_enter_room` carries everything the first `cmd_game_start` uses: the roster plus `initial_dealer_pos` — the first hand's East dealer in roster order. The client itself places seats from exactly this field on this same message (`GameParam.FirstBanker = initial_dealer_pos + 1`, "根据第一局的东家 确定座位"), and the value is identical between the original and reconnect announcements (verified on a live capture: `2 = 2`). On `is_reconnect` with a non-empty roster, the bridge now rotates `player_list` by `initial_dealer_pos`, resolves the seat from the auth uid, and sets `shift` — restoring correct attribution for every subsequent event (windows, broadcasts, scores) through `actor_of()`.

The `hand_status` field discriminates the two reconnect moments: mid-hand (non-null) suppresses the second `start_game` at the next kyoku boundary — the tracker already holds this game — while pre-deal reconnects (null) still owe it. A new `seat_resolved` flag guards `cmd_game_start`'s rotation so the pre-deal path emits `start_game` from the already-rotated roster without double-rotating.

## Known, accepted limits

- Bridge-local `meld_counts` reset at reconnect: the inbound tsumogiri flag can mislabel melded opponents' discards until their next meld. Outbound frames use the global tracker's hand and are unaffected.
- The per-game mjai log file stops at the reconnect point; history reads the bus and stays complete.

## Tests

Three, from the live capture's payload (ids swapped for fakes): the incident itself (our window attributed to seat 2), the mid-hand next-kyoku boundary (no second `start_game`, correct oya via `shift`), and the pre-deal case (`start_game` emitted once, no double rotation). Verified live after the fix: a forced network drop mid-game reconnects with autoplay intact.

`cargo test` green on top of latest v3 (939 passing), clippy and rustfmt clean.