### PR TITLE
fix: offer chi/pon on the haitei discard

### DIFF
--- a/src/capture/chromium/profile.rs
+++ b/src/capture/chromium/profile.rs
@@ -520,7 +520,11 @@ mod tests {
             &[udir.clone(), "--remote-debugging-port=1234".into()],
             profile
         ));
-        assert!(is_controlled_browser("chromium", &[udir.clone()], profile));
+        assert!(is_controlled_browser(
+            "chromium",
+            std::slice::from_ref(&udir),
+            profile
+        ));
 
         // Renderer/GPU child: has --type → not the process we target directly.
         assert!(!is_controlled_browser(
@@ -555,15 +559,23 @@ mod tests {
 
         // A non-browser process is never matched, even with the arg — e.g.
         // the cmd.exe that launched the browser carries the same argument.
-        assert!(!is_controlled_browser("firefox", &[udir.clone()], profile));
-        assert!(!is_controlled_browser("cmd.exe", &[udir.clone()], profile));
+        assert!(!is_controlled_browser(
+            "firefox",
+            std::slice::from_ref(&udir),
+            profile
+        ));
+        assert!(!is_controlled_browser(
+            "cmd.exe",
+            std::slice::from_ref(&udir),
+            profile
+        ));
 
         // Regression: every browser family the backend can auto-detect must
         // match, not just chrome/chromium — a surviving msedge.exe went
         // unreclaimed and capture timed out waiting for the CDP endpoint.
         for name in ["msedge.exe", "brave.exe", "vivaldi.exe", "opera.exe"] {
             assert!(
-                is_controlled_browser(name, &[udir.clone()], profile),
+                is_controlled_browser(name, std::slice::from_ref(&udir), profile),
                 "{name} must be reclaimable"
             );
         }

--- a/src/game_state/tracker.rs
+++ b/src/game_state/tracker.rs
@@ -176,6 +176,9 @@ impl GameTracker {
                             m.from_who = target;
                         }
                     }
+                    if let AkagiEvent::Dahai { actor, pai, .. } = ev {
+                        open_haitei_claims(s, *actor, pai);
+                    }
                     // Runs after `apply_ippatsu_patch_4p`, which has already
                     // retired every ippatsu window (a kakan is a call) — the
                     // live path checks chankan with ippatsu still up. Harmless
@@ -206,6 +209,9 @@ impl GameTracker {
                         if let Some(m) = s.players.get_mut(actor).and_then(|p| p.melds.last_mut()) {
                             m.from_who = target;
                         }
+                    }
+                    if let AkagiEvent::Dahai { actor, pai, .. } = ev {
+                        open_haitei_claims_3p(s, *actor, pai);
                     }
                     // Same ippatsu-ordering caveat as the 4p arm above.
                     if let Some((actor, pai, seat)) = &opponent_kakan {
@@ -325,6 +331,81 @@ fn meld_target(ev: &AkagiEvent) -> Option<(usize, i8)> {
         | AkagiEvent::Chi { actor, target, .. }
         | AkagiEvent::Daiminkan { actor, target, .. } => Some((*actor as usize, *target as i8)),
         _ => None,
+    }
+}
+
+/// riichienv-core 0.4.8 gates chi/pon/kan detection on
+/// `wall.drawable_count > 0`, a stricter variant than Riichi City plays:
+/// on a live 2026-08-24 capture the server offered a chi on the haitei
+/// discard (the last live-wall tile) and the claim window timed out
+/// because the engine's empty claim set made `can_act` false — the bot
+/// was never asked. Re-run the engine's own claim detection with the
+/// gate satisfied — restoring the wall immediately after, since the ron
+/// arm already ran during apply with the true haitei conditions — and
+/// splice only the chi/pon claims back in (kan at an empty live wall is
+/// left to the engine's own judgment).
+fn open_haitei_claims(s: &mut GameState, discarder: u8, pai: &str) {
+    use riichienv_core::action::{ActionType, Phase};
+    if s.wall.drawable_count != 0 || s.phase != Phase::WaitAct {
+        return;
+    }
+    let Some(tile) = riichienv_core::parser::mjai_to_tid(pai) else {
+        return;
+    };
+    s.wall.drawable_count = 1;
+    let mut claimants = Vec::new();
+    for i in 0..s.players.len() as u8 {
+        if i == discarder {
+            continue;
+        }
+        let (legals, _) = s._get_claim_actions_for_player(i, discarder, tile);
+        let calls: Vec<_> = legals
+            .into_iter()
+            .filter(|a| matches!(a.action_type, ActionType::Chi | ActionType::Pon))
+            .collect();
+        if !calls.is_empty() {
+            s.current_claims.insert(i, calls);
+            claimants.push(i);
+        }
+    }
+    s.wall.drawable_count = 0;
+    if !claimants.is_empty() {
+        s.phase = Phase::WaitResponse;
+        s.active_players = claimants;
+    }
+}
+
+/// Sanma twin of [`open_haitei_claims`]: pon (there is no chi in sanma)
+/// on the last live-wall discard, same engine gate, same live incident
+/// class.
+fn open_haitei_claims_3p(s: &mut GameState3P, discarder: u8, pai: &str) {
+    use riichienv_core::action::{ActionType, Phase};
+    if s.wall.drawable_count != 0 || s.phase != Phase::WaitAct {
+        return;
+    }
+    let Some(tile) = riichienv_core::parser::mjai_to_tid(pai) else {
+        return;
+    };
+    s.wall.drawable_count = 1;
+    let mut claimants = Vec::new();
+    for i in 0..s.players.len() as u8 {
+        if i == discarder {
+            continue;
+        }
+        let (legals, _) = s._get_claim_actions_for_player(i, discarder, tile);
+        let calls: Vec<_> = legals
+            .into_iter()
+            .filter(|a| matches!(a.action_type, ActionType::Chi | ActionType::Pon))
+            .collect();
+        if !calls.is_empty() {
+            s.current_claims.insert(i, calls);
+            claimants.push(i);
+        }
+    }
+    s.wall.drawable_count = 0;
+    if !claimants.is_empty() {
+        s.phase = Phase::WaitResponse;
+        s.active_players = claimants;
     }
 }
 
@@ -543,6 +624,49 @@ mod tests {
             pai: pai.into(),
             tsumogiri: false,
         }
+    }
+
+    /// riichienv-core gates chi/pon on a non-empty live wall; Riichi City
+    /// offers them on the haitei discard too (live 2026-08-24 capture:
+    /// the server offered a chi on the very last live-wall tile and the
+    /// window timed out because the engine's empty claim set made
+    /// `can_act` false). The post-apply patch must splice those claims
+    /// back in — with the wall restored, so the false non-empty wall
+    /// doesn't leak into anything else.
+    #[test]
+    fn haitei_discard_still_offers_claims() {
+        use riichienv_core::action::Phase;
+        let mut t = GameTracker::new();
+        t.handle(&start_game()).unwrap();
+        // Our seat (0) holds 3m4m among others; seat 3 is our claim
+        // source ((3+1)%4 = 0).
+        t.handle(&start_kyoku_with_our_hand()).unwrap();
+        if let Some(TrackedGame::Four(s)) = t.state.as_mut() {
+            s.wall.drawable_count = 0;
+        }
+        t.handle(&dahai(3, "2m")).unwrap();
+        assert_eq!(
+            t.our_seat_can_act(),
+            Some(true),
+            "the chi on the haitei discard must be offered"
+        );
+        if let Some(TrackedGame::Four(s)) = t.state.as_ref() {
+            assert_eq!(s.wall.drawable_count, 0, "wall restored after the splice");
+            assert_eq!(s.phase, Phase::WaitResponse);
+        }
+        // And a tile we cannot use still yields nothing at haitei.
+        let mut t2 = GameTracker::new();
+        t2.handle(&start_game()).unwrap();
+        t2.handle(&start_kyoku_with_our_hand()).unwrap();
+        if let Some(TrackedGame::Four(s)) = t2.state.as_mut() {
+            s.wall.drawable_count = 0;
+        }
+        t2.handle(&dahai(3, "S")).unwrap();
+        assert_eq!(
+            t2.our_seat_can_act(),
+            Some(false),
+            "no pair, no run — nothing to claim"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes a pre-existing gap in shared code, observed on a live 2026-08-24 Riichi City capture: `riichienv-core 0.4.8` gates chi/pon/kan detection on `wall.drawable_count > 0`, a stricter variant than the games actually play. With the live wall empty — the hand's final discard at haitei — the engine's claim set comes back empty, `can_act` goes false, and the bot is never asked. In the capture, the server offered a chi on that discard and the call window burned its full timer with Akagi silent.

## Scope

Any hand that plays toward an exhaustive draw hits this: the final discard happens at wall == 0, and pon (from any player) or chi (from the previous player) on it is suppressed. Ron is unaffected — the ron arm runs before the wall gate, so houtei raoyui still works. Kan replacement draws (rinshan, dead-wall) also deplete the engine's count, so kan-heavy hands can hit the suppression a few tiles early. Platform-independent: the same tracker/engine path feeds Majsoul and Tenhou, where the visible effect is the bot going quiet on a claim the server is offering.

## Fix

After applying a wall-empty `dahai`, re-run the engine's own claim detection with the gate satisfied (bumping `drawable_count` by one and restoring it immediately — the ron arm already ran during apply with the true haitei conditions) and splice the chi/pon claims into `current_claims`, setting the response phase. Kan stays gated: an empty live wall is the engine's own call there. 4p and sanma twins.

A unit test pins the offer (chi from the previous seat at wall 0) and that the wall is restored after the splice; a tile we cannot use still yields nothing.

The second commit fixes pre-existing `clippy --all-targets` failures in `profile.rs` test helpers that the floating stable toolchain newly flags on v3 — any PR currently trips them.

`cargo test` green on top of latest v3 (937 passing), clippy `-D warnings` and rustfmt clean.