### PR TITLE
fix(tenhou): survive a mid-game rejoin that skips TAIKYOKU

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,9 @@ Useful when debugging a bot or a bridge issue.
   is a snapshot of the table, not a replay, so Akagi cannot rebuild the
   hand in progress. It shows a "rejoined mid-hand" toast and pauses
   analysis and autoplay until the next hand starts; from there on the
-  game is tracked normally. The hands played before the drop are not
-  kept in History.
+  game is tracked normally. A game rejoined this way is not saved to
+  History, since Akagi never saw the hands before the drop and a partial
+  record would skew the statistics.
 - **Bot crashed mid-game.** The Inspector tab shows the last frame the
   bot saw before dying; attach it to the bug report.
 - **Wrong bot picked for a 3-player game.** Check `bot.active_3p` in

--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ Useful when debugging a bot or a bridge issue.
   "couldn't terminate the browser already using profile …" — close it
   manually and click Restart. Running two Akagi instances against the
   same profile is unsupported.
+- **Tenhou reconnected in the middle of a hand.** Tenhou's rejoin message
+  is a snapshot of the table, not a replay, so Akagi cannot rebuild the
+  hand in progress. It shows a "rejoined mid-hand" toast and pauses
+  analysis and autoplay until the next hand starts; from there on the
+  game is tracked normally. The hands played before the drop are not
+  kept in History.
 - **Bot crashed mid-game.** The Inspector tab shows the last frame the
   bot saw before dying; attach it to the bug report.
 - **Wrong bot picked for a 3-player game.** Check `bot.active_3p` in

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -94,6 +94,10 @@ pub struct BridgeHooks {
     /// Riichi City: frame-injection gate, maintained by the bridge between
     /// `cmd_enter_room` and `cmd_room_end` (see `autoplay::inject`).
     pub riichi_inject: Option<crate::autoplay::inject::SharedInjectBus>,
+    /// Frontend toast channel, for states a bridge must tell the user about
+    /// that no mjai event can carry (Tenhou: a mid-hand rejoin pauses
+    /// analysis until the next hand). Wired by both capture backends.
+    pub notify: Option<crate::event_bus::NotifyBus>,
 }
 
 /// Construct a bridge for the given platform.
@@ -114,9 +118,11 @@ pub fn for_platform(
                 .with_time_budget(hooks.time_budget)
                 .with_input_watch(hooks.input_watch),
         ),
-        crate::config::Platform::Tenhou => {
-            Box::new(TenhouBridge::new(flow_log, session).with_shared_state(hooks.tenhou_state))
-        }
+        crate::config::Platform::Tenhou => Box::new(
+            TenhouBridge::new(flow_log, session)
+                .with_shared_state(hooks.tenhou_state)
+                .with_notify(hooks.notify),
+        ),
         crate::config::Platform::RiichiCity => {
             Box::new(RiichiCityBridge::new(flow_log, session).with_inject(hooks.riichi_inject))
         }

--- a/src/bridge/tenhou/README.md
+++ b/src/bridge/tenhou/README.md
@@ -24,7 +24,7 @@ out any deliberate divergence.
 | Tag | Trigger | mjai output |
 |---|---|---|
 | `<Z/>` | heartbeat | (none) |
-| `HELO` / `REJOIN` / `BYE` / `SHUFFLE` | session control | (none) |
+| `HELO` / `REJOIN` / `SAIKAI` / `BYE` / `SHUFFLE` | session control | (none) |
 | `GO` | rules / room, before `TAIKYOKU` | (none; stashed for `MatchInfo`, bit `0x10` = sanma) |
 | `UN` | roster, wire-relative names | (none; consumed by `start_game`, an empty slot = sanma) |
 | `TAIKYOKU` | start of game | `start_game` (resolves our seat from `oya`) |

--- a/src/bridge/tenhou/README.md
+++ b/src/bridge/tenhou/README.md
@@ -72,8 +72,12 @@ both were seen; the kyoku frame only fills in when it was not
 0 points). That check is final. Before it fires — and on a flow that joined
 mid-game and will never see it — the bridge takes the earlier hints in this
 order: `<GO type>` bit `0x10`, then a `<UN/>` roster with exactly one empty
-slot, then (REINIT only) the shape of the snapshot itself: the ghost's score
-still 0, its river empty, and no 2m–8m in our hand.
+slot, then the table total on the kyoku frame itself (`ten` plus the riichi
+sticks in `seed[2]`: Tenhou deals 100000 points in yonma and 105000 in sanma,
+and a bust ends the game, so the total never changes — see
+`state::three_players_from_scores`), and as a last resort on `REINIT` the
+shape of the snapshot: the ghost's score still 0, its river empty, and no
+2m–8m in our hand or any river.
 
 ### Meld bitfield
 
@@ -159,8 +163,16 @@ The bridge therefore:
    `start_game` at the next `<INIT/>`, which reopens the game for the
    tracker, bots and history on the right seat and player count.
 
-Games that end while suspended end silently: the `end_game` is withheld like
-everything else, and the next game's `<TAIKYOKU/>` lifts the suspension.
+The game's end is the one event that still passes while suspended, so the
+tracker closes the game, the bot manager stops its runner and History resets.
+Whether it arrives during the suspended hand or after play resumed, the
+`end_game` of a game this flow joined mid-way is emitted as *terminated*
+(`MjaiEvent::terminated_game`): the hands before the rejoin were never seen
+here, so History drops the game instead of filing the remainder as a complete
+one with its own per-hand stats. The flag clears at the next `<TAIKYOKU/>`,
+or at an E1H0 `<INIT/>` — the first deal is a game start whether or not a
+`TAIKYOKU` announced it, and it re-seats the flow the same way `TAIKYOKU`
+would.
 
 ## Adding a new tag handler
 

--- a/src/bridge/tenhou/README.md
+++ b/src/bridge/tenhou/README.md
@@ -24,9 +24,12 @@ out any deliberate divergence.
 | Tag | Trigger | mjai output |
 |---|---|---|
 | `<Z/>` | heartbeat | (none) |
-| `HELO` / `REJOIN` / `GO` / `UN` / `BYE` / `SHUFFLE` | session control | (none) |
+| `HELO` / `REJOIN` / `BYE` / `SHUFFLE` | session control | (none) |
+| `GO` | rules / room, before `TAIKYOKU` | (none; stashed for `MatchInfo`, bit `0x10` = sanma) |
+| `UN` | roster, wire-relative names | (none; consumed by `start_game`, an empty slot = sanma) |
 | `TAIKYOKU` | start of game | `start_game` (resolves our seat from `oya`) |
 | `INIT` | start of kyoku | `start_kyoku` (sanma detected via 0-score slot) |
+| `REINIT` | rejoin: snapshot of the hand in progress | (none — see *Reconnecting mid-hand*) |
 | `T<n>` / `U<n>` / `V<n>` / `W<n>` | tsumo (rel seats 0..3) | `tsumo` |
 | `D<n>` / `E<n>` / `F<n>` / `G<n>` (uppercase) | discard of just-drawn tile | `dahai { tsumogiri: true }` |
 | `d<n>` / `e<n>` / `f<n>` / `g<n>` (lowercase) | tedashi | `dahai { tsumogiri: false }` |
@@ -49,8 +52,28 @@ Tenhou tiles are integer indices `0..=135`. `index / 4` gives tile type
 
 Tenhou messages always use *relative* seats: rel 0 is the observing player.
 `State::rel_to_abs` / `abs_to_rel` translate to mjai's absolute frame. The
-bridge resolves our absolute seat from `<TAIKYOKU oya="N"/>`: `seat = (4 - N) % 4`
-(`(3 - N) % 3` once sanma is detected at INIT).
+bridge resolves our absolute seat from `<TAIKYOKU oya="N"/>`: `seat = (4 - N) % 4`.
+Wire-abs 0 is whoever dealt E1, and the wire stays 4-positional in sanma (the
+absent seat is a ghost at wire-abs 3; `seed[0]` skips its deal, so E1 E2 E3 S1
+are 0 1 2 4).
+
+A flow that starts mid-game — a reconnect, or Akagi attaching between hands —
+never sees `<TAIKYOKU/>`. Every kyoku frame (`INIT` / `REINIT`) carries the
+same information in another form: the dealer of kyoku index `seed[0]` sits at
+wire-abs `seed[0] % 4`, and `oya` is that dealer's seat relative to us, so
+`state::seat_from_kyoku` recovers ours. `TAIKYOKU` stays authoritative when
+both were seen; the kyoku frame only fills in when it was not
+(`State::seat_resolved`).
+
+### Player count
+
+`start_game` must say 3 or 4, and only the E1H0 `<INIT/>` proves it (a 0 in
+`ten` at the very first deal is the absent seat; nobody starts a real game on
+0 points). That check is final. Before it fires — and on a flow that joined
+mid-game and will never see it — the bridge takes the earlier hints in this
+order: `<GO type>` bit `0x10`, then a `<UN/>` roster with exactly one empty
+slot, then (REINIT only) the shape of the snapshot itself: the ghost's score
+still 0, its river empty, and no 2m–8m in our hand.
 
 ### Meld bitfield
 
@@ -106,6 +129,38 @@ two distinct indices.
 
 Session control (`JOIN` / `GOK` / `NEXTREADY`) is deliberately **not** encoded:
 Akagi observes a real client, which sends those itself.
+
+## Reconnecting mid-hand (`REINIT`)
+
+When the client rejoins a game the server sends `<REINIT/>` in place of
+`<INIT/>`: `seed` / `ten` / `oya` / `hai` as in `INIT`, plus per-seat
+`m<rel>` (comma-separated `<N m=…/>` bitfields) and `kawa<rel>` (tile
+indices, with `255` marking the riichi declaration). It is a *snapshot*, not
+a log — nothing says when a call happened relative to the discards — so the
+mjai event stream for the hand in progress cannot be reconstructed. (Majsoul's
+`GameRestore` is an ordered action log, which is why the Majsoul bridge can
+replay and this one cannot.)
+
+The bridge therefore:
+
+1. resolves our seat and the player count from the frame (see above), so the
+   rest of the game is attributed correctly even though `<TAIKYOKU/>` was
+   never seen on this flow;
+2. rebuilds only what this flow itself needs — our hand (`hai`), our calls
+   (`m0`), riichi (`255` in `kawa0`) and whether a draw is in hand (tile
+   count) — so autoplay and `Bridge::build` keep working for the remainder of
+   the hand;
+3. emits **nothing** and sets `State::suspended`: every handler still runs
+   (the hand and window keep tracking), but `dispatch` drops their events
+   until the next `<INIT/>`. Feeding them to the tracker would apply live
+   play to a hand it last saw several turns ago (or, with a seat-0 bridge, to
+   the wrong seats), and each `?` draw that lands on our seat renders as 1m;
+4. posts a warning toast (via `BridgeHooks::notify`) and owes a fresh
+   `start_game` at the next `<INIT/>`, which reopens the game for the
+   tracker, bots and history on the right seat and player count.
+
+Games that end while suspended end silently: the `end_game` is withheld like
+everything else, and the next game's `<TAIKYOKU/>` lifts the suspension.
 
 ## Adding a new tag handler
 

--- a/src/bridge/tenhou/README.md
+++ b/src/bridge/tenhou/README.md
@@ -136,14 +136,22 @@ Akagi observes a real client, which sends those itself.
 
 ## Reconnecting mid-hand (`REINIT`)
 
-When the client rejoins a game the server sends `<REINIT/>` in place of
-`<INIT/>`: `seed` / `ten` / `oya` / `hai` as in `INIT`, plus per-seat
-`m<rel>` (comma-separated `<N m=…/>` bitfields) and `kawa<rel>` (tile
-indices, with `255` marking the riichi declaration). It is a *snapshot*, not
-a log — nothing says when a call happened relative to the discards — so the
-mjai event stream for the hand in progress cannot be reconstructed. (Majsoul's
-`GameRestore` is an ordered action log, which is why the Majsoul bridge can
-replay and this one cannot.)
+When the web client rejoins a game it opens a fresh socket, so the bridge
+that sees the rejoin is a fresh one. The captured sequence is
+
+```
+↑ HELO            ↓ GO (type, lobby)      ↓ UN (full roster)
+↑ GOK             ↓ SAIKAI (ba, oya, sc)  ↓ REINIT …   then live play
+```
+
+— **no `TAIKYOKU`**. `<REINIT/>` stands in for `<INIT/>`: `seed` / `ten` /
+`oya` / `hai` as in `INIT`, plus `m<rel>` for every seat that has called
+(comma-separated `<N m=…/>` bitfields; absent otherwise) and `kawa<rel>`
+(tile indices, with `255` marking the riichi declaration — the next entry is
+the riichi tile). It is a *snapshot*, not a log — nothing says when a call
+happened relative to the discards — so the mjai event stream for the hand in
+progress cannot be reconstructed. (Majsoul's `GameRestore` is an ordered
+action log, which is why the Majsoul bridge can replay and this one cannot.)
 
 The bridge therefore:
 

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -24,8 +24,9 @@ use super::{Bridge, Direction, ParseResult};
 use crate::{
     autoplay::tenhou_state::{SharedTenhouState, TenhouState},
     config::Platform,
+    event_bus::NotifyBus,
     logger::{FlowLogger, Session},
-    schema::{mjai::Actor, GameMeta, MatchInfo, MjaiEvent},
+    schema::{mjai::Actor, GameMeta, MatchInfo, MjaiEvent, Notification},
 };
 use chrono::Local;
 use meld::{Meld, MeldKind};
@@ -33,10 +34,12 @@ use serde_json::Value as JsonValue;
 use state::State;
 use std::sync::Arc;
 use tile::{tenhou_to_mjai, tenhou_to_mjai_one};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 const HEARTBEAT: &[u8] = b"<Z/>";
 const BAKAZE: [&str; 4] = ["E", "S", "W", "N"];
+/// Sentinel in a `<REINIT/>` `kawa<n>` list marking the riichi declaration.
+const REINIT_RIICHI_MARK: u32 = 255;
 
 /// Per-flow Tenhou state. One bridge instance per WebSocket connection.
 pub struct TenhouBridge {
@@ -49,6 +52,9 @@ pub struct TenhouBridge {
     /// after every parsed frame; `None` unless the chromium capture path
     /// wired it (see [`crate::autoplay::tenhou_state`]).
     shared: Option<SharedTenhouState>,
+    /// Frontend toast channel, for states the user has to know about but no
+    /// mjai event can carry (a mid-hand reconnect). `None` in tests.
+    notify: Option<NotifyBus>,
 }
 
 impl TenhouBridge {
@@ -59,6 +65,20 @@ impl TenhouBridge {
             session,
             mjai_log: None,
             shared: None,
+            notify: None,
+        }
+    }
+
+    /// Attach the frontend notification bus.
+    pub fn with_notify(mut self, notify: Option<NotifyBus>) -> Self {
+        self.notify = notify;
+        self
+    }
+
+    fn notify(&self, n: Notification) {
+        if let Some(tx) = &self.notify {
+            // No subscriber (headless / CLI) is not an error.
+            let _ = tx.send(n);
         }
     }
 
@@ -106,6 +126,15 @@ impl TenhouBridge {
         }
     }
 
+    /// Open the mjai log if this flow has none yet. `<TAIKYOKU/>` rotates
+    /// one per game; a flow that starts mid-game (reconnect, late attach)
+    /// never sees it, so the first kyoku frame opens the file instead.
+    fn ensure_mjai_log(&mut self) {
+        if self.mjai_log.is_none() {
+            self.rotate_mjai_log();
+        }
+    }
+
     fn write_mjai(&self, events: &[MjaiEvent]) {
         let Some(log) = &self.mjai_log else { return };
         for ev in events {
@@ -131,6 +160,26 @@ impl TenhouBridge {
             _ => {}
         }
 
+        let events = self.dispatch_tag(tag, msg);
+
+        // A flow that attached mid-kyoku (`<REINIT/>`) has no history for the
+        // hand in progress, so its events would land on whatever the tracker
+        // last saw — a hand it may be several turns behind on, or none at
+        // all. The handler still ran (autoplay needs the hand and window it
+        // maintains); only the stream is withheld until `on_init` lifts the
+        // suspension at the next kyoku.
+        if self.state.suspended && !events.is_empty() {
+            debug!(
+                target: "akagi::bridge::tenhou",
+                "dropping {} event(s) from <{tag}/>: joined mid-kyoku, waiting for the next INIT",
+                events.len()
+            );
+            return Vec::new();
+        }
+        events
+    }
+
+    fn dispatch_tag(&mut self, tag: &str, msg: &JsonValue) -> Vec<MjaiEvent> {
         if tag == "GO" {
             return self.on_go(msg);
         }
@@ -142,6 +191,9 @@ impl TenhouBridge {
         }
         if tag == "INIT" {
             return self.on_init(msg);
+        }
+        if tag == "REINIT" {
+            return self.on_reinit(msg);
         }
         if let Some(actor) = tsumo_actor(tag) {
             return self.on_tsumo(actor, tag, msg);
@@ -170,10 +222,16 @@ impl TenhouBridge {
 
     /// `<GO type="…" lobby="…"/>` — rules/room announcement, sent before
     /// `<TAIKYOKU/>`. No mjai events; the raw bitfield is stashed for
-    /// history's `MatchInfo` (room tier lives in bits 0x20 / 0x80).
+    /// history's `MatchInfo` (room tier lives in bits 0x20 / 0x80). Bit
+    /// 0x10 is the three-player flag — the earliest sanma signal, and the
+    /// only one a flow gets before its first kyoku frame when that frame is
+    /// not the E1H0 `<INIT/>` (see `on_init`).
     fn on_go(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
         self.state.go_type = parse_u32(msg, "type");
         self.state.lobby = parse_u32(msg, "lobby");
+        if let Some(three) = self.state.three_players_hint() {
+            self.state.set_three_players(three);
+        }
         Vec::new()
     }
 
@@ -181,7 +239,8 @@ impl TenhouBridge {
     /// wire-*relative* order (n0 = us). A reconnect `<UN/>` carries only the
     /// returning player's name, so only the roster form (n0 and n1 both
     /// present) is accepted — a partial update must not clobber good names.
-    /// No mjai events; consumed at `start_game` emission.
+    /// No mjai events; consumed at `start_game` emission. A roster with one
+    /// empty slot is the sanma ghost, which doubles as a player-count hint.
     fn on_un(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
         let name = |key: &str| {
             msg.get(key).and_then(JsonValue::as_str).map(|raw| {
@@ -196,6 +255,9 @@ impl TenhouBridge {
         let n2 = name("n2").unwrap_or_default();
         let n3 = name("n3").unwrap_or_default();
         self.state.un_names = Some([n0, n1, n2, n3]);
+        if let Some(three) = self.state.three_players_hint() {
+            self.state.set_three_players(three);
+        }
         Vec::new()
     }
 
@@ -215,12 +277,53 @@ impl TenhouBridge {
         // wire-abs seat is the inverse: (-oya_rel) mod 4. For sanma our
         // wire-abs is always in {0, 1, 2} because we are a real player —
         // wire-abs 3 is the ghost slot.
-        self.state.num_players = 4;
+        //
+        // Player count: a new game re-announces itself with <GO/> (and
+        // <UN/>), so their hint is this game's; the E1H0 <INIT/> that
+        // follows has the final say either way.
+        self.state
+            .set_three_players(self.state.three_players_hint().unwrap_or(false));
         self.state.seat = (4 - oya_rel) % 4;
-        self.state.is_3p = false;
+        self.state.seat_resolved = true;
+        // A new game on a flow that was waiting out a mid-kyoku join.
+        self.state.suspended = false;
         self.state.pending_start_game = true;
         self.rotate_mjai_log();
         Vec::new()
+    }
+
+    /// Adopt the seat a kyoku frame implies when `<TAIKYOKU/>` never told
+    /// us — a flow that attached mid-game (reconnect, late start). When it
+    /// did, TAIKYOKU stays authoritative and a disagreement is only logged:
+    /// it would mean a malformed frame, not a seat change.
+    fn resolve_seat_from_kyoku(&mut self, tag: &str, kyoku_index: i32, oya_rel: u8) {
+        let derived = state::seat_from_kyoku(kyoku_index, oya_rel);
+        if self.state.seat_resolved {
+            if derived != self.state.seat {
+                warn!(
+                    target: "akagi::bridge::tenhou",
+                    "<{tag}/> seed={kyoku_index} oya={oya_rel} implies our seat is {derived}, \
+                     TAIKYOKU said {}; keeping TAIKYOKU's",
+                    self.state.seat
+                );
+            }
+            return;
+        }
+        if self.state.is_ghost_abs(derived) {
+            warn!(
+                target: "akagi::bridge::tenhou",
+                "<{tag}/> seed={kyoku_index} oya={oya_rel} resolves our seat onto the sanma ghost slot; \
+                 keeping seat {}",
+                self.state.seat
+            );
+            return;
+        }
+        info!(
+            target: "akagi::bridge::tenhou",
+            "<{tag}/> on a flow with no TAIKYOKU: resolved our seat as {derived} from seed={kyoku_index} oya={oya_rel}"
+        );
+        self.state.seat = derived;
+        self.state.seat_resolved = true;
     }
 
     /// Seat-ordered display names for `start_game`. `<UN/>` roster names are
@@ -262,6 +365,14 @@ impl TenhouBridge {
             return Vec::new();
         }
 
+        // The seat, in case this flow never saw <TAIKYOKU/>. Must precede
+        // every rel→abs translation below.
+        self.resolve_seat_from_kyoku("INIT", seed[0], oya_rel);
+        // A new kyoku is a clean slate for the tracker: whatever this flow
+        // missed of the previous one no longer matters.
+        self.state.suspended = false;
+        self.ensure_mjai_log();
+
         let bakaze = BAKAZE[(seed[0] as usize) / 4];
         let kyoku = (seed[0] as u8) % 4 + 1;
         let honba = seed[1].max(0) as u8;
@@ -272,13 +383,12 @@ impl TenhouBridge {
         // Sanma detection per Python reference: at the very first kyoku of a
         // game, a 0-score slot in `ten` signals the absent 4th player. No
         // legitimate game starts with anyone at 0 points, so the value-based
-        // check is safe at E1H0 (it would not be safe mid-game). We do NOT
-        // wrap `seat` after detection — wire-abs is still 4-cycle, and our
-        // wire-abs (already in {0, 1, 2} for any real sanma player) doubles
-        // as mjai-abs.
-        if bakaze == "E" && kyoku == 1 && honba == 0 && raw_ten.contains(&0) {
-            self.state.is_3p = true;
-            self.state.num_players = 3;
+        // check is safe at E1H0 (it would not be safe mid-game) and overrides
+        // the <GO/> / <UN/> hints. We do NOT wrap `seat` after detection —
+        // wire-abs is still 4-cycle, and our wire-abs (already in {0, 1, 2}
+        // for any real sanma player) doubles as mjai-abs.
+        if bakaze == "E" && kyoku == 1 && honba == 0 {
+            self.state.set_three_players(raw_ten.contains(&0));
         }
 
         // Our hand. Tenhou messages are already in *our* viewpoint (rel seat 0
@@ -354,8 +464,99 @@ impl TenhouBridge {
             tehais,
             num_players: self.state.num_players,
         });
-        self.write_mjai(&events);
         events
+    }
+
+    /// `<REINIT seed="…" ten="…" oya="…" hai="…" m0..m3="…" kawa0..kawa3="…"/>`
+    /// — the server's picture of a kyoku already in progress, sent in place
+    /// of `<INIT/>` when the client rejoins a game.
+    ///
+    /// It is a snapshot, not a log: each seat's river and calls are listed,
+    /// but nothing says *when* a call happened relative to the discards, so
+    /// the mjai stream for the hand cannot be rebuilt (Majsoul's
+    /// `GameRestore` can — it is an ordered action log). We therefore emit
+    /// nothing, rebuild only what this flow itself needs — our seat, the
+    /// player count, and the hand / calls / riichi state autoplay and
+    /// `build` read — and suspend the stream until the next `<INIT/>`,
+    /// which re-opens the game with a fresh `start_game`. Feeding the live
+    /// events into the tracker instead would apply them to a hand it last
+    /// saw several turns ago (or, with a fresh seat-0 bridge, to the wrong
+    /// seats altogether), and every `?` draw that lands on our seat renders
+    /// as a 1m.
+    ///
+    /// Field layout mirrors `<INIT/>` (`seed` / `ten` / `oya` / `hai`, all
+    /// wire-relative) plus per-seat `m<rel>` (comma-separated `<N m=…/>`
+    /// bitfields) and `kawa<rel>` (tile indices; `255` marks the riichi
+    /// declaration).
+    fn on_reinit(&mut self, msg: &JsonValue) -> Vec<MjaiEvent> {
+        let seed = parse_csv_i32(msg, "seed");
+        let ten = parse_csv_i32(msg, "ten");
+        let oya_rel = parse_u8(msg, "oya").unwrap_or(0);
+        if seed.is_empty() {
+            warn!(target: "akagi::bridge::tenhou", "REINIT missing seed field: {msg}");
+            return Vec::new();
+        }
+        self.resolve_seat_from_kyoku("REINIT", seed[0], oya_rel);
+
+        let hai = parse_csv_u32(msg, "hai");
+        let kawa = |rel: u8| -> Vec<u32> {
+            parse_csv_u32(msg, &format!("kawa{rel}"))
+                .into_iter()
+                .filter(|&t| t != REINIT_RIICHI_MARK)
+                .collect()
+        };
+
+        // Player count. <GO/> / <UN/> normally precede a rejoin and decide
+        // it; a flow that saw neither falls back to the shape of the frame:
+        // the sanma ghost has no score to move (stays 0), no river, and our
+        // hand can hold no 2m–8m (sanma removes them). Any one alone is
+        // possible in yonma; all three together are not.
+        if self.state.three_players_hint().is_none() && !self.state.is_3p {
+            let ghost_rel = self.state.abs_to_rel(3);
+            let ghost_score_zero = ten.get(ghost_rel as usize) == Some(&0);
+            let ghost_river_empty = kawa(ghost_rel).is_empty();
+            let no_middle_manzu = hai.iter().all(|&t| !(4..=31).contains(&t));
+            if ghost_score_zero && ghost_river_empty && no_middle_manzu {
+                info!(target: "akagi::bridge::tenhou", "REINIT looks like sanma (ghost slot idle, no 2m–8m)");
+                self.state.set_three_players(true);
+            }
+        }
+
+        // Rebuild the per-kyoku state autoplay reads. Only our own calls are
+        // tracked (as in `on_meld`); nukidora is not a meld.
+        self.state.reset_for_kyoku();
+        self.state.hand = hai;
+        self.state.melds = parse_csv_u32(msg, "m0")
+            .into_iter()
+            .filter(|m| (m & 0x3F) != 0x20)
+            .map(Meld::parse)
+            .collect();
+        self.state.in_riichi = parse_csv_u32(msg, "kawa0").contains(&REINIT_RIICHI_MARK);
+        // 13 tiles (+ a 14th while a draw is in hand), less 3 per call.
+        self.state.is_tsumo = (self.state.hand.len() + 3 * self.state.melds.len()) % 3 == 2;
+        // Every discard followed a draw or a call; close enough for a
+        // counter nothing downstream reads precisely.
+        let discarded: u32 = (0..4).map(|rel| kawa(rel).len() as u32).sum();
+        self.state.live_wall = 70u32.saturating_sub(discarded + u32::from(self.state.is_tsumo));
+
+        self.state.suspended = true;
+        self.state.pending_start_game = true;
+        self.ensure_mjai_log();
+        warn!(
+            target: "akagi::bridge::tenhou",
+            "REINIT: rejoined seed={} as seat {} with {} tiles, {} call(s){}; analysis paused until the next INIT",
+            seed[0],
+            self.state.seat,
+            self.state.hand.len(),
+            self.state.melds.len(),
+            if self.state.in_riichi { ", in riichi" } else { "" }
+        );
+        self.notify(
+            Notification::warn("Tenhou: rejoined mid-hand")
+                .body("The hand in progress can't be reconstructed, so analysis is paused until the next hand starts.")
+                .id("tenhou-reinit"),
+        );
+        Vec::new()
     }
 
     /// `<T0/>`, `<U7/>`, `<V12/>`, `<W3/>` — tsumo.
@@ -384,7 +585,6 @@ impl TenhouBridge {
             self.state.window = None;
         }
         let events = vec![MjaiEvent::Tsumo { actor, pai }];
-        self.write_mjai(&events);
         events
     }
 
@@ -460,7 +660,6 @@ impl TenhouBridge {
             pai,
             tsumogiri,
         }];
-        self.write_mjai(&events);
         events
     }
 
@@ -511,7 +710,6 @@ impl TenhouBridge {
                 actor,
                 pai: Some("N".to_string()),
             }];
-            self.write_mjai(&events);
             return events;
         }
 
@@ -590,7 +788,6 @@ impl TenhouBridge {
         }
 
         let events = vec![event];
-        self.write_mjai(&events);
         events
     }
 
@@ -611,7 +808,7 @@ impl TenhouBridge {
                 .and_then(|s| s.parse::<u8>().ok())
                 .or(v.as_u64().map(|n| n as u8))
         });
-        let events = match step {
+        match step {
             Some(1) => {
                 // Step 1 acknowledges the declaration; the riichi tile is
                 // still owed as a separate discard frame, so our window
@@ -627,10 +824,8 @@ impl TenhouBridge {
                 }
                 vec![MjaiEvent::ReachAccepted { actor }]
             }
-            _ => return Vec::new(),
-        };
-        self.write_mjai(&events);
-        events
+            _ => Vec::new(),
+        }
     }
 
     /// `<DORA hai="..."/>` — new dora indicator (kan dora).
@@ -640,7 +835,6 @@ impl TenhouBridge {
         };
         let dora_marker = tenhou_to_mjai_one(idx);
         let events = vec![MjaiEvent::Dora { dora_marker }];
-        self.write_mjai(&events);
         events
     }
 
@@ -687,7 +881,6 @@ impl TenhouBridge {
         if msg.get("owari").is_some() {
             events.push(MjaiEvent::end_game());
         }
-        self.write_mjai(&events);
         events
     }
 
@@ -714,7 +907,6 @@ impl TenhouBridge {
         if msg.get("owari").is_some() {
             events.push(MjaiEvent::end_game());
         }
-        self.write_mjai(&events);
         events
     }
 }
@@ -762,6 +954,7 @@ impl Bridge for TenhouBridge {
             args: msg.clone(),
         });
         let events = self.dispatch(&msg);
+        self.write_mjai(&events);
         // Mirror the freshly-applied hand + window to autoplay. Done for every
         // dispatched frame, not just the ones that produced mjai events: a
         // frame that only closes the decision window still has to be seen.
@@ -1801,5 +1994,370 @@ mod tests {
             })
             .expect("start_kyoku emitted");
         assert_eq!(oya, 0, "yonma E1 dealer should be at wire-abs 0");
+    }
+
+    // ------------------------------------------------------------------
+    // Reconnect / mid-game attach (issue #280)
+    // ------------------------------------------------------------------
+
+    /// A hand with no 1m (indices 0..=3): a `?` draw that lands on our seat
+    /// renders as 1m downstream, so its absence is the tell.
+    const HAND_NO_1M: &str = "4,8,12,36,40,44,72,76,80,108,112,116,120";
+
+    fn tehais_len(events: &[MjaiEvent]) -> usize {
+        events
+            .iter()
+            .find_map(|e| match e {
+                MjaiEvent::StartKyoku { tehais, .. } => Some(tehais.len()),
+                _ => None,
+            })
+            .expect("start_kyoku emitted")
+    }
+
+    /// The reconnect sequence as the bridge sees it on a fresh WebSocket:
+    /// no `<TAIKYOKU/>`, a `<REINIT/>` snapshot of the hand in progress, then
+    /// live play. The seat comes from the kyoku frame, the rest of the hand
+    /// is withheld, and the next `<INIT/>` reopens the game on the right
+    /// seat with a fresh `start_game`.
+    #[test]
+    fn reinit_on_a_fresh_flow_resolves_seat_and_suspends_until_next_init() {
+        let mut b = TenhouBridge::new(None, None);
+        // E3 (seed 2): the dealer is wire-abs 2 and we see them at rel 1,
+        // so we sit at wire-abs 1.
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"2,1,0,3,4,60","ten":"230,260,250,260","oya":"1","hai":"{HAND_NO_1M}","kawa0":"20,255,24","kawa1":"33","kawa2":"5","kawa3":"9"}}"#
+        );
+        assert!(
+            parse_one(&mut b, &reinit).is_empty(),
+            "REINIT emits nothing"
+        );
+        assert_eq!(b.state.seat, 1);
+        assert!(b.state.seat_resolved);
+        assert!(b.state.suspended);
+        assert!(b.state.in_riichi, "255 in kawa0 marks our riichi");
+        assert_eq!(b.state.hand.len(), 13);
+        assert!(!b.state.is_tsumo);
+        assert_eq!(
+            b.state.live_wall,
+            70 - 5,
+            "five discards, riichi mark excluded"
+        );
+
+        // Live play for the rest of this hand is withheld, but the hand keeps
+        // tracking for autoplay.
+        assert!(parse_one(&mut b, r#"{"tag":"U"}"#).is_empty());
+        assert!(parse_one(&mut b, r#"{"tag":"E33"}"#).is_empty());
+        assert!(parse_one(&mut b, r#"{"tag":"T60","t":"16"}"#).is_empty());
+        assert_eq!(b.state.hand.len(), 14);
+        assert!(b.state.is_tsumo);
+        assert!(b.state.window.is_some(), "autoplay still sees the window");
+        assert!(parse_one(&mut b, r#"{"tag":"D60"}"#).is_empty());
+        assert_eq!(b.state.hand.len(), 13);
+        let agari = r#"{"tag":"AGARI","who":"2","fromWho":"1","sc":"230,0,260,-20,250,20,260,0","ba":"1,0"}"#;
+        assert!(
+            parse_one(&mut b, agari).is_empty(),
+            "the hand's end is withheld too"
+        );
+        assert!(b.state.suspended);
+
+        // E4 (seed 3): dealer wire-abs 3, at rel 2 from seat 1 — consistent.
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"3,0,0,1,2,8","ten":"230,260,270,240","oya":"2","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert!(!b.state.suspended);
+        assert_eq!(events.len(), 2, "start_game + start_kyoku, got {events:?}");
+        match &events[0] {
+            MjaiEvent::StartGame {
+                id, num_players, ..
+            } => {
+                assert_eq!(*id, Some(1));
+                assert_eq!(*num_players, 4);
+            }
+            other => panic!("expected StartGame, got {other:?}"),
+        }
+        match &events[1] {
+            MjaiEvent::StartKyoku {
+                oya,
+                tehais,
+                scores,
+                ..
+            } => {
+                assert_eq!(*oya, 3);
+                let hand: Vec<u32> = HAND_NO_1M.split(',').map(|t| t.parse().unwrap()).collect();
+                assert_eq!(tehais[1], tenhou_to_mjai(&hand));
+                assert_eq!(tehais[0], vec!["?"; 13]);
+                // ten is relative: rel0=us(1) 230, rel1=abs2 260, rel2=abs3 270, rel3=abs0 240.
+                assert_eq!(scores, &vec![24_000, 23_000, 26_000, 27_000]);
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+
+        // Resumed: draws land on the right seats.
+        let events = parse_one(&mut b, r#"{"tag":"W"}"#);
+        assert!(matches!(&events[0], MjaiEvent::Tsumo { actor: 0, pai } if pai == "?"));
+        let events = parse_one(&mut b, r#"{"tag":"T9"}"#);
+        assert!(matches!(&events[0], MjaiEvent::Tsumo { actor: 1, pai } if pai == "3m"));
+    }
+
+    /// Akagi attached between hands (or the rejoin landed exactly on a kyoku
+    /// boundary): the first `<INIT/>` alone must place us and open the game.
+    #[test]
+    fn init_on_a_fresh_flow_derives_seat_and_opens_the_game() {
+        let mut b = TenhouBridge::new(None, None);
+        // S2 (seed 5): dealer wire-abs 1, seen at rel 3 → we sit at 2.
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"5,0,1,1,2,8","ten":"200,300,250,240","oya":"3","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(b.state.seat, 2);
+        assert_eq!(events.len(), 2, "{events:?}");
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame {
+                id: Some(2),
+                num_players: 4,
+                ..
+            }
+        ));
+        match &events[1] {
+            MjaiEvent::StartKyoku {
+                bakaze,
+                kyoku,
+                oya,
+                tehais,
+                scores,
+                ..
+            } => {
+                assert_eq!(bakaze, "S");
+                assert_eq!(*kyoku, 2);
+                assert_eq!(*oya, 1);
+                assert_eq!(tehais[2].len(), 13);
+                assert_ne!(tehais[2][0], "?");
+                assert_eq!(scores, &vec![25_000, 24_000, 20_000, 30_000]);
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+        // S3 (seed 6): we deal. Only start_kyoku now, still on seat 2.
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"6,0,0,1,2,8","ten":"200,300,250,240","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], MjaiEvent::StartKyoku { oya: 2, .. }));
+        assert_eq!(b.state.seat, 2);
+    }
+
+    /// TAIKYOKU remains the authority when both are present; a kyoku frame
+    /// that disagrees is a malformed frame, not a seat change.
+    #[test]
+    fn taikyoku_seat_wins_over_a_disagreeing_kyoku_frame() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#); // seat 3
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(b.state.seat, 3);
+        match &events[1] {
+            MjaiEvent::StartKyoku { tehais, .. } => {
+                assert_ne!(tehais[3][0], "?");
+                assert_eq!(tehais[0], vec!["?"; 13]);
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+    }
+
+    /// REINIT on a flow that did see TAIKYOKU (same-socket re-auth, or a
+    /// server that replays it): the seat is already right, and the rest of
+    /// the reconnect handling is identical.
+    #[test]
+    fn reinit_after_taikyoku_keeps_the_taikyoku_seat() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"2"}"#); // seat 2
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"2","hai":"{HAND_NO_1M}","kawa0":"20","kawa2":"5"}}"#
+        );
+        assert!(parse_one(&mut b, &reinit).is_empty());
+        assert_eq!(b.state.seat, 2);
+        assert!(b.state.suspended);
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"1,0,0,1,2,8","ten":"250,250,250,250","oya":"3","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { id: Some(2), .. }
+        ));
+        assert!(matches!(&events[1], MjaiEvent::StartKyoku { oya: 1, .. }));
+    }
+
+    /// The hand, our calls and the draw-in-hand flag come back from REINIT
+    /// so autoplay can keep encoding discards for the rest of the hand.
+    #[test]
+    fn reinit_restores_our_calls_and_draw_in_hand() {
+        use crate::autoplay::tenhou_state::new_shared;
+        let shared = new_shared();
+        let mut b = TenhouBridge::new(None, None).with_shared_state(Some(shared.clone()));
+        // Pon of 1p (t=27 → tile type 9) from rel 1; see meld.rs bit layout.
+        let pon = (27u32 << 9) | 8 | 1;
+        // 10 concealed tiles + one pon = no draw in hand.
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"4,8,12,40,44,48,72,76,80,108","m0":"{pon}","kawa0":"20","kawa1":"36"}}"#
+        );
+        parse_one(&mut b, &reinit);
+        assert_eq!(b.state.melds.len(), 1);
+        assert_eq!(b.state.melds[0].kind, MeldKind::Pon);
+        assert_eq!(b.state.melds[0].pai(), "1p");
+        assert!(!b.state.is_tsumo);
+        assert!(!b.state.in_riichi);
+        let published = shared.read().unwrap().clone().expect("published");
+        assert_eq!(published.seat, 0);
+        assert_eq!(published.hand.len(), 10);
+        assert_eq!(published.melds.len(), 1);
+
+        // 11 concealed tiles + one pon = it is our turn, draw in hand.
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"4,8,12,40,44,48,72,76,80,108,112","m0":"{pon}","kawa0":"20","kawa1":"36"}}"#
+        );
+        parse_one(&mut b, &reinit);
+        assert!(b.state.is_tsumo);
+        assert!(shared.read().unwrap().as_ref().unwrap().is_tsumo);
+    }
+
+    /// `<GO type/>` bit 0x10 is the three-player flag. It is the only sanma
+    /// signal a rejoining flow gets when the next kyoku is not E1H0.
+    #[test]
+    fn go_type_sanma_bit_sets_three_players_before_the_first_kyoku() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"GO","type":"25","lobby":"0"}"#); // 0x19
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"0"}"#);
+        // E2 mid-game: no E1H0 check to fall back on. Ghost is rel 3 for seat 0.
+        let init = r#"{"tag":"INIT","seed":"1,0,0,1,2,4","ten":"350,300,400,0","oya":"1","hai":"0,32,36,40,44,72,76,80,108,112,116,120,124"}"#;
+        let events = parse_one(&mut b, init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { num_players: 3, .. }
+        ));
+        match &events[1] {
+            MjaiEvent::StartKyoku { scores, oya, .. } => {
+                assert_eq!(scores, &vec![35_000, 30_000, 40_000]);
+                assert_eq!(*oya, 1);
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+        assert_eq!(tehais_len(&events), 3);
+    }
+
+    /// Without `<GO/>`, a roster with one empty slot says sanma.
+    #[test]
+    fn un_roster_with_an_empty_slot_marks_sanma() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(
+            &mut b,
+            r#"{"tag":"UN","n0":"alice","n1":"","n2":"bob","n3":"carol"}"#,
+        );
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"2"}"#); // seat 2, ghost at rel 1
+                                                              // E2 (seed 1): dealer wire-abs 1 sits at rel 3 from seat 2.
+        let init = r#"{"tag":"INIT","seed":"1,0,0,1,2,4","ten":"350,0,300,400","oya":"3","hai":"0,32,36,40,44,72,76,80,108,112,116,120,124"}"#;
+        let events = parse_one(&mut b, init);
+        match &events[0] {
+            MjaiEvent::StartGame {
+                num_players, names, ..
+            } => {
+                assert_eq!(*num_players, 3);
+                assert_eq!(names, &vec!["bob", "carol", "alice"]);
+            }
+            other => panic!("expected StartGame, got {other:?}"),
+        }
+        match &events[1] {
+            MjaiEvent::StartKyoku { scores, oya, .. } => {
+                assert_eq!(scores, &vec![30_000, 40_000, 35_000]);
+                assert_eq!(*oya, 1);
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+    }
+
+    /// The E1H0 score check stays authoritative over a wrong hint.
+    #[test]
+    fn e1h0_init_overrides_a_wrong_sanma_hint() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"GO","type":"25","lobby":"0"}"#);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"0"}"#);
+        assert!(b.state.is_3p, "hint applied");
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert!(!b.state.is_3p);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { num_players: 4, .. }
+        ));
+        assert_eq!(tehais_len(&events), 4);
+    }
+
+    /// A rejoining flow that saw neither `<GO/>` nor `<UN/>` reads the
+    /// player count off the REINIT frame: an idle ghost slot plus a hand
+    /// with no 2m–8m.
+    #[test]
+    fn reinit_on_a_fresh_flow_infers_sanma_from_the_frame_shape() {
+        // E2 (seed 1): dealer wire-abs 1 at rel 1 → seat 0, ghost at rel 3.
+        let sanma_hand = "0,32,36,40,44,72,76,80,108,112,116,120,124";
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44"}}"#
+        );
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, &reinit);
+        assert_eq!(b.state.seat, 0);
+        assert!(b.state.is_3p);
+        let init = r#"{"tag":"INIT","seed":"2,0,0,1,2,8","ten":"350,300,400,0","oya":"2","hai":"0,32,36,40,44,72,76,80,108,112,116,120,124"}"#;
+        let events = parse_one(&mut b, init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { num_players: 3, .. }
+        ));
+        assert_eq!(tehais_len(&events), 3);
+
+        // A 5m in hand rules sanma out even with the other two signs.
+        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"17,32,36,40,44,72,76,80,108,112,116,120,124","kawa0":"36","kawa1":"40","kawa2":"44"}"#;
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, reinit);
+        assert!(!b.state.is_3p);
+        // So does a river on the 4th wire slot.
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44","kawa3":"48"}}"#
+        );
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, &reinit);
+        assert!(!b.state.is_3p);
+    }
+
+    /// Suspension is per hand: a new game's TAIKYOKU lifts it as well.
+    #[test]
+    fn new_game_after_a_suspended_hand_resumes_normally() {
+        let mut b = TenhouBridge::new(None, None);
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"7,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        parse_one(&mut b, &reinit);
+        assert!(b.state.suspended);
+        assert!(parse_one(
+            &mut b,
+            r#"{"tag":"RYUUKYOKU","sc":"250,0,250,0,250,0,250,0","owari":"1"}"#
+        )
+        .is_empty());
+        parse_one(&mut b, r#"{"tag":"GO","type":"9","lobby":"0"}"#);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#);
+        assert!(!b.state.suspended);
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"1","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { id: Some(3), .. }
+        ));
     }
 }

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -155,8 +155,11 @@ impl TenhouBridge {
 
         // Tags that contribute no mjai events — silently ignored. The Python
         // reference does the same in `_convert_helo`, `_convert_rejoin`, etc.
+        // `SAIKAI` (再開) is the rejoin's resume notice — `ba`, `oya`, `sc` —
+        // sent between `<UN/>` and `<REINIT/>`; everything it says, REINIT
+        // repeats.
         match tag {
-            "HELO" | "REJOIN" | "BYE" | "SHUFFLE" => return Vec::new(),
+            "HELO" | "REJOIN" | "SAIKAI" | "BYE" | "SHUFFLE" => return Vec::new(),
             _ => {}
         }
 
@@ -327,6 +330,10 @@ impl TenhouBridge {
         first_deal: bool,
     ) {
         let derived = state::seat_from_kyoku(kyoku_index, oya_rel);
+        if self.state.seat_resolved && first_deal && derived == self.state.seat {
+            // TAIKYOKU and the first deal agree, as they always should.
+            return;
+        }
         if self.state.seat_resolved && !first_deal {
             if derived != self.state.seat {
                 warn!(
@@ -2595,5 +2602,92 @@ mod tests {
             MjaiEvent::StartGame { num_players: 4, .. }
         ));
         assert_eq!(tehais_len(&events), 4);
+    }
+
+    /// The rejoin sequence as captured from the web client on a fresh
+    /// socket: `HELO`, `GO`, `UN` (full roster), `SAIKAI`, `REINIT`, then
+    /// live play — no `TAIKYOKU`. Our riichi is the `255` in `kawa0`; the
+    /// only call on the table is another seat's (`m3`), so we track none.
+    #[test]
+    fn rejoin_sequence_as_captured_from_the_web_client() {
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(
+            &mut b,
+            r#"{"tag":"GO","type":"1","lobby":"0","gpid":"00000000-00000000"}"#,
+        );
+        parse_one(
+            &mut b,
+            r#"{"tag":"UN","n0":"us","n1":"shimocha","n2":"toimen","n3":"kamicha","dan":"0,11,0,0","rate":"1500.00,1605.68,1500.00,1500.00","sx":"M,M,M,M"}"#,
+        );
+        assert!(parse_one(
+            &mut b,
+            r#"{"tag":"SAIKAI","ba":"0,1","oya":"2","sc":"240,0,250,0,250,0,250,0"}"#
+        )
+        .is_empty());
+        let reinit = r#"{"tag":"REINIT","seed":"0,0,1,3,0,23","ten":"240,250,250,250","oya":"2","hai":"14,18,22,36,37,48,52,57,58,61,89,93,96","m3":"48203","kawa0":"1,106,74,8,255,40","kawa1":"79,122,3,6,41","kawa2":"72,100,9,21,98","kawa3":"107,78,67,43,113,73"}"#;
+        assert!(parse_one(&mut b, reinit).is_empty());
+        assert_eq!(b.state.seat, 2, "E1 dealer at rel 2 → we sit at wire-abs 2");
+        assert!(b.state.seat_resolved);
+        assert!(b.state.suspended);
+        assert!(b.state.in_riichi);
+        assert!(b.state.melds.is_empty());
+        assert_eq!(b.state.hand.len(), 13);
+        assert!(!b.state.is_tsumo);
+        assert!(!b.state.is_3p);
+        assert_eq!(b.state.num_players, 4);
+
+        // Our draw right after the rejoin: tracked for autoplay, not emitted.
+        assert!(parse_one(&mut b, r#"{"tag":"T120"}"#).is_empty());
+        assert!(b.state.is_tsumo);
+        assert_eq!(b.state.hand.len(), 14);
+        assert!(b.state.window.is_some());
+        assert!(parse_one(&mut b, r#"{"tag":"D120"}"#).is_empty());
+        assert_eq!(b.state.hand.len(), 13);
+        assert!(parse_one(&mut b, r#"{"tag":"U"}"#).is_empty());
+
+        // The hand ends (our ron) and E2 begins: the game reopens on seat 2
+        // with the roster from the rejoin's <UN/>.
+        assert!(parse_one(
+            &mut b,
+            r#"{"tag":"AGARI","who":"0","fromWho":"1","sc":"240,77,250,-77,250,0,250,0","ba":"0,1"}"#
+        )
+        .is_empty());
+        let events = parse_one(
+            &mut b,
+            r#"{"tag":"INIT","seed":"1,0,0,2,0,55","ten":"317,173,250,250","oya":"3","hai":"36,4,124,72,84,50,60,128,32,40,62,44,63"}"#,
+        );
+        assert_eq!(events.len(), 2, "{events:?}");
+        match &events[0] {
+            MjaiEvent::StartGame {
+                id,
+                num_players,
+                names,
+                ..
+            } => {
+                assert_eq!(*id, Some(2));
+                assert_eq!(*num_players, 4);
+                assert_eq!(names, &vec!["toimen", "kamicha", "us", "shimocha"]);
+            }
+            other => panic!("expected StartGame, got {other:?}"),
+        }
+        match &events[1] {
+            MjaiEvent::StartKyoku {
+                kyoku,
+                oya,
+                scores,
+                tehais,
+                ..
+            } => {
+                assert_eq!(*kyoku, 2);
+                assert_eq!(*oya, 1);
+                assert_eq!(scores, &vec![25_000, 25_000, 31_700, 17_300]);
+                assert_eq!(tehais[2].len(), 13);
+                assert_ne!(tehais[2][0], "?");
+            }
+            other => panic!("expected StartKyoku, got {other:?}"),
+        }
+        assert!(!b.state.suspended);
+        let events = parse_one(&mut b, r#"{"tag":"W"}"#);
+        assert!(matches!(&events[0], MjaiEvent::Tsumo { actor: 1, pai } if pai == "?"));
     }
 }

--- a/src/bridge/tenhou/mod.rs
+++ b/src/bridge/tenhou/mod.rs
@@ -160,7 +160,7 @@ impl TenhouBridge {
             _ => {}
         }
 
-        let events = self.dispatch_tag(tag, msg);
+        let mut events = self.dispatch_tag(tag, msg);
 
         // A flow that attached mid-kyoku (`<REINIT/>`) has no history for the
         // hand in progress, so its events would land on whatever the tracker
@@ -168,15 +168,34 @@ impl TenhouBridge {
         // all. The handler still ran (autoplay needs the hand and window it
         // maintains); only the stream is withheld until `on_init` lifts the
         // suspension at the next kyoku.
-        if self.state.suspended && !events.is_empty() {
-            debug!(
-                target: "akagi::bridge::tenhou",
-                "dropping {} event(s) from <{tag}/>: joined mid-kyoku, waiting for the next INIT",
-                events.len()
-            );
-            return Vec::new();
+        // The one exception is the game's end: the tracker has to close the
+        // game, the bot manager stop its runner, History reset — so
+        // `end_game` alone passes, and as terminated (see `end_game_event`).
+        if self.state.suspended {
+            let before = events.len();
+            events.retain(|e| matches!(e, MjaiEvent::EndGame { .. }));
+            if before != events.len() {
+                debug!(
+                    target: "akagi::bridge::tenhou",
+                    "dropping {} event(s) from <{tag}/>: joined mid-kyoku, waiting for the next INIT",
+                    before - events.len()
+                );
+            }
         }
         events
+    }
+
+    /// The game-end event for this flow. A game this flow joined mid-way has
+    /// no complete record — the hands before the rejoin were never seen here
+    /// — so its end is reported as terminated: the tracker and bots still
+    /// close the game, but History drops it instead of filing the remainder
+    /// as a full game with its own per-hand stats.
+    fn end_game_event(&self) -> MjaiEvent {
+        if self.state.rejoined_mid_game {
+            MjaiEvent::terminated_game()
+        } else {
+            MjaiEvent::end_game()
+        }
     }
 
     fn dispatch_tag(&mut self, tag: &str, msg: &JsonValue) -> Vec<MjaiEvent> {
@@ -287,6 +306,7 @@ impl TenhouBridge {
         self.state.seat_resolved = true;
         // A new game on a flow that was waiting out a mid-kyoku join.
         self.state.suspended = false;
+        self.state.rejoined_mid_game = false;
         self.state.pending_start_game = true;
         self.rotate_mjai_log();
         Vec::new()
@@ -295,10 +315,19 @@ impl TenhouBridge {
     /// Adopt the seat a kyoku frame implies when `<TAIKYOKU/>` never told
     /// us — a flow that attached mid-game (reconnect, late start). When it
     /// did, TAIKYOKU stays authoritative and a disagreement is only logged:
-    /// it would mean a malformed frame, not a seat change.
-    fn resolve_seat_from_kyoku(&mut self, tag: &str, kyoku_index: i32, oya_rel: u8) {
+    /// it would mean a malformed frame, not a seat change. The first deal
+    /// (`first_deal`: E1 honba 0) is the exception — it is the same
+    /// statement TAIKYOKU makes, so it always wins, which also lets a new
+    /// game re-seat a flow whose TAIKYOKU went missing.
+    fn resolve_seat_from_kyoku(
+        &mut self,
+        tag: &str,
+        kyoku_index: i32,
+        oya_rel: u8,
+        first_deal: bool,
+    ) {
         let derived = state::seat_from_kyoku(kyoku_index, oya_rel);
-        if self.state.seat_resolved {
+        if self.state.seat_resolved && !first_deal {
             if derived != self.state.seat {
                 warn!(
                     target: "akagi::bridge::tenhou",
@@ -367,10 +396,18 @@ impl TenhouBridge {
 
         // The seat, in case this flow never saw <TAIKYOKU/>. Must precede
         // every rel→abs translation below.
-        self.resolve_seat_from_kyoku("INIT", seed[0], oya_rel);
+        let first_deal = seed[0] == 0 && seed[1] == 0;
+        self.resolve_seat_from_kyoku("INIT", seed[0], oya_rel, first_deal);
         // A new kyoku is a clean slate for the tracker: whatever this flow
         // missed of the previous one no longer matters.
         self.state.suspended = false;
+        if first_deal {
+            // E1H0 happens once per game, so it is a game start whether or
+            // not a <TAIKYOKU/> announced it; a flow that rejoined the
+            // previous game is whole again from here.
+            self.state.pending_start_game = true;
+            self.state.rejoined_mid_game = false;
+        }
         self.ensure_mjai_log();
 
         let bakaze = BAKAZE[(seed[0] as usize) / 4];
@@ -387,8 +424,14 @@ impl TenhouBridge {
         // the <GO/> / <UN/> hints. We do NOT wrap `seat` after detection —
         // wire-abs is still 4-cycle, and our wire-abs (already in {0, 1, 2}
         // for any real sanma player) doubles as mjai-abs.
-        if bakaze == "E" && kyoku == 1 && honba == 0 {
+        if first_deal {
             self.state.set_three_players(raw_ten.contains(&0));
+        } else if self.state.three_players_hint().is_none() {
+            // A flow that joined mid-game with neither <GO/> nor <UN/> —
+            // the table total still says how many are playing.
+            if let Some(three) = state::three_players_from_scores(&raw_ten, kyotaku) {
+                self.state.set_three_players(three);
+            }
         }
 
         // Our hand. Tenhou messages are already in *our* viewpoint (rel seat 0
@@ -496,7 +539,8 @@ impl TenhouBridge {
             warn!(target: "akagi::bridge::tenhou", "REINIT missing seed field: {msg}");
             return Vec::new();
         }
-        self.resolve_seat_from_kyoku("REINIT", seed[0], oya_rel);
+        let first_deal = seed[0] == 0 && seed.get(1) == Some(&0);
+        self.resolve_seat_from_kyoku("REINIT", seed[0], oya_rel, first_deal);
 
         let hai = parse_csv_u32(msg, "hai");
         let kawa = |rel: u8| -> Vec<u32> {
@@ -507,39 +551,57 @@ impl TenhouBridge {
         };
 
         // Player count. <GO/> / <UN/> normally precede a rejoin and decide
-        // it; a flow that saw neither falls back to the shape of the frame:
-        // the sanma ghost has no score to move (stays 0), no river, and our
-        // hand can hold no 2m–8m (sanma removes them). Any one alone is
-        // possible in yonma; all three together are not.
-        if self.state.three_players_hint().is_none() && !self.state.is_3p {
-            let ghost_rel = self.state.abs_to_rel(3);
-            let ghost_score_zero = ten.get(ghost_rel as usize) == Some(&0);
-            let ghost_river_empty = kawa(ghost_rel).is_empty();
-            let no_middle_manzu = hai.iter().all(|&t| !(4..=31).contains(&t));
-            if ghost_score_zero && ghost_river_empty && no_middle_manzu {
-                info!(target: "akagi::bridge::tenhou", "REINIT looks like sanma (ghost slot idle, no 2m–8m)");
-                self.state.set_three_players(true);
+        // it. A flow that saw neither reads the table total (see
+        // `three_players_from_scores`); should that be unreadable, the
+        // frame's shape is the last resort: the sanma ghost has no score to
+        // move (stays 0) and no river, and neither our hand nor any river can
+        // hold a 2m–8m (sanma removes them). Each alone happens in yonma;
+        // all of them together do not.
+        if self.state.three_players_hint().is_none() {
+            let raw_ten: Vec<i32> = ten.iter().map(|s| s * 100).collect();
+            let kyotaku = seed.get(2).copied().unwrap_or(0).max(0) as u8;
+            match state::three_players_from_scores(&raw_ten, kyotaku) {
+                Some(three) => self.state.set_three_players(three),
+                None if !self.state.is_3p => {
+                    let ghost_rel = self.state.abs_to_rel(3);
+                    let ghost_score_zero = ten.get(ghost_rel as usize) == Some(&0);
+                    let ghost_river_empty = kawa(ghost_rel).is_empty();
+                    let middle_manzu = |t: &u32| (4..=31).contains(t);
+                    let no_middle_manzu = !hai.iter().any(middle_manzu)
+                        && !(0..4).any(|rel| kawa(rel).iter().any(middle_manzu));
+                    if ghost_score_zero && ghost_river_empty && no_middle_manzu {
+                        info!(target: "akagi::bridge::tenhou", "REINIT looks like sanma (ghost slot idle, no 2m–8m in play)");
+                        self.state.set_three_players(true);
+                    }
+                }
+                None => {}
             }
         }
 
         // Rebuild the per-kyoku state autoplay reads. Only our own calls are
-        // tracked (as in `on_meld`); nukidora is not a meld.
+        // tracked (as in `on_meld`); nukidora is not a meld, but each one
+        // took a tile out of the hand.
         self.state.reset_for_kyoku();
         self.state.hand = hai;
-        self.state.melds = parse_csv_u32(msg, "m0")
+        let m0 = parse_csv_u32(msg, "m0");
+        let nukidora = m0.iter().filter(|m| (*m & 0x3F) == 0x20).count();
+        self.state.melds = m0
             .into_iter()
             .filter(|m| (m & 0x3F) != 0x20)
             .map(Meld::parse)
             .collect();
         self.state.in_riichi = parse_csv_u32(msg, "kawa0").contains(&REINIT_RIICHI_MARK);
-        // 13 tiles (+ a 14th while a draw is in hand), less 3 per call.
-        self.state.is_tsumo = (self.state.hand.len() + 3 * self.state.melds.len()) % 3 == 2;
+        // 13 tiles (+ a 14th while a draw is in hand), less 3 per call and
+        // 1 per nukidora.
+        self.state.is_tsumo =
+            (self.state.hand.len() + 3 * self.state.melds.len() + nukidora) % 3 == 2;
         // Every discard followed a draw or a call; close enough for a
         // counter nothing downstream reads precisely.
         let discarded: u32 = (0..4).map(|rel| kawa(rel).len() as u32).sum();
         self.state.live_wall = 70u32.saturating_sub(discarded + u32::from(self.state.is_tsumo));
 
         self.state.suspended = true;
+        self.state.rejoined_mid_game = true;
         self.state.pending_start_game = true;
         self.ensure_mjai_log();
         warn!(
@@ -879,7 +941,7 @@ impl TenhouBridge {
         }];
         events.push(MjaiEvent::EndKyoku);
         if msg.get("owari").is_some() {
-            events.push(MjaiEvent::end_game());
+            events.push(self.end_game_event());
         }
         events
     }
@@ -905,7 +967,7 @@ impl TenhouBridge {
             MjaiEvent::EndKyoku,
         ];
         if msg.get("owari").is_some() {
-            events.push(MjaiEvent::end_game());
+            events.push(self.end_game_event());
         }
         events
     }
@@ -1080,6 +1142,7 @@ fn parse_tile_csv(v: &JsonValue) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::GameEndReason;
 
     fn parse_one(b: &mut TenhouBridge, json: &str) -> Vec<MjaiEvent> {
         b.parse(Direction::Down, json.as_bytes()).events
@@ -2148,14 +2211,17 @@ mod tests {
         assert_eq!(b.state.seat, 2);
     }
 
-    /// TAIKYOKU remains the authority when both are present; a kyoku frame
-    /// that disagrees is a malformed frame, not a seat change.
+    /// TAIKYOKU remains the authority mid-game; a later kyoku frame that
+    /// disagrees is a malformed frame, not a seat change. The first deal is
+    /// the one frame that says the same thing TAIKYOKU does, so it wins.
     #[test]
     fn taikyoku_seat_wins_over_a_disagreeing_kyoku_frame() {
         let mut b = TenhouBridge::new(None, None);
         parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#); // seat 3
+                                                              // E2 (seed 1): dealer wire-abs 1 sits at rel 2 from seat 3; oya "0"
+                                                              // would put us at 1.
         let init = format!(
-            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+            r#"{{"tag":"INIT","seed":"1,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
         );
         let events = parse_one(&mut b, &init);
         assert_eq!(b.state.seat, 3);
@@ -2166,6 +2232,19 @@ mod tests {
             }
             other => panic!("expected StartKyoku, got {other:?}"),
         }
+
+        // E1H0 disagreeing with TAIKYOKU: the deal wins.
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#); // seat 3
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(b.state.seat, 0);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { id: Some(0), .. }
+        ));
     }
 
     /// REINIT on a flow that did see TAIKYOKU (same-socket re-auth, or a
@@ -2299,14 +2378,15 @@ mod tests {
     }
 
     /// A rejoining flow that saw neither `<GO/>` nor `<UN/>` reads the
-    /// player count off the REINIT frame: an idle ghost slot plus a hand
-    /// with no 2m–8m.
+    /// player count off the table total; when that is unreadable, off the
+    /// frame's shape: an idle ghost slot and no 2m–8m anywhere in play.
     #[test]
     fn reinit_on_a_fresh_flow_infers_sanma_from_the_frame_shape() {
         // E2 (seed 1): dealer wire-abs 1 at rel 1 → seat 0, ghost at rel 3.
+        // 104000 on the table is neither yonma nor sanma, so shape decides.
         let sanma_hand = "0,32,36,40,44,72,76,80,108,112,116,120,124";
         let reinit = format!(
-            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44"}}"#
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"340,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44"}}"#
         );
         let mut b = TenhouBridge::new(None, None);
         parse_one(&mut b, &reinit);
@@ -2320,21 +2400,44 @@ mod tests {
         ));
         assert_eq!(tehais_len(&events), 3);
 
-        // A 5m in hand rules sanma out even with the other two signs.
-        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"17,32,36,40,44,72,76,80,108,112,116,120,124","kawa0":"36","kawa1":"40","kawa2":"44"}"#;
+        // A 5m in hand rules sanma out even with the other signs.
+        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"340,300,400,0","oya":"1","hai":"17,32,36,40,44,72,76,80,108,112,116,120,124","kawa0":"36","kawa1":"40","kawa2":"44"}"#;
         let mut b = TenhouBridge::new(None, None);
         parse_one(&mut b, reinit);
         assert!(!b.state.is_3p);
-        // So does a river on the 4th wire slot.
+        // So does a 2m–8m in anyone's river...
         let reinit = format!(
-            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44","kawa3":"48"}}"#
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"340,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"20","kawa2":"44"}}"#
+        );
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, &reinit);
+        assert!(!b.state.is_3p);
+        // ...or a river on the 4th wire slot.
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"340,300,400,0","oya":"1","hai":"{sanma_hand}","kawa0":"36","kawa1":"40","kawa2":"44","kawa3":"48"}}"#
+        );
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, &reinit);
+        assert!(!b.state.is_3p);
+
+        // The table total alone settles it when it is readable: 105000 is
+        // sanma even with a 4p-looking hand, 100000 is yonma even with a
+        // sanma-looking one.
+        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"17,32,36,40,44,72,76,80,108,112,116,120,124","kawa0":"36"}"#;
+        let mut b = TenhouBridge::new(None, None);
+        parse_one(&mut b, reinit);
+        assert!(b.state.is_3p);
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"250,250,500,0","oya":"1","hai":"{sanma_hand}","kawa0":"36"}}"#
         );
         let mut b = TenhouBridge::new(None, None);
         parse_one(&mut b, &reinit);
         assert!(!b.state.is_3p);
     }
 
-    /// Suspension is per hand: a new game's TAIKYOKU lifts it as well.
+    /// Suspension is per hand: a new game's TAIKYOKU lifts it as well, and
+    /// a game rejoined mid-way ends terminated while the next, seen whole,
+    /// ends confirmed.
     #[test]
     fn new_game_after_a_suspended_hand_resumes_normally() {
         let mut b = TenhouBridge::new(None, None);
@@ -2343,14 +2446,24 @@ mod tests {
         );
         parse_one(&mut b, &reinit);
         assert!(b.state.suspended);
-        assert!(parse_one(
+        // The game's end still goes out — as terminated, since this flow
+        // never saw the whole game — so every consumer closes it.
+        let events = parse_one(
             &mut b,
-            r#"{"tag":"RYUUKYOKU","sc":"250,0,250,0,250,0,250,0","owari":"1"}"#
-        )
-        .is_empty());
+            r#"{"tag":"RYUUKYOKU","sc":"250,0,250,0,250,0,250,0","owari":"1"}"#,
+        );
+        assert_eq!(events.len(), 1, "{events:?}");
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::EndGame {
+                reason: GameEndReason::Terminated,
+                ..
+            }
+        ));
         parse_one(&mut b, r#"{"tag":"GO","type":"9","lobby":"0"}"#);
         parse_one(&mut b, r#"{"tag":"TAIKYOKU","oya":"1"}"#);
         assert!(!b.state.suspended);
+        assert!(!b.state.rejoined_mid_game);
         let init = format!(
             r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"1","hai":"{HAND_NO_1M}"}}"#
         );
@@ -2359,5 +2472,128 @@ mod tests {
             &events[0],
             MjaiEvent::StartGame { id: Some(3), .. }
         ));
+        let events = parse_one(
+            &mut b,
+            r#"{"tag":"RYUUKYOKU","sc":"250,0,250,0,250,0,250,0","owari":"1"}"#,
+        );
+        assert!(matches!(
+            events.last(),
+            Some(MjaiEvent::EndGame {
+                reason: GameEndReason::Confirmed,
+                ..
+            })
+        ));
+    }
+
+    /// The hands after the rejoin resume normally, but the game as a whole
+    /// was never seen by this flow, so its end is still terminated: History
+    /// must not file the remainder as a complete game.
+    #[test]
+    fn rejoined_game_ends_terminated_even_after_resuming() {
+        let mut b = TenhouBridge::new(None, None);
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"6,0,0,1,2,4","ten":"250,250,250,250","oya":"2","hai":"{HAND_NO_1M}"}}"#
+        );
+        parse_one(&mut b, &reinit);
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"7,0,0,1,2,4","ten":"250,250,250,250","oya":"3","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(events.len(), 2);
+        assert!(b.state.rejoined_mid_game);
+        let events = parse_one(
+            &mut b,
+            r#"{"tag":"AGARI","who":"0","fromWho":"1","sc":"250,80,250,-80,250,0,250,0","ba":"0,0","owari":"1"}"#,
+        );
+        assert_eq!(events.len(), 3, "{events:?}");
+        assert!(matches!(
+            &events[2],
+            MjaiEvent::EndGame {
+                reason: GameEndReason::Terminated,
+                ..
+            }
+        ));
+    }
+
+    /// If a new game's TAIKYOKU went missing too, its first deal is enough:
+    /// E1H0 re-seats the flow, reopens the game, and clears the rejoin.
+    #[test]
+    fn first_deal_without_taikyoku_opens_a_new_game() {
+        let mut b = TenhouBridge::new(None, None);
+        let reinit = format!(
+            r#"{{"tag":"REINIT","seed":"7,0,0,1,2,4","ten":"250,250,250,250","oya":"0","hai":"{HAND_NO_1M}"}}"#
+        );
+        parse_one(&mut b, &reinit);
+        assert_eq!(b.state.seat, 3);
+        parse_one(
+            &mut b,
+            r#"{"tag":"AGARI","who":"0","fromWho":"0","sc":"250,120,250,-40,250,-40,250,-40","ba":"0,0","owari":"1"}"#,
+        );
+        // Next game, different seat, no TAIKYOKU: E1 dealer at rel 3 → seat 1.
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"3","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert_eq!(b.state.seat, 1);
+        assert!(!b.state.rejoined_mid_game);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { id: Some(1), .. }
+        ));
+        assert!(matches!(&events[1], MjaiEvent::StartKyoku { oya: 0, .. }));
+        let events = parse_one(
+            &mut b,
+            r#"{"tag":"RYUUKYOKU","sc":"250,0,250,0,250,0,250,0","owari":"1"}"#,
+        );
+        assert!(matches!(
+            events.last(),
+            Some(MjaiEvent::EndGame {
+                reason: GameEndReason::Confirmed,
+                ..
+            })
+        ));
+    }
+
+    /// Nukidora took tiles out of the hand without adding a meld; the
+    /// draw-in-hand judgement has to count them.
+    #[test]
+    fn reinit_counts_nukidora_when_judging_the_draw_in_hand() {
+        let mut b = TenhouBridge::new(None, None);
+        // Sanma table (35000 × 3), two kita declared (`m` low bits 0x20).
+        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"0,32,36,40,44,72,76,80,112,116,120","m0":"32,32","kawa0":"36"}"#;
+        parse_one(&mut b, reinit);
+        assert!(b.state.is_3p);
+        assert!(b.state.melds.is_empty(), "kita is not a meld");
+        assert!(!b.state.is_tsumo, "11 tiles + 2 kita = 13, nothing drawn");
+        let reinit = r#"{"tag":"REINIT","seed":"1,0,0,1,2,8","ten":"350,300,400,0","oya":"1","hai":"0,32,36,40,44,72,76,80,112,116,120,124","m0":"32,32","kawa0":"36"}"#;
+        parse_one(&mut b, reinit);
+        assert!(b.state.is_tsumo, "12 tiles + 2 kita = 14, draw in hand");
+    }
+
+    /// A flow that joined mid-game with neither GO nor UN reads the player
+    /// count off the table total on its first INIT.
+    #[test]
+    fn init_on_a_fresh_flow_reads_player_count_off_the_scores() {
+        let mut b = TenhouBridge::new(None, None);
+        // S1 (seed 4): dealer wire-abs 0 at rel 2 → seat 2. Total 105000.
+        let init = r#"{"tag":"INIT","seed":"4,0,0,1,2,8","ten":"400,300,350,0","oya":"2","hai":"0,32,36,40,44,72,76,80,108,112,116,120,124"}"#;
+        let events = parse_one(&mut b, init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { num_players: 3, .. }
+        ));
+        assert_eq!(tehais_len(&events), 3);
+
+        // Yonma with one riichi stick out: 99000 + 1000.
+        let mut b = TenhouBridge::new(None, None);
+        let init = format!(
+            r#"{{"tag":"INIT","seed":"1,0,1,1,2,8","ten":"240,250,250,250","oya":"1","hai":"{HAND_NO_1M}"}}"#
+        );
+        let events = parse_one(&mut b, &init);
+        assert!(matches!(
+            &events[0],
+            MjaiEvent::StartGame { num_players: 4, .. }
+        ));
+        assert_eq!(tehais_len(&events), 4);
     }
 }

--- a/src/bridge/tenhou/state.rs
+++ b/src/bridge/tenhou/state.rs
@@ -60,6 +60,11 @@ pub struct State {
     /// window from here) but their events are dropped — see
     /// `TenhouBridge::dispatch`.
     pub suspended: bool,
+    /// True from a `<REINIT/>` until the next game starts: this flow never
+    /// saw the hands before the rejoin, so the game's record is incomplete
+    /// and its `end_game` goes out as terminated (History drops it rather
+    /// than filing the remainder as a complete game with its own stats).
+    pub rejoined_mid_game: bool,
     /// `<GO type=…/>` rule/room bitfield (room tier in bits 0x20/0x80),
     /// stashed for `start_game` emission. Read non-destructively so a
     /// reconnect's re-emitted `start_game` (TAIKYOKU+INIT with no fresh
@@ -96,6 +101,7 @@ impl Default for State {
             last_revealed_tile_actor: None,
             pending_start_game: true,
             suspended: false,
+            rejoined_mid_game: false,
             go_type: None,
             lobby: None,
             log_id: None,
@@ -121,6 +127,21 @@ pub fn seat_from_kyoku(kyoku_index: i32, oya_rel: u8) -> u8 {
     (oya_abs + 4 - oya_rel % 4) % 4
 }
 
+/// Player count from a kyoku frame's scores. Tenhou deals 25000 × 4 =
+/// 100000 points in yonma and 35000 × 3 = 105000 in sanma, and points only
+/// move between the players and the riichi sticks on the table (a bust ends
+/// the game), so the total names the player count on any frame, not just
+/// the first deal. `ten` is in points (already × 100); `kyotaku` is the
+/// stick count from `seed[2]`. `None` for a total that is neither.
+pub fn three_players_from_scores(ten: &[i32], kyotaku: u8) -> Option<bool> {
+    let total = ten.iter().sum::<i32>() + 1000 * i32::from(kyotaku);
+    match total {
+        100_000 => Some(false),
+        105_000 => Some(true),
+        _ => None,
+    }
+}
+
 impl State {
     /// Set the player count. `<GO/>`, `<UN/>`, `<TAIKYOKU/>` and the E1H0
     /// `<INIT/>` all feed this; the last one wins, and E1H0 is authoritative.
@@ -130,15 +151,23 @@ impl State {
     }
 
     /// Player count implied by the session frames seen on this flow, before
-    /// any kyoku frame: `<GO/>`'s sanma bit, else a `<UN/>` roster with one
-    /// empty slot. `None` when neither was seen (a flow attached mid-game).
+    /// any kyoku frame: `<GO/>`'s sanma bit, else a `<UN/>` roster with
+    /// exactly one empty slot (the ghost) or none. `None` when neither was
+    /// seen (a flow attached mid-game) or the roster is not readable — our
+    /// own name (`n0`) is never blank, so a blank one is not a roster.
     pub fn three_players_hint(&self) -> Option<bool> {
         if let Some(t) = self.go_type {
             return Some(t & GO_TYPE_SANMA != 0);
         }
-        self.un_names
-            .as_ref()
-            .map(|names| names.iter().filter(|n| !n.is_empty()).count() == 3)
+        let names = self.un_names.as_ref()?;
+        if names[0].is_empty() {
+            return None;
+        }
+        match names.iter().filter(|n| n.is_empty()).count() {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
     }
 
     /// Convert wire-relative seat to wire-absolute seat. Always uses 4-cycle
@@ -283,6 +312,37 @@ mod tests {
         assert_eq!(s.three_players_hint(), Some(true), "GO bit wins");
         s.go_type = Some(0x09);
         assert_eq!(s.three_players_hint(), Some(false));
+        // A blank own name is not a roster; two blanks is not a table.
+        s.go_type = None;
+        s.un_names = Some(["".into(), "".into(), "b".into(), "c".into()]);
+        assert_eq!(s.three_players_hint(), None);
+        s.un_names = Some(["a".into(), "".into(), "".into(), "c".into()]);
+        assert_eq!(s.three_players_hint(), None);
+    }
+
+    /// 100000 points on the table (players + sticks) is yonma, 105000 is
+    /// sanma, on any deal.
+    #[test]
+    fn three_players_from_scores_reads_the_table_total() {
+        assert_eq!(three_players_from_scores(&[25_000; 4], 0), Some(false));
+        assert_eq!(
+            three_players_from_scores(&[35_000, 35_000, 35_000, 0], 0),
+            Some(true)
+        );
+        assert_eq!(
+            three_players_from_scores(&[35_000, 35_000, 35_000], 0),
+            Some(true)
+        );
+        // Mid-game, two riichi sticks out.
+        assert_eq!(
+            three_players_from_scores(&[18_000, 31_000, 24_000, 25_000], 2),
+            Some(false)
+        );
+        assert_eq!(
+            three_players_from_scores(&[40_000, 30_000, 34_000, 0], 1),
+            Some(true)
+        );
+        assert_eq!(three_players_from_scores(&[30_000; 4], 0), None);
     }
 
     #[test]

--- a/src/bridge/tenhou/state.rs
+++ b/src/bridge/tenhou/state.rs
@@ -21,6 +21,11 @@ pub struct State {
     /// is always in `{0, 1, 2}` since we are a real player; the same value is
     /// our mjai-abs seat.
     pub seat: u8,
+    /// True once this flow knows our seat — from `<TAIKYOKU/>`, or failing
+    /// that from the first kyoku frame (`<INIT/>` / `<REINIT/>`), whose
+    /// `seed`/`oya` pair pins it down (see [`seat_from_kyoku`]). A flow that
+    /// starts mid-game (reconnect, late attach) never sees `<TAIKYOKU/>`.
+    pub seat_resolved: bool,
     /// Tenhou tile indices in our hand (other players' hands are not tracked).
     pub hand: Vec<u32>,
     /// Open melds we have called this kyoku.
@@ -41,10 +46,20 @@ pub struct State {
     /// (discard / kakan / ankan), so a subsequent `<AGARI/>` can attribute
     /// the ron target correctly.
     pub last_revealed_tile_actor: Option<u8>,
-    /// True once `<TAIKYOKU/>` has been seen and `start_game` is owed at the
-    /// next `<INIT/>`. We defer emission so we know yonma vs sanma (via INIT's
+    /// True while `start_game` is owed at the next `<INIT/>`. Set by
+    /// `<TAIKYOKU/>` and `<REINIT/>`, and true from the start so a flow that
+    /// first sees the game mid-way (a reconnect that skips `<TAIKYOKU/>`, or
+    /// Akagi attaching between hands) still opens the game for the tracker.
+    /// Emission is deferred to `<INIT/>` so we know yonma vs sanma (via the
     /// 0-score slot) and can stamp `num_players` correctly on `start_game`.
     pub pending_start_game: bool,
+    /// True between a `<REINIT/>` and the next `<INIT/>`: this flow attached
+    /// to a kyoku already in progress and has no event history for it, so
+    /// nothing it parses can be turned into a coherent mjai stream until the
+    /// next kyoku starts. Handlers still run (autoplay reads the hand and
+    /// window from here) but their events are dropped — see
+    /// `TenhouBridge::dispatch`.
+    pub suspended: bool,
     /// `<GO type=…/>` rule/room bitfield (room tier in bits 0x20/0x80),
     /// stashed for `start_game` emission. Read non-destructively so a
     /// reconnect's re-emitted `start_game` (TAIKYOKU+INIT with no fresh
@@ -69,6 +84,7 @@ impl Default for State {
     fn default() -> Self {
         Self {
             seat: 0,
+            seat_resolved: false,
             hand: Vec::new(),
             melds: Vec::new(),
             in_riichi: false,
@@ -78,7 +94,8 @@ impl Default for State {
             is_3p: false,
             num_players: 4,
             last_revealed_tile_actor: None,
-            pending_start_game: false,
+            pending_start_game: true,
+            suspended: false,
             go_type: None,
             lobby: None,
             log_id: None,
@@ -88,7 +105,42 @@ impl Default for State {
     }
 }
 
+/// `<GO type=…/>` bit for a three-player (sanma) table.
+pub const GO_TYPE_SANMA: u32 = 0x10;
+
+/// Our wire-absolute seat from a kyoku frame (`<INIT/>` / `<REINIT/>`).
+///
+/// Wire-abs 0 is the player who dealt E1, and the deal rotates 0→1→2→3, so
+/// the dealer of kyoku index `k` (`seed[0]`: `bakaze * 4 + kyoku - 1`) sits
+/// at wire-abs `k % 4`. `oya` on the same frame is that dealer's seat
+/// *relative* to us, which leaves exactly one possibility for ours. Sanma
+/// keeps the 4-cycle (`seed[0]` skips the ghost's turn: E1 E2 E3 S1 are
+/// 0 1 2 4), so the same formula holds and never lands on the ghost.
+pub fn seat_from_kyoku(kyoku_index: i32, oya_rel: u8) -> u8 {
+    let oya_abs = kyoku_index.rem_euclid(4) as u8;
+    (oya_abs + 4 - oya_rel % 4) % 4
+}
+
 impl State {
+    /// Set the player count. `<GO/>`, `<UN/>`, `<TAIKYOKU/>` and the E1H0
+    /// `<INIT/>` all feed this; the last one wins, and E1H0 is authoritative.
+    pub fn set_three_players(&mut self, three: bool) {
+        self.is_3p = three;
+        self.num_players = if three { 3 } else { 4 };
+    }
+
+    /// Player count implied by the session frames seen on this flow, before
+    /// any kyoku frame: `<GO/>`'s sanma bit, else a `<UN/>` roster with one
+    /// empty slot. `None` when neither was seen (a flow attached mid-game).
+    pub fn three_players_hint(&self) -> Option<bool> {
+        if let Some(t) = self.go_type {
+            return Some(t & GO_TYPE_SANMA != 0);
+        }
+        self.un_names
+            .as_ref()
+            .map(|names| names.iter().filter(|n| !n.is_empty()).count() == 3)
+    }
+
     /// Convert wire-relative seat to wire-absolute seat. Always uses 4-cycle
     /// arithmetic because the Tenhou wire is 4-positional in both yonma and
     /// sanma — `(rel + seat) % num_players` would conflate wire-rel 0 (us)
@@ -175,6 +227,62 @@ mod tests {
         for abs in 0..3u8 {
             assert!(!s.is_ghost_abs(abs));
         }
+    }
+
+    /// The dealer of kyoku index `k` sits at wire-abs `k % 4`; `oya` is that
+    /// seat relative to us. Every combination round-trips through the
+    /// TAIKYOKU formula (`seat = (4 - oya_rel_at_e1) % 4`).
+    #[test]
+    fn seat_from_kyoku_matches_taikyoku_derivation() {
+        for seat in 0..4u8 {
+            let s = State {
+                seat,
+                ..Default::default()
+            };
+            for kyoku_index in 0..16i32 {
+                let oya_abs = (kyoku_index % 4) as u8;
+                let oya_rel = s.abs_to_rel(oya_abs);
+                assert_eq!(seat_from_kyoku(kyoku_index, oya_rel), seat);
+            }
+        }
+        // E1: oya rel 1 → we sit at wire-abs 3, same as TAIKYOKU oya="1".
+        assert_eq!(seat_from_kyoku(0, 1), 3);
+        // S2 (index 5, dealer wire-abs 1) seen as our toimen → we are 3.
+        assert_eq!(seat_from_kyoku(5, 2), 3);
+    }
+
+    /// Sanma skips the ghost's deal, so its kyoku indices are 0 1 2 4 5 6 …
+    /// and the derivation never resolves a real player onto wire-abs 3.
+    #[test]
+    fn seat_from_kyoku_sanma_never_hits_the_ghost() {
+        for seat in 0..3u8 {
+            let s = State {
+                seat,
+                is_3p: true,
+                num_players: 3,
+                ..Default::default()
+            };
+            for kyoku_index in [0, 1, 2, 4, 5, 6, 8, 9, 10] {
+                let oya_rel = s.abs_to_rel((kyoku_index % 4) as u8);
+                let derived = seat_from_kyoku(kyoku_index, oya_rel);
+                assert_eq!(derived, seat);
+                assert!(!s.is_ghost_abs(derived));
+            }
+        }
+    }
+
+    #[test]
+    fn three_players_hint_prefers_go_over_roster() {
+        let mut s = State::default();
+        assert_eq!(s.three_players_hint(), None, "nothing seen yet");
+        s.un_names = Some(["a".into(), "".into(), "b".into(), "c".into()]);
+        assert_eq!(s.three_players_hint(), Some(true), "one empty roster slot");
+        s.un_names = Some(["a".into(), "b".into(), "c".into(), "d".into()]);
+        assert_eq!(s.three_players_hint(), Some(false));
+        s.go_type = Some(GO_TYPE_SANMA | 0x09);
+        assert_eq!(s.three_players_hint(), Some(true), "GO bit wins");
+        s.go_type = Some(0x09);
+        assert_eq!(s.three_players_hint(), Some(false));
     }
 
     #[test]

--- a/src/capture/chromium/mod.rs
+++ b/src/capture/chromium/mod.rs
@@ -115,20 +115,24 @@ impl CaptureBackend for ChromiumBackend {
                 .context("reading chromium CDP endpoint (chromium failed to start?)")?;
         info!("chromium CDP endpoint: {cdp_endpoint}");
 
+        let mut hooks = ctx
+            .autoplay
+            .as_ref()
+            .map(|a| crate::bridge::BridgeHooks {
+                time_budget: Some(a.time_budget.clone()),
+                input_watch: Some(a.input_watch.clone()),
+                tenhou_state: Some(a.tenhou_state.clone()),
+                // Chromium has no injection relay; Riichi City autoplay
+                // only runs on the MITM path.
+                riichi_inject: None,
+                notify: None,
+            })
+            .unwrap_or_default();
+        hooks.notify = Some(ctx.notify_bus.clone());
         let bridges = Arc::new(FlowBridges::<cdp::FlowKey>::new(
             ctx.session.clone(),
             ctx.platform,
-            ctx.autoplay
-                .as_ref()
-                .map(|a| crate::bridge::BridgeHooks {
-                    time_budget: Some(a.time_budget.clone()),
-                    input_watch: Some(a.input_watch.clone()),
-                    tenhou_state: Some(a.tenhou_state.clone()),
-                    // Chromium has no injection relay; Riichi City autoplay
-                    // only runs on the MITM path.
-                    riichi_inject: None,
-                })
-                .unwrap_or_default(),
+            hooks,
         ));
 
         let cdp_run = cdp::run(

--- a/src/proxy/handler.rs
+++ b/src/proxy/handler.rs
@@ -420,6 +420,7 @@ impl ProxyHandler {
                     } else {
                         None
                     },
+                    notify: self.notify_tx.clone(),
                     ..bridge::BridgeHooks::default()
                 };
                 Arc::new(StdMutex::new(bridge::for_platform(

--- a/tests/tenhou_reconnect.rs
+++ b/tests/tenhou_reconnect.rs
@@ -1,0 +1,156 @@
+//! Regression for the Tenhou reconnect corruption reported in issue #280.
+//!
+//! When the Tenhou client drops and rejoins a game, the capture backend
+//! opens a fresh WebSocket flow and therefore a fresh `TenhouBridge`. The
+//! rejoin sequence carries the hand in progress as `<REINIT/>` and need not
+//! repeat `<TAIKYOKU/>`, so the new bridge used to sit at the default seat 0
+//! for the rest of the game while the (per-session) tracker kept the real
+//! seat. Every opponent draw that mapped onto our seat arrived as a `?`,
+//! which the riichi engine stores as tile 0 — a 1m — and the next `<INIT/>`
+//! only repeated the mistake. This drives the bridge → tracker pipeline
+//! through that exact sequence from a non-East seat.
+
+use akagi::bridge::tenhou::TenhouBridge;
+use akagi::bridge::{Bridge, Direction};
+use akagi::game_state::tracker::GameTracker;
+use akagi::schema::MjaiEvent;
+
+/// Opening hand with no 1m, so a stray `?`-turned-1m stands out.
+const HAND_E1: &str = "4,8,12,36,40,44,72,76,80,108,112,116,120";
+/// Same for the second hand (tile 16 is the red 5m).
+const HAND_E2: &str = "8,12,16,40,44,48,76,80,84,112,116,120,124";
+
+fn feed(bridge: &mut TenhouBridge, tracker: &mut GameTracker, json: &str) -> Vec<MjaiEvent> {
+    let events = bridge.parse(Direction::Down, json.as_bytes()).events;
+    for ev in &events {
+        tracker.handle(ev).expect("tracker accepts bridge output");
+    }
+    events
+}
+
+fn our_tehai(tracker: &GameTracker) -> Vec<String> {
+    let snap = tracker.snapshot().expect("game in progress");
+    let seat = snap.our_seat.expect("seat known") as usize;
+    let mut tehai = snap.players[seat].tehai.clone();
+    tehai.sort();
+    tehai
+}
+
+fn sorted_mjai(indices: &str) -> Vec<String> {
+    let mut v: Vec<String> = indices
+        .split(',')
+        .map(|t| akagi::bridge::tenhou::tile::tenhou_to_mjai_one(t.parse().unwrap()))
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn tenhou_rejoin_without_taikyoku_keeps_our_seat_and_hand_intact() {
+    let mut tracker = GameTracker::new();
+
+    // ---- Flow 1: the game starts normally. We sit West (wire-abs 2). ----
+    let mut flow1 = TenhouBridge::new(None, None);
+    feed(
+        &mut flow1,
+        &mut tracker,
+        r#"{"tag":"GO","type":"9","lobby":"0"}"#,
+    );
+    feed(
+        &mut flow1,
+        &mut tracker,
+        r#"{"tag":"UN","n0":"us","n1":"shimocha","n2":"toimen","n3":"kamicha"}"#,
+    );
+    feed(&mut flow1, &mut tracker, r#"{"tag":"TAIKYOKU","oya":"2"}"#);
+    let init = format!(
+        r#"{{"tag":"INIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"2","hai":"{HAND_E1}"}}"#
+    );
+    feed(&mut flow1, &mut tracker, &init);
+    assert_eq!(tracker.our_seat(), Some(2));
+    assert_eq!(our_tehai(&tracker), sorted_mjai(HAND_E1));
+
+    // Dealer (rel 2 = abs 0) draws and discards, then abs 1, then us, then abs 3.
+    for frame in [
+        r#"{"tag":"V"}"#,
+        r#"{"tag":"F5"}"#,
+        r#"{"tag":"W"}"#,
+        r#"{"tag":"G9"}"#,
+        r#"{"tag":"T20"}"#,
+        r#"{"tag":"D20"}"#,
+        r#"{"tag":"U"}"#,
+        r#"{"tag":"E33"}"#,
+    ] {
+        feed(&mut flow1, &mut tracker, frame);
+    }
+    assert_eq!(our_tehai(&tracker), sorted_mjai(HAND_E1));
+    let seen_before_drop = tracker.events_seen;
+    drop(flow1);
+
+    // ---- Flow 2: the client rejoins. No TAIKYOKU, a REINIT snapshot. ----
+    let mut flow2 = TenhouBridge::new(None, None);
+    let reinit = format!(
+        r#"{{"tag":"REINIT","seed":"0,0,0,1,2,4","ten":"250,250,250,250","oya":"2","hai":"{HAND_E1}","kawa0":"20","kawa1":"33","kawa2":"5","kawa3":"9"}}"#
+    );
+    assert!(feed(&mut flow2, &mut tracker, &reinit).is_empty());
+
+    // The rest of this hand is withheld from the tracker entirely.
+    for frame in [
+        r#"{"tag":"V"}"#,
+        r#"{"tag":"F40"}"#,
+        r#"{"tag":"W"}"#,
+        r#"{"tag":"G44"}"#,
+        r#"{"tag":"T24"}"#,
+        r#"{"tag":"D24"}"#,
+        r#"{"tag":"U"}"#,
+        r#"{"tag":"E48"}"#,
+        r#"{"tag":"AGARI","who":"2","fromWho":"2","sc":"250,-10,250,-10,250,30,250,-10","ba":"0,0"}"#,
+    ] {
+        assert!(
+            feed(&mut flow2, &mut tracker, frame).is_empty(),
+            "{frame} must not reach the tracker"
+        );
+    }
+    assert_eq!(tracker.events_seen, seen_before_drop);
+    assert_eq!(our_tehai(&tracker), sorted_mjai(HAND_E1));
+
+    // ---- Next kyoku: E2, dealer wire-abs 1 (rel 3 from seat 2). ----
+    let init = format!(
+        r#"{{"tag":"INIT","seed":"1,0,0,1,2,8","ten":"240,240,280,240","oya":"3","hai":"{HAND_E2}"}}"#
+    );
+    let events = feed(&mut flow2, &mut tracker, &init);
+    assert!(
+        matches!(
+            &events[0],
+            MjaiEvent::StartGame {
+                id: Some(2),
+                num_players: 4,
+                ..
+            }
+        ),
+        "the rejoined flow reopens the game on our real seat: {events:?}"
+    );
+    let snap = tracker.snapshot().unwrap();
+    assert_eq!(snap.our_seat, Some(2));
+    assert_eq!(snap.kyoku, 2);
+    assert_eq!(snap.oya, 1);
+    assert_eq!(our_tehai(&tracker), sorted_mjai(HAND_E2));
+
+    // Live play resumes on the right seats: opponent draws stay hidden and
+    // never leak into our hand as 1m; our own draw lands in it.
+    feed(&mut flow2, &mut tracker, r#"{"tag":"W"}"#);
+    assert_eq!(our_tehai(&tracker), sorted_mjai(HAND_E2));
+    feed(&mut flow2, &mut tracker, r#"{"tag":"G12"}"#);
+    let events = feed(&mut flow2, &mut tracker, r#"{"tag":"T24"}"#);
+    assert!(matches!(&events[0], MjaiEvent::Tsumo { actor: 2, pai } if pai == "7m"));
+    let snap = tracker.snapshot().unwrap();
+    let mut expected = sorted_mjai(HAND_E2);
+    expected.push("7m".into());
+    expected.sort();
+    assert_eq!(our_tehai(&tracker), expected);
+    assert_eq!(snap.players[2].drawn_tile.as_deref(), Some("7m"));
+    assert!(
+        !snap.players[2].tehai.iter().any(|t| t == "1m"),
+        "no phantom 1m: {:?}",
+        snap.players[2].tehai
+    );
+}


### PR DESCRIPTION
Fixes #280.

## Problem

After Tenhou drops and rejoins an in-progress game, Akagi reports newly observed tiles as 1m, and the next kyoku does not recover.

Root cause, confirmed against the bridge and tracker code:

- A reconnect opens a fresh WebSocket flow and therefore a fresh `TenhouBridge`, which only learned our seat from `<TAIKYOKU/>`. The rejoin sequence carries the hand in progress as `<REINIT/>` (ignored until now) and does not necessarily repeat `<TAIKYOKU/>`, so the new bridge stayed at the default seat 0.
- The tracker is per session and kept the real seat, so every event for the rest of the game was attributed to the wrong seats. An opponent's draw that mapped onto our seat arrived as `?`, which the riichi engine stores as tile 0, a 1m.
- The next `<INIT/>` never re-derived the seat, so the mistake repeated every hand.

## Fix

- **Seat from any kyoku frame.** The dealer of kyoku index `k` (`seed[0]`) sits at wire-abs `k % 4`, and `oya` is that dealer relative to us, so `INIT` / `REINIT` pin our seat down on their own. Used when `<TAIKYOKU/>` was not seen on the flow, and on the first deal (E1H0), which says the same thing TAIKYOKU does; TAIKYOKU stays authoritative for every other frame.
- **`<REINIT/>` handled.** It is a snapshot, not a log: nothing says when a call happened relative to the discards, so the hand in progress cannot be replayed into the mjai stream. The bridge rebuilds only its own state (hand, calls incl. nukidora, riichi, draw-in-hand) so autoplay keeps working, withholds every event until the next `<INIT/>`, and owes a fresh `start_game` there so the tracker, bots and history reopen on the right seat and player count. A warning toast tells the user analysis is paused until the next hand (new `BridgeHooks::notify`, wired by both capture backends).
- **A rejoined game is closed as terminated.** Its `end_game` still reaches every consumer (the tracker closes the game, the bot manager stops its runner) even while suspended, but as `terminated`: the flow never saw the hands before the drop, so History drops the game instead of filing the remainder as a complete one with its own per-hand stats. Cleared by the next `<TAIKYOKU/>` or E1H0 `<INIT/>`.
- **Player count without the E1H0 check.** A rejoining flow never sees the first deal, so the count now also comes from `<GO type>` bit `0x10`, a `<UN/>` roster with one empty slot, the table total on any kyoku frame (100000 points in yonma, 105000 in sanma, riichi sticks included), or as a last resort the REINIT frame's shape. The E1H0 score check remains final when it fires.
- A fresh flow's first `INIT` now opens the game as well, so attaching between hands works. The mjai log is opened on the first kyoku frame when no `TAIKYOKU` rotated one, and events are written from `parse()` so withheld events stay out of it.

## Tests

- Bridge unit tests: REINIT on a fresh flow (seat, suspension, resume at next INIT), INIT on a fresh flow, TAIKYOKU precedence vs. first-deal authority, REINIT after TAIKYOKU, hand/calls/nukidora/draw restore, GO / UN / table-total / frame-shape sanma detection, E1H0 override, terminated end for a rejoined game (during and after suspension), new game with and without TAIKYOKU.
- `tests/tenhou_reconnect.rs`: bridge-to-tracker integration test replaying the reported sequence from a non-East seat and asserting the tracked hand never gains a phantom 1m.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass.

## Notes

- Confirmed against a captured rejoin from the web client (fresh socket): `HELO` → `GO` → `UN` (full roster) → `SAIKAI` → `REINIT` → live play, with **no `TAIKYOKU`**. `REINIT` carries `seed` / `ten` / `oya` / `hai`, `m<rel>` for seats that have called, and `kawa<rel>` with `255` marking the riichi declaration. The sequence is replayed in a unit test; `SAIKAI` (the resume notice) is listed among the ignored session tags.
- Verified end to end on that session: after the rejoin the bridge resolved the real seat from `REINIT`, paused the rest of the hand, and the next `INIT` reopened the game on the right seat with correctly attributed draws.

